### PR TITLE
feat: ナビゲーションのサイドバー移行

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
   <body class="bg-gray-50">
     <!-- サイドバーナビゲーション（PC/iPad Landscape用：1024px以上で表示） -->
     <% if user_signed_in? %>
-      <aside class="sidebar-nav fixed left-0 top-0 h-screen w-64 bg-white shadow-lg z-40 flex flex-col">
+      <aside class="sidebar-nav fixed inset-y-0 left-0 w-64 bg-white shadow-lg z-40 flex flex-col">
         <!-- 上部セクション -->
         <div class="flex flex-col flex-1 overflow-y-auto">
           <!-- ロゴ -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -202,13 +202,18 @@
         }
 
         /* === モバイルヘッダー内のメニュー表示制御 === */
-        /* モバイル（768px未満）*/
+        /* 1024px未満: ハンバーガーメニューのみ表示、デスクトップメニュー非表示 */
         .desktop-menu { display: none !important; }
         .mobile-menu-btn { display: flex !important; }
-        /* タブレット以上（768px以上、1024px未満）*/
-        @media (min-width: 768px) {
-          .desktop-menu { display: flex !important; }
-          .mobile-menu-btn { display: none !important; }
+
+        /* === サイドバーのスクロール制御 === */
+        .sidebar-nav {
+          overflow: hidden; /* サイドバー全体はスクロールしない */
+        }
+
+        .sidebar-nav > div.overflow-y-auto {
+          overscroll-behavior: contain; /* スクロールがメイン画面に伝播しない */
+          -webkit-overflow-scrolling: touch; /* iOS用スムーススクロール */
         }
 
         /* === サイドバーナビアイテムのスタイル（インディゴ背景用） === */
@@ -248,43 +253,80 @@
           background-color: rgba(255, 255, 255, 0.1); /* 白の10%透過 */
           color: #ffffff;
         }
+
+        /* === モバイルメニューアイテムのスタイル（インディゴ背景用） === */
+        .mobile-menu-item {
+          display: block;
+          padding: 0.75rem 1rem;
+          border-radius: 0.5rem;
+          font-size: 1rem;
+          font-weight: 500;
+          color: rgba(255, 255, 255, 0.9);
+          transition: background-color 0.15s ease-in-out;
+        }
+
+        .mobile-menu-item:hover {
+          background-color: rgba(255, 255, 255, 0.1);
+          color: #ffffff;
+        }
+
+        .mobile-menu-item.active {
+          background-color: rgba(255, 255, 255, 0.2);
+          color: #ffffff;
+          font-weight: 600;
+        }
+
+        .mobile-menu-item-small {
+          display: block;
+          padding: 0.75rem 1rem;
+          border-radius: 0.375rem;
+          font-size: 1rem;
+          color: rgba(255, 255, 255, 0.8);
+          transition: background-color 0.15s ease-in-out;
+        }
+
+        .mobile-menu-item-small:hover {
+          background-color: rgba(255, 255, 255, 0.1);
+          color: #ffffff;
+        }
       </style>
 
       <!-- モバイルメニュー（デフォルトは非表示） -->
       <% if user_signed_in? %>
         <div class="hidden" id="mobile-menu">
-          <div class="pt-2 pb-3 space-y-1 bg-gray-50 border-t border-gray-200 px-4">
-            <%= link_to "ダッシュボード", dashboard_path, class: "block px-4 py-3 text-base font-medium rounded-md #{current_page?(dashboard_path) || current_page?(root_path) ? 'bg-indigo-50 text-indigo-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-800'}" %>
-            <%= link_to "イベント", events_path, class: "block px-4 py-3 text-base font-medium rounded-md #{current_page?(events_path) ? 'bg-indigo-50 text-indigo-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-800'}" %>
-            <%= link_to "ローテーション", rotations_path, class: "block px-4 py-3 text-base font-medium rounded-md #{current_page?(rotations_path) ? 'bg-indigo-50 text-indigo-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-800'}" %>
-            <%= link_to "対戦履歴", matches_path, class: "block px-4 py-3 text-base font-medium rounded-md #{current_page?(matches_path) ? 'bg-indigo-50 text-indigo-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-800'}" %>
-            <%= link_to "統計", statistics_path, class: "block px-4 py-3 text-base font-medium rounded-md #{current_page?(statistics_path) ? 'bg-indigo-50 text-indigo-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-800'}" %>
+          <!-- ナビゲーション部分（インディゴ背景） -->
+          <div class="pt-2 pb-3 space-y-1 bg-[#4F39F6] px-4">
+            <%= link_to "ダッシュボード", dashboard_path, class: "mobile-menu-item #{current_page?(dashboard_path) || current_page?(root_path) ? 'active' : ''}" %>
+            <%= link_to "イベント", events_path, class: "mobile-menu-item #{current_page?(events_path) ? 'active' : ''}" %>
+            <%= link_to "ローテーション", rotations_path, class: "mobile-menu-item #{current_page?(rotations_path) ? 'active' : ''}" %>
+            <%= link_to "対戦履歴", matches_path, class: "mobile-menu-item #{current_page?(matches_path) ? 'active' : ''}" %>
+            <%= link_to "統計", statistics_path, class: "mobile-menu-item #{current_page?(statistics_path) ? 'active' : ''}" %>
             <% if current_user.is_admin? %>
-              <div class="border-t border-gray-200 mt-3 pt-3">
-                <div class="px-4 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider">管理者メニュー</div>
-                <%= link_to "機体マスタ", mobile_suits_path, class: "block px-4 py-3 text-base font-medium rounded-md #{current_page?(mobile_suits_path) ? 'bg-indigo-50 text-indigo-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-800'}" %>
-                <%= link_to "ユーザー管理", users_path, class: "block px-4 py-3 text-base font-medium rounded-md #{current_page?(users_path) ? 'bg-indigo-50 text-indigo-700' : 'text-gray-600 hover:bg-gray-100 hover:text-gray-800'}" %>
+              <div class="border-t border-indigo-400 mt-3 pt-3">
+                <div class="px-4 py-2 text-xs font-semibold text-indigo-200 uppercase tracking-wider">管理者メニュー</div>
+                <%= link_to "機体マスタ", mobile_suits_path, class: "mobile-menu-item #{current_page?(mobile_suits_path) ? 'active' : ''}" %>
+                <%= link_to "ユーザー管理", users_path, class: "mobile-menu-item #{current_page?(users_path) ? 'active' : ''}" %>
               </div>
             <% end %>
           </div>
-          <!-- ユーザー情報セクション -->
-          <div class="pt-4 pb-3 border-t border-gray-200 bg-white px-4">
+          <!-- ユーザー情報セクション（インディゴ背景） -->
+          <div class="pt-4 pb-3 border-t border-indigo-400 bg-[#4F39F6] px-4">
             <div class="flex items-center px-4">
               <div class="flex-shrink-0">
-                <div class="h-10 w-10 rounded-full bg-indigo-100 flex items-center justify-center">
-                  <span class="text-indigo-600 font-medium text-sm"><%= current_user.nickname[0] %></span>
+                <div class="h-10 w-10 rounded-full bg-white/20 flex items-center justify-center">
+                  <span class="text-white font-medium text-sm"><%= current_user.nickname[0] %></span>
                 </div>
               </div>
               <div class="ml-3">
-                <div class="text-base font-medium text-gray-800"><%= current_user.nickname %></div>
-                <div class="text-sm text-gray-500"><%= current_user.username %></div>
+                <div class="text-base font-medium text-white"><%= current_user.nickname %></div>
+                <div class="text-sm text-indigo-200"><%= current_user.username %></div>
               </div>
             </div>
             <div class="mt-3 space-y-1">
               <% if current_user.is_admin? %>
                 <!-- 視点切り替え -->
                 <div class="px-4 py-2">
-                  <select onchange="if(this.value) switchUserView(this.value);" class="w-full text-sm border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 <%= viewing_as_someone_else? ? 'bg-orange-50 border-orange-300' : '' %>">
+                  <select onchange="if(this.value) switchUserView(this.value);" class="w-full text-sm border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-white <%= viewing_as_someone_else? ? 'bg-orange-50 border-orange-300 text-gray-800' : 'bg-white/90 border-indigo-300 text-gray-800' %>">
                     <% if viewing_as_someone_else? %>
                       <option value=""><%= viewing_as_user.nickname %>の視点 ▼</option>
                       <option value="clear">--- 管理者視点に戻す ---</option>
@@ -300,9 +342,9 @@
                 </div>
               <% end %>
               <% unless current_user.username == 'guest' %>
-                <%= link_to "設定", edit_profile_path, class: "block px-4 py-3 text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-md" %>
+                <%= link_to "設定", edit_profile_path, class: "mobile-menu-item-small" %>
               <% end %>
-              <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "block w-full text-left px-4 py-3 text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-md" %>
+              <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "mobile-menu-item-small w-full text-left" %>
             </div>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,119 @@
   </head>
 
   <body class="bg-gray-50">
-    <nav class="bg-white shadow-sm">
+    <!-- サイドバーナビゲーション（PC/iPad Landscape用：1024px以上で表示） -->
+    <% if user_signed_in? %>
+      <aside class="sidebar-nav fixed left-0 top-0 h-full w-64 bg-white shadow-lg z-40 flex flex-col">
+        <!-- 上部セクション -->
+        <div class="flex flex-col flex-1 overflow-y-auto">
+          <!-- ロゴ -->
+          <div class="flex-shrink-0 px-4 py-4 border-b border-gray-200">
+            <%= link_to root_path do %>
+              <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.モバイル for KGY" class="h-12">
+            <% end %>
+          </div>
+
+          <!-- メインナビゲーション -->
+          <nav class="flex-1 px-3 py-4 space-y-1">
+            <%= link_to dashboard_path, class: "sidebar-nav-item #{current_page?(dashboard_path) || current_page?(root_path) ? 'active' : ''}" do %>
+              <span class="sidebar-nav-icon">📊</span>
+              <span>ダッシュボード</span>
+            <% end %>
+
+            <%= link_to events_path, class: "sidebar-nav-item #{current_page?(events_path) ? 'active' : ''}" do %>
+              <span class="sidebar-nav-icon">🎮</span>
+              <span>イベント</span>
+            <% end %>
+
+            <%= link_to rotations_path, class: "sidebar-nav-item #{current_page?(rotations_path) ? 'active' : ''}" do %>
+              <span class="sidebar-nav-icon">🔄</span>
+              <span>ローテーション</span>
+            <% end %>
+
+            <%= link_to matches_path, class: "sidebar-nav-item #{current_page?(matches_path) ? 'active' : ''}" do %>
+              <span class="sidebar-nav-icon">⚔️</span>
+              <span>対戦履歴</span>
+            <% end %>
+
+            <%= link_to statistics_path, class: "sidebar-nav-item #{current_page?(statistics_path) ? 'active' : ''}" do %>
+              <span class="sidebar-nav-icon">📈</span>
+              <span>統計</span>
+            <% end %>
+
+            <% if current_user.is_admin? %>
+              <!-- 管理者メニューセパレーター -->
+              <div class="pt-4 mt-4 border-t border-gray-200">
+                <div class="px-3 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                  管理者メニュー
+                </div>
+              </div>
+
+              <%= link_to mobile_suits_path, class: "sidebar-nav-item #{current_page?(mobile_suits_path) ? 'active' : ''}" do %>
+                <span class="sidebar-nav-icon">🤖</span>
+                <span>機体マスタ</span>
+              <% end %>
+
+              <%= link_to users_path, class: "sidebar-nav-item #{current_page?(users_path) ? 'active' : ''}" do %>
+                <span class="sidebar-nav-icon">👥</span>
+                <span>ユーザー管理</span>
+              <% end %>
+            <% end %>
+          </nav>
+        </div>
+
+        <!-- 下部セクション（固定） -->
+        <div class="flex-shrink-0 border-t border-gray-200 p-4">
+          <!-- ユーザー情報 -->
+          <div class="flex items-center mb-3">
+            <div class="flex-shrink-0">
+              <div class="h-10 w-10 rounded-full bg-indigo-100 flex items-center justify-center">
+                <span class="text-indigo-600 font-medium text-sm"><%= current_user.nickname[0] %></span>
+              </div>
+            </div>
+            <div class="ml-3">
+              <div class="text-sm font-medium text-gray-800"><%= current_user.nickname %></div>
+              <div class="text-xs text-gray-500"><%= current_user.username %></div>
+            </div>
+          </div>
+
+          <!-- 管理者用: 視点切り替え -->
+          <% if current_user.is_admin? %>
+            <div class="mb-3">
+              <select onchange="if(this.value) switchUserView(this.value);" class="w-full text-sm border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 <%= viewing_as_someone_else? ? 'bg-orange-50 border-orange-300' : '' %>">
+                <% if viewing_as_someone_else? %>
+                  <option value=""><%= viewing_as_user.nickname %>の視点 ▼</option>
+                  <option value="clear">--- 管理者視点に戻す ---</option>
+                <% else %>
+                  <option value="">視点切り替え...</option>
+                <% end %>
+                <% User.where(is_admin: false).order(:nickname).each do |user| %>
+                  <% unless viewing_as_someone_else? && user.id == viewing_as_user.id %>
+                    <option value="<%= user.id %>"><%= user.nickname %></option>
+                  <% end %>
+                <% end %>
+              </select>
+            </div>
+          <% end %>
+
+          <!-- 設定・ログアウト -->
+          <div class="space-y-1">
+            <% unless current_user.username == 'guest' %>
+              <%= link_to edit_profile_path, class: "sidebar-nav-item-small" do %>
+                <span>⚙️</span>
+                <span>設定</span>
+              <% end %>
+            <% end %>
+            <%= button_to destroy_user_session_path, method: :delete, class: "sidebar-nav-item-small w-full text-left" do %>
+              <span>🚪</span>
+              <span>ログアウト</span>
+            <% end %>
+          </div>
+        </div>
+      </aside>
+    <% end %>
+
+    <!-- モバイルヘッダーナビゲーション（1024px未満で表示） -->
+    <nav class="mobile-header-nav bg-white shadow-sm">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
           <!-- ロゴとデスクトップメニュー -->
@@ -108,13 +220,73 @@
       </div>
 
       <style>
+        /* === サイドバーとモバイルヘッダーの表示制御 === */
+        /* モバイル・タブレット（1024px未満）: サイドバー非表示、モバイルヘッダー表示 */
+        .sidebar-nav { display: none !important; }
+        .mobile-header-nav { display: block !important; }
+        .main-content-with-sidebar { margin-left: 0; }
+
+        /* デスクトップ・iPad Landscape（1024px以上）: サイドバー表示、モバイルヘッダー非表示 */
+        @media (min-width: 1024px) {
+          .sidebar-nav { display: flex !important; }
+          .mobile-header-nav { display: none !important; }
+          .main-content-with-sidebar { margin-left: 16rem; /* w-64 = 256px = 16rem */ }
+        }
+
+        /* === モバイルヘッダー内のメニュー表示制御 === */
         /* モバイル（768px未満）*/
         .desktop-menu { display: none !important; }
         .mobile-menu-btn { display: flex !important; }
-        /* デスクトップ（768px以上）*/
+        /* タブレット以上（768px以上、1024px未満）*/
         @media (min-width: 768px) {
           .desktop-menu { display: flex !important; }
           .mobile-menu-btn { display: none !important; }
+        }
+
+        /* === サイドバーナビアイテムのスタイル === */
+        .sidebar-nav-item {
+          display: flex;
+          align-items: center;
+          padding: 0.75rem 1rem;
+          border-radius: 0.5rem;
+          font-size: 0.875rem;
+          font-weight: 500;
+          color: #374151; /* text-gray-700 */
+          transition: background-color 0.15s ease-in-out;
+        }
+
+        .sidebar-nav-item:hover {
+          background-color: #f3f4f6; /* bg-gray-100 */
+        }
+
+        .sidebar-nav-item.active {
+          background-color: #eef2ff; /* bg-indigo-50 */
+          color: #4338ca; /* text-indigo-700 */
+          font-weight: 600;
+        }
+
+        .sidebar-nav-icon {
+          margin-right: 0.75rem;
+          font-size: 1.125rem;
+        }
+
+        .sidebar-nav-item-small {
+          display: flex;
+          align-items: center;
+          padding: 0.5rem 0.75rem;
+          border-radius: 0.375rem;
+          font-size: 0.875rem;
+          color: #6b7280; /* text-gray-500 */
+          transition: background-color 0.15s ease-in-out;
+        }
+
+        .sidebar-nav-item-small:hover {
+          background-color: #f3f4f6; /* bg-gray-100 */
+          color: #374151; /* text-gray-700 */
+        }
+
+        .sidebar-nav-item-small span:first-child {
+          margin-right: 0.5rem;
         }
       </style>
 
@@ -218,7 +390,7 @@
 
     <!-- フラッシュメッセージ -->
     <% if flash.any? %>
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
+      <div class="main-content-with-sidebar max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
         <% flash.each do |type, message| %>
           <%
             alert_class = case type.to_s
@@ -260,7 +432,7 @@
       </div>
     <% end %>
 
-    <main>
+    <main class="main-content-with-sidebar">
       <%= yield %>
     </main>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,16 +35,16 @@
   <body class="bg-gray-50">
     <!-- サイドバーナビゲーション（PC/iPad Landscape用：1024px以上で表示） -->
     <% if user_signed_in? %>
-      <aside class="sidebar-nav fixed inset-y-0 left-0 w-64 bg-white shadow-lg z-40 flex flex-col">
-        <!-- 上部セクション -->
-        <div class="flex flex-col flex-1 overflow-y-auto">
-          <!-- ロゴ -->
-          <div class="flex-shrink-0 px-4 py-4 border-b border-gray-200">
-            <%= link_to root_path do %>
-              <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.モバイル for KGY" class="h-12">
-            <% end %>
-          </div>
+      <aside class="sidebar-nav fixed inset-y-0 left-0 w-64 shadow-lg z-40 flex flex-col">
+        <!-- ロゴ部分（白背景） -->
+        <div class="flex-shrink-0 px-4 py-4 bg-white border-b border-gray-200">
+          <%= link_to root_path do %>
+            <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.モバイル for KGY" class="h-12">
+          <% end %>
+        </div>
 
+        <!-- メイン部分（インディゴ背景） -->
+        <div class="flex flex-col flex-1 overflow-y-auto bg-[#4F39F6]">
           <!-- メインナビゲーション -->
           <nav class="flex-1 px-3 py-4 space-y-1">
             <%= link_to "ダッシュボード", dashboard_path, class: "sidebar-nav-item #{current_page?(dashboard_path) || current_page?(root_path) ? 'active' : ''}" %>
@@ -55,8 +55,8 @@
 
             <% if current_user.is_admin? %>
               <!-- 管理者メニューセパレーター -->
-              <div class="pt-4 mt-4 border-t border-gray-200">
-                <div class="px-3 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+              <div class="pt-4 mt-4 border-t border-indigo-400">
+                <div class="px-3 py-2 text-xs font-semibold text-indigo-200 uppercase tracking-wider">
                   管理者メニュー
                 </div>
               </div>
@@ -67,25 +67,25 @@
           </nav>
         </div>
 
-        <!-- 下部セクション（固定） -->
-        <div class="flex-shrink-0 border-t border-gray-200 p-4">
+        <!-- 下部セクション（固定・インディゴ背景） -->
+        <div class="flex-shrink-0 border-t border-indigo-400 p-4 bg-[#4F39F6]">
           <!-- ユーザー情報 -->
           <div class="flex items-center mb-3">
             <div class="flex-shrink-0">
-              <div class="h-10 w-10 rounded-full bg-indigo-100 flex items-center justify-center">
-                <span class="text-indigo-600 font-medium text-sm"><%= current_user.nickname[0] %></span>
+              <div class="h-10 w-10 rounded-full bg-white/20 flex items-center justify-center">
+                <span class="text-white font-medium text-sm"><%= current_user.nickname[0] %></span>
               </div>
             </div>
             <div class="ml-3">
-              <div class="text-sm font-medium text-gray-800"><%= current_user.nickname %></div>
-              <div class="text-xs text-gray-500"><%= current_user.username %></div>
+              <div class="text-sm font-medium text-white"><%= current_user.nickname %></div>
+              <div class="text-xs text-indigo-200"><%= current_user.username %></div>
             </div>
           </div>
 
           <!-- 管理者用: 視点切り替え -->
           <% if current_user.is_admin? %>
             <div class="mb-3">
-              <select onchange="if(this.value) switchUserView(this.value);" class="w-full text-sm border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 <%= viewing_as_someone_else? ? 'bg-orange-50 border-orange-300' : '' %>">
+              <select onchange="if(this.value) switchUserView(this.value);" class="w-full text-sm border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-white <%= viewing_as_someone_else? ? 'bg-orange-50 border-orange-300 text-gray-800' : 'bg-white/90 border-indigo-300 text-gray-800' %>">
                 <% if viewing_as_someone_else? %>
                   <option value=""><%= viewing_as_user.nickname %>の視点 ▼</option>
                   <option value="clear">--- 管理者視点に戻す ---</option>
@@ -211,7 +211,7 @@
           .mobile-menu-btn { display: none !important; }
         }
 
-        /* === サイドバーナビアイテムのスタイル === */
+        /* === サイドバーナビアイテムのスタイル（インディゴ背景用） === */
         .sidebar-nav-item {
           display: flex;
           align-items: center;
@@ -219,17 +219,18 @@
           border-radius: 0.5rem;
           font-size: 0.875rem;
           font-weight: 500;
-          color: #374151; /* text-gray-700 */
+          color: rgba(255, 255, 255, 0.9); /* 白（少し透過） */
           transition: background-color 0.15s ease-in-out;
         }
 
         .sidebar-nav-item:hover {
-          background-color: #f3f4f6; /* bg-gray-100 */
+          background-color: rgba(255, 255, 255, 0.1); /* 白の10%透過 */
+          color: #ffffff;
         }
 
         .sidebar-nav-item.active {
-          background-color: #eef2ff; /* bg-indigo-50 */
-          color: #4338ca; /* text-indigo-700 */
+          background-color: rgba(255, 255, 255, 0.2); /* 白の20%透過 */
+          color: #ffffff;
           font-weight: 600;
         }
 
@@ -239,13 +240,13 @@
           padding: 0.5rem 0.75rem;
           border-radius: 0.375rem;
           font-size: 0.875rem;
-          color: #6b7280; /* text-gray-500 */
+          color: rgba(255, 255, 255, 0.8); /* 白（少し透過） */
           transition: background-color 0.15s ease-in-out;
         }
 
         .sidebar-nav-item-small:hover {
-          background-color: #f3f4f6; /* bg-gray-100 */
-          color: #374151; /* text-gray-700 */
+          background-color: rgba(255, 255, 255, 0.1); /* 白の10%透過 */
+          color: #ffffff;
         }
       </style>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
   <body class="bg-gray-50">
     <!-- サイドバーナビゲーション（PC/iPad Landscape用：1024px以上で表示） -->
     <% if user_signed_in? %>
-      <aside class="sidebar-nav fixed left-0 top-0 h-full w-64 bg-white shadow-lg z-40 flex flex-col">
+      <aside class="sidebar-nav fixed left-0 top-0 h-screen w-64 bg-white shadow-lg z-40 flex flex-col">
         <!-- 上部セクション -->
         <div class="flex flex-col flex-1 overflow-y-auto">
           <!-- ロゴ -->
@@ -47,30 +47,11 @@
 
           <!-- メインナビゲーション -->
           <nav class="flex-1 px-3 py-4 space-y-1">
-            <%= link_to dashboard_path, class: "sidebar-nav-item #{current_page?(dashboard_path) || current_page?(root_path) ? 'active' : ''}" do %>
-              <span class="sidebar-nav-icon">📊</span>
-              <span>ダッシュボード</span>
-            <% end %>
-
-            <%= link_to events_path, class: "sidebar-nav-item #{current_page?(events_path) ? 'active' : ''}" do %>
-              <span class="sidebar-nav-icon">🎮</span>
-              <span>イベント</span>
-            <% end %>
-
-            <%= link_to rotations_path, class: "sidebar-nav-item #{current_page?(rotations_path) ? 'active' : ''}" do %>
-              <span class="sidebar-nav-icon">🔄</span>
-              <span>ローテーション</span>
-            <% end %>
-
-            <%= link_to matches_path, class: "sidebar-nav-item #{current_page?(matches_path) ? 'active' : ''}" do %>
-              <span class="sidebar-nav-icon">⚔️</span>
-              <span>対戦履歴</span>
-            <% end %>
-
-            <%= link_to statistics_path, class: "sidebar-nav-item #{current_page?(statistics_path) ? 'active' : ''}" do %>
-              <span class="sidebar-nav-icon">📈</span>
-              <span>統計</span>
-            <% end %>
+            <%= link_to "ダッシュボード", dashboard_path, class: "sidebar-nav-item #{current_page?(dashboard_path) || current_page?(root_path) ? 'active' : ''}" %>
+            <%= link_to "イベント", events_path, class: "sidebar-nav-item #{current_page?(events_path) ? 'active' : ''}" %>
+            <%= link_to "ローテーション", rotations_path, class: "sidebar-nav-item #{current_page?(rotations_path) ? 'active' : ''}" %>
+            <%= link_to "対戦履歴", matches_path, class: "sidebar-nav-item #{current_page?(matches_path) ? 'active' : ''}" %>
+            <%= link_to "統計", statistics_path, class: "sidebar-nav-item #{current_page?(statistics_path) ? 'active' : ''}" %>
 
             <% if current_user.is_admin? %>
               <!-- 管理者メニューセパレーター -->
@@ -80,15 +61,8 @@
                 </div>
               </div>
 
-              <%= link_to mobile_suits_path, class: "sidebar-nav-item #{current_page?(mobile_suits_path) ? 'active' : ''}" do %>
-                <span class="sidebar-nav-icon">🤖</span>
-                <span>機体マスタ</span>
-              <% end %>
-
-              <%= link_to users_path, class: "sidebar-nav-item #{current_page?(users_path) ? 'active' : ''}" do %>
-                <span class="sidebar-nav-icon">👥</span>
-                <span>ユーザー管理</span>
-              <% end %>
+              <%= link_to "機体マスタ", mobile_suits_path, class: "sidebar-nav-item #{current_page?(mobile_suits_path) ? 'active' : ''}" %>
+              <%= link_to "ユーザー管理", users_path, class: "sidebar-nav-item #{current_page?(users_path) ? 'active' : ''}" %>
             <% end %>
           </nav>
         </div>
@@ -130,15 +104,9 @@
           <!-- 設定・ログアウト -->
           <div class="space-y-1">
             <% unless current_user.username == 'guest' %>
-              <%= link_to edit_profile_path, class: "sidebar-nav-item-small" do %>
-                <span>⚙️</span>
-                <span>設定</span>
-              <% end %>
+              <%= link_to "設定", edit_profile_path, class: "sidebar-nav-item-small" %>
             <% end %>
-            <%= button_to destroy_user_session_path, method: :delete, class: "sidebar-nav-item-small w-full text-left" do %>
-              <span>🚪</span>
-              <span>ログアウト</span>
-            <% end %>
+            <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "sidebar-nav-item-small w-full text-left" %>
           </div>
         </div>
       </aside>
@@ -265,11 +233,6 @@
           font-weight: 600;
         }
 
-        .sidebar-nav-icon {
-          margin-right: 0.75rem;
-          font-size: 1.125rem;
-        }
-
         .sidebar-nav-item-small {
           display: flex;
           align-items: center;
@@ -283,10 +246,6 @@
         .sidebar-nav-item-small:hover {
           background-color: #f3f4f6; /* bg-gray-100 */
           color: #374151; /* text-gray-700 */
-        }
-
-        .sidebar-nav-item-small span:first-child {
-          margin-right: 0.5rem;
         }
       </style>
 
@@ -390,7 +349,7 @@
 
     <!-- フラッシュメッセージ -->
     <% if flash.any? %>
-      <div class="main-content-with-sidebar max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
+      <div class="<%= 'main-content-with-sidebar' if user_signed_in? %> max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
         <% flash.each do |type, message| %>
           <%
             alert_class = case type.to_s
@@ -432,7 +391,7 @@
       </div>
     <% end %>
 
-    <main class="main-content-with-sidebar">
+    <main class="<%= 'main-content-with-sidebar' if user_signed_in? %>">
       <%= yield %>
     </main>
   </body>


### PR DESCRIPTION
## Summary

- PC/iPad Landscape (1024px以上) 向けに左側常駐のサイドバーナビゲーションを導入
- ヘッダーに配置されていた「ユーザー切り替え」「設定」「ログアウト」をサイドバー下部に集約
- モバイル/iPad Portrait (1024px未満) では既存のハンバーガーメニューを維持

## 変更内容

### サイドバー構造
- **上部**: ロゴ + メインナビ（ダッシュボード、イベント、ローテーション、対戦履歴、統計）+ 管理者メニュー（機体マスタ、ユーザー管理）
- **下部（固定）**: ユーザー情報 + 視点切り替え（管理者のみ）+ 設定 + ログアウト

### レスポンシブ動作
| 画面幅 | デバイス | ナビゲーション |
|--------|---------|---------------|
| 0 - 1023px | スマホ、iPad Portrait | ハンバーガーメニュー |
| 1024px以上 | iPad Landscape、PC | サイドバー |

## Test plan

- [ ] 1024px以上でサイドバーが表示されること
- [ ] 1024px未満でハンバーガーメニューが表示されること
- [ ] アクティブページのハイライト表示
- [ ] サイドバーからログアウト可能
- [ ] 管理者で視点切り替え可能
- [ ] 各ページ（ダッシュボード、イベント、ローテーション、対戦履歴、統計、機体マスタ、ユーザー管理、設定）でレイアウト崩れがないこと

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)