### PR TITLE
fix: 試合履歴ページのモバイル表示崩れを修正

### DIFF
--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -103,50 +103,48 @@
             </div>
 
             <%= link_to match_path(match), class: "block" do %>
-              <div class="grid grid-cols-3 gap-2 sm:gap-4 items-center">
+              <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
                 <% team1_players = match.match_players.where(team_number: 1).order(:position) %>
                 <% team2_players = match.match_players.where(team_number: 2).order(:position) %>
 
                 <!-- Team 1 -->
-                <div class="<%= match.winning_team == 1 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2 sm:p-3' : 'bg-red-50 border-2 border-red-400 rounded p-2 sm:p-3' %> relative">
+                <div class="<%= match.winning_team == 1 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">
                   <div class="text-xs font-semibold text-gray-500 mb-2 flex items-center justify-between">
-                    <span class="hidden sm:inline">チーム1</span>
-                    <span class="sm:hidden">T1</span>
-                    <span class="px-1.5 sm:px-2 py-0.5 rounded text-xs font-bold <%= match.winning_team == 1 ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
+                    <span>チーム1</span>
+                    <span class="px-2 py-0.5 rounded text-xs font-bold <%= match.winning_team == 1 ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
                       <%= match.winning_team == 1 ? 'WIN' : 'LOSE' %>
                     </span>
                   </div>
-                  <% team1_players.each do |player| %>
-                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-1">
-                      <div class="flex items-center flex-wrap">
-                        <span class="text-xs sm:text-sm font-medium <%= player.position == 1 ? 'text-red-600 font-bold' : 'text-gray-900' %>"><%= player.user.nickname %></span>
-                        <% if player.position == 1 %>
-                          <span class="ml-1 px-1 sm:px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
+                  <% team1_players.each_with_index do |player, index| %>
+                    <div class="mb-1">
+                      <span class="<%= index == 0 ? 'text-red-600 font-bold' : 'text-gray-700' %>">
+                        <%= player.user.nickname %>
+                        <% if index == 0 %>
+                          <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
                         <% end %>
-                      </div>
-                      <span class="text-xs text-gray-500 truncate"><%= player.mobile_suit.name %></span>
+                      </span>
+                      <div class="text-gray-500"><%= player.mobile_suit.name %></div>
                     </div>
                   <% end %>
                 </div>
 
                 <!-- VS -->
-                <div class="text-center text-gray-400 font-bold text-base sm:text-xl">
+                <div class="flex items-center justify-center text-gray-400 font-bold text-lg">
                   VS
                 </div>
 
                 <!-- Team 2 -->
-                <div class="<%= match.winning_team == 2 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2 sm:p-3' : 'bg-red-50 border-2 border-red-400 rounded p-2 sm:p-3' %> relative">
+                <div class="<%= match.winning_team == 2 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">
                   <div class="text-xs font-semibold text-gray-500 mb-2 flex items-center justify-between">
-                    <span class="hidden sm:inline">チーム2</span>
-                    <span class="sm:hidden">T2</span>
-                    <span class="px-1.5 sm:px-2 py-0.5 rounded text-xs font-bold <%= match.winning_team == 2 ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
+                    <span>チーム2</span>
+                    <span class="px-2 py-0.5 rounded text-xs font-bold <%= match.winning_team == 2 ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
                       <%= match.winning_team == 2 ? 'WIN' : 'LOSE' %>
                     </span>
                   </div>
                   <% team2_players.each do |player| %>
-                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-1">
-                      <span class="text-xs sm:text-sm font-medium text-gray-900"><%= player.user.nickname %></span>
-                      <span class="text-xs text-gray-500 truncate"><%= player.mobile_suit.name %></span>
+                    <div class="mb-1">
+                      <span class="text-gray-700"><%= player.user.nickname %></span>
+                      <div class="text-gray-500"><%= player.mobile_suit.name %></div>
                     </div>
                   <% end %>
                 </div>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -84,25 +84,25 @@
   <div class="bg-white shadow overflow-hidden sm:rounded-lg">
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
-        <li class="relative">
+        <li class="<%= current_user.is_admin? ? 'pl-10' : '' %> relative">
           <% if current_user.is_admin? %>
-            <div class="absolute left-2 top-4 z-10" onclick="event.stopPropagation();">
+            <div class="absolute left-2 top-4 z-10">
               <input type="checkbox" name="match_ids[]" value="<%= match.id %>" form="bulk-delete-form" class="match-checkbox rounded border-gray-300 text-blue-600 focus:ring-blue-500">
             </div>
           <% end %>
-          <%= link_to match_path(match), class: "block hover:bg-gray-50 transition #{current_user.is_admin? ? 'pl-10' : ''}" do %>
-            <div class="px-6 py-4">
-              <div class="flex items-center justify-between mb-3">
-                <div class="flex items-center space-x-3">
-                  <span class="text-sm text-gray-500">
-                    <%= match.played_at.strftime('%Y年%m月%d日') %>
-                  </span>
-                  <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-                    <%= match.event.name %>
-                  </span>
-                </div>
+          <div class="px-6 py-4">
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center space-x-3">
+                <%= link_to match_path(match), class: "text-sm text-gray-500 hover:text-blue-600" do %>
+                  <%= match.played_at.strftime('%Y年%m月%d日') %>
+                <% end %>
+                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
+                  <%= match.event.name %>
+                </span>
               </div>
+            </div>
 
+            <%= link_to match_path(match), class: "block" do %>
               <div class="grid grid-cols-3 gap-2 sm:gap-4 items-center">
                 <% team1_players = match.match_players.where(team_number: 1).order(:position) %>
                 <% team2_players = match.match_players.where(team_number: 2).order(:position) %>
@@ -151,8 +151,8 @@
                   <% end %>
                 </div>
               </div>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
## Summary
試合履歴ページ（`/matches`）のモバイル表示でUIが崩れていた問題を修正し、イベント詳細ページの対戦記録と同じレイアウトに統一。

## 原因
#13 で修正したイベント一覧ページと同様、リスト項目全体を `link_to` ブロックで囲んでいた構造が原因。また、`grid-cols-3` を使用していたためモバイルでも3列表示になり、内容が圧縮されていた。

## 修正内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| リンク構造 | リスト項目全体を `link_to` で囲む | 日付と対戦カードを別々の `link_to` に分割 |
| `pl-10` | `link_to` に適用 | `li` 要素に移動 |
| グリッド | `grid-cols-3`（常に3列） | `grid-cols-1 md:grid-cols-3`（モバイルで縦積み） |
| レイアウト | 独自の複雑なflex構造 | イベント詳細ページと同じスタイル |

## Test plan
- [ ] 試合履歴ページがモバイルで正しく表示される（縦積みレイアウト）
- [ ] デスクトップでは3列レイアウトで表示される
- [ ] 日付クリックで試合詳細に遷移できる
- [ ] 対戦カードクリックで試合詳細に遷移できる
- [ ] 管理者のチェックボックスが正しく動作する
- [ ] イベント詳細ページの対戦記録と見た目が統一されている

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)