### PR TITLE
fix: 管理者Namespaceのパス参照修正漏れ

### DIFF
--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -132,7 +132,7 @@ module Admin
           flash[:notice] = "#{imported_count}件の機体を追加、#{updated_count}件を更新しました。"
         end
 
-        redirect_to mobile_suits_path
+        redirect_to admin_mobile_suits_path
       rescue => e
         redirect_to new_mobile_suits_admin_imports_path, alert: "CSVファイルの読み込みに失敗しました: #{e.message}"
       end

--- a/app/views/admin/imports/new_mobile_suits.html.erb
+++ b/app/views/admin/imports/new_mobile_suits.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
-    <%= link_to "← 機体マスタに戻る", mobile_suits_path, class: "text-blue-600 hover:text-blue-500" %>
+    <%= link_to "← 機体マスタに戻る", admin_mobile_suits_path, class: "text-blue-600 hover:text-blue-500" %>
   </div>
 
   <h1 class="text-3xl font-bold text-gray-900 mb-6">機体マスタCSVインポート</h1>
@@ -40,7 +40,7 @@
     </div>
 
     <div class="flex justify-end space-x-3">
-      <%= link_to "キャンセル", mobile_suits_path, class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
+      <%= link_to "キャンセル", admin_mobile_suits_path, class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
       <%= submit_tag "インポート", class: "px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700", data: { turbo_confirm: "CSVファイルをインポートしますか？" } %>
     </div>
   <% end %>

--- a/app/views/dashboard/admin_dashboard.html.erb
+++ b/app/views/dashboard/admin_dashboard.html.erb
@@ -136,14 +136,14 @@
             <span class="text-sm font-medium text-gray-900">試合一覧</span>
           <% end %>
 
-          <%= link_to mobile_suits_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
+          <%= link_to admin_mobile_suits_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
             <svg class="h-8 w-8 text-indigo-600 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
             </svg>
             <span class="text-sm font-medium text-gray-900">機体マスタ</span>
           <% end %>
 
-          <%= link_to users_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
+          <%= link_to admin_users_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
             <svg class="h-8 w-8 text-indigo-600 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
             </svg>


### PR DESCRIPTION
## Summary
#12（管理者用ページのNamespace完全移行）で修正漏れがあり、管理者ダッシュボードでエラーが発生していた問題を修正。

## 修正内容
| ファイル | 修正 |
|----------|------|
| `app/controllers/admin/imports_controller.rb` | `mobile_suits_path` → `admin_mobile_suits_path` |
| `app/views/admin/imports/new_mobile_suits.html.erb` | `mobile_suits_path` → `admin_mobile_suits_path` (2箇所) |
| `app/views/dashboard/admin_dashboard.html.erb` | `mobile_suits_path` → `admin_mobile_suits_path`、`users_path` → `admin_users_path` |

## Test plan
- [ ] 管理者でログインしてダッシュボードが表示される
- [ ] ダッシュボードの「機体マスタ」「ユーザー管理」リンクが動作する
- [ ] 機体マスタCSVインポート画面の「戻る」「キャンセル」リンクが動作する

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)