### PR TITLE
feat: ユーザー種別による機能制限の整備

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,7 @@ module Admin
     before_action :set_user, only: [:edit, :update, :destroy]
 
     def index
-      @users = User.all.order(is_admin: :desc, nickname: :asc)
+      @users = User.where(is_guest: false).order(is_admin: :desc, nickname: :asc)
     end
 
     def new

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :set_user_cookie
 
   # ユーザー視点切り替え機能
-  helper_method :viewing_as_user, :viewing_as_someone_else?
+  helper_method :viewing_as_user, :viewing_as_someone_else?, :can_react?
 
   # 現在表示中のユーザー視点を取得
   # 管理者が視点切り替えをしている場合は、そのユーザーを返す
@@ -25,6 +25,11 @@ class ApplicationController < ActionController::Base
   # 視点切り替え中かどうか
   def viewing_as_someone_else?
     current_user&.is_admin && session[:view_as_user_id].present? && session[:view_as_user_id] != current_user.id
+  end
+
+  # スタンプを押せるかどうか（viewing_as_user が一般ユーザーの場合のみ）
+  def can_react?
+    user_signed_in? && viewing_as_user&.regular_user?
   end
 
   private

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -16,7 +16,7 @@ class DashboardController < ApplicationController
     # 基本統計
     @total_matches = Match.count
     @total_events = Event.count
-    @total_users = User.count
+    @total_users = User.regular_users.count
 
     # 今日のイベント
     @today_event = Event.where(held_on: Time.zone.today).first
@@ -66,7 +66,7 @@ class DashboardController < ApplicationController
     # 基本統計
     @total_matches = Match.count
     @total_events = Event.count
-    @total_users = User.count
+    @total_users = User.regular_users.count
 
     # 全試合データを一度だけ読み込み（Eager Loading）
     load_all_user_matches

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -48,7 +48,7 @@ class MatchesController < ApplicationController
   def new
     @match = @event.matches.build(played_at: Time.current)
     4.times { |i| @match.match_players.build(position: i + 1) }
-    @users = User.non_guest.order(:nickname)
+    @users = User.regular_users.order(:nickname)
     @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
   end
 
@@ -59,14 +59,14 @@ class MatchesController < ApplicationController
     if @match.save
       redirect_to @event, notice: "対戦記録を登録しました。"
     else
-      @users = User.non_guest.order(:nickname)
+      @users = User.regular_users.order(:nickname)
       @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
       render :new, status: :unprocessable_entity
     end
   end
 
   def edit
-    @users = User.non_guest.order(:nickname)
+    @users = User.regular_users.order(:nickname)
     @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
   end
 
@@ -74,7 +74,7 @@ class MatchesController < ApplicationController
     if @match.update(match_params)
       redirect_to @match, notice: "対戦記録を更新しました。"
     else
-      @users = User.non_guest.order(:nickname)
+      @users = User.regular_users.order(:nickname)
       @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -4,7 +4,7 @@ class ReactionsController < ApplicationController
 
   def toggle
     unless can_react?
-      redirect_to match_path(@match), alert: "スタンプは一般ユーザーのみ利用できます。"
+      head :forbidden
       return
     end
 

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -6,7 +6,7 @@ class ReactionsController < ApplicationController
     unless can_react?
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: turbo_stream.prepend("flash-messages", partial: "shared/flash_message",
+          render turbo_stream: turbo_stream.update("flash-messages", partial: "shared/flash_message",
             locals: { type: "warning", message: "スタンプは一般ユーザーのみ利用できます。" })
         end
         format.html { redirect_to matches_path, alert: "スタンプは一般ユーザーのみ利用できます。" }

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -3,14 +3,20 @@ class ReactionsController < ApplicationController
   before_action :set_match
 
   def toggle
+    unless can_react?
+      redirect_to match_path(@match), alert: "スタンプは一般ユーザーのみ利用できます。"
+      return
+    end
+
+    @reaction_user = viewing_as_user
     @master_emoji = MasterEmoji.find(params[:master_emoji_id])
-    @reaction = @match.reactions.find_by(user: current_user, master_emoji: @master_emoji)
+    @reaction = @match.reactions.find_by(user: @reaction_user, master_emoji: @master_emoji)
 
     if @reaction
       @reaction.destroy
       @action = :removed
     else
-      @match.reactions.create!(user: current_user, master_emoji: @master_emoji)
+      @match.reactions.create!(user: @reaction_user, master_emoji: @master_emoji)
       @action = :added
     end
 

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -4,7 +4,13 @@ class ReactionsController < ApplicationController
 
   def toggle
     unless can_react?
-      head :forbidden
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.prepend("flash-messages", partial: "shared/flash_message",
+            locals: { type: "warning", message: "スタンプは一般ユーザーのみ利用できます。" })
+        end
+        format.html { redirect_to matches_path, alert: "スタンプは一般ユーザーのみ利用できます。" }
+      end
       return
     end
 

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -6,9 +6,9 @@ class StatisticsController < ApplicationController
   def index
     @active_tab = params[:tab] || 'overall'
 
-    # ゲストユーザーは個人統計タブにアクセス不可
+    # ゲストユーザー（または管理者がゲスト視点切り替え中）は個人統計タブにアクセス不可
     personal_tabs = %w[overview events event_progression mobile_suits opponent_suits partners opponents]
-    if current_user.is_guest && personal_tabs.include?(@active_tab)
+    if viewing_as_user.is_guest && personal_tabs.include?(@active_tab)
       redirect_to statistics_path(tab: 'overall'), alert: '個人統計を見るには管理者にアカウント発行を依頼してください'
       return
     end

--- a/app/javascript/controllers/auto_dismiss_controller.js
+++ b/app/javascript/controllers/auto_dismiss_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.timeout = setTimeout(() => {
+      this.element.style.transition = "opacity 0.5s ease-out"
+      this.element.style.opacity = "0"
+      setTimeout(() => this.element.remove(), 500)
+    }, 3000)
+  }
+
+  disconnect() {
+    if (this.timeout) clearTimeout(this.timeout)
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,11 @@ class User < ApplicationRecord
   scope :regular_users, -> { where(is_admin: false, is_guest: false) }
   scope :non_guest, -> { where(is_guest: false) }
 
+  # 一般ユーザー（管理者でもゲストでもない）かどうか
+  def regular_user?
+    !is_admin && !is_guest
+  end
+
   # Virtual email attribute (maps to username for Devise compatibility)
   def email
     username

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -15,7 +15,7 @@
         <tr>
           <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ユーザー名</th>
           <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ニックネーム</th>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">管理者</th>
+          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">種別</th>
           <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">通知</th>
           <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">操作</th>
         </tr>
@@ -28,6 +28,8 @@
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
               <% if user.is_admin? %>
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-indigo-100 text-indigo-800">管理者</span>
+              <% elsif user.is_guest? %>
+                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-amber-100 text-amber-800">ゲスト</span>
               <% else %>
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">一般</span>
               <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,8 +1,8 @@
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-8">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">ダッシュボード</h1>
-    <p class="mt-2 text-sm text-gray-600">ようこそ、<%= current_user.nickname %>さん</p>
-    <% if current_user.is_guest %>
+    <p class="mt-2 text-sm text-gray-600">ようこそ、<%= viewing_as_user.nickname %>さん</p>
+    <% if viewing_as_user.is_guest %>
       <div class="mt-4 bg-amber-50 border-l-4 border-amber-400 p-4">
         <div class="flex">
           <div class="flex-shrink-0">
@@ -223,7 +223,7 @@
         </div>
       <% end %>
 
-      <% if current_user.is_guest %>
+      <% if viewing_as_user.is_guest %>
         <!-- ゲスト用: 個人戦績の代わりに案内を表示 -->
         <div class="bg-white shadow rounded-lg p-6">
           <div class="text-center py-8">
@@ -501,7 +501,7 @@
         <div class="px-6 py-5 border-b border-gray-200">
           <h2 class="text-lg font-bold text-gray-900">🏆 あなたの戦績</h2>
         </div>
-        <% if current_user.is_guest %>
+        <% if viewing_as_user.is_guest %>
           <div class="px-6 py-8 text-center">
             <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -535,7 +535,7 @@
           <h2 class="text-lg font-bold text-gray-900">🤝 ベストパートナー</h2>
         </div>
         <div class="divide-y divide-gray-200">
-          <% if current_user.is_guest %>
+          <% if viewing_as_user.is_guest %>
             <div class="px-6 py-8 text-center">
               <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -584,7 +584,7 @@
             <h2 class="text-lg font-bold text-gray-900">📱 機体トレンド</h2>
             <span class="text-xs text-gray-500" title="直近イベントでの使用機体と勝率">ℹ️ イベント別</span>
           </div>
-          <% if !current_user.is_guest && @trend_event %>
+          <% if !viewing_as_user.is_guest && @trend_event %>
             <p class="text-xs text-gray-500 mt-1">
               <%= @trend_event.name %>
               <% if @is_today_event %>
@@ -594,7 +594,7 @@
           <% end %>
         </div>
         <div class="divide-y divide-gray-200">
-          <% if current_user.is_guest %>
+          <% if viewing_as_user.is_guest %>
             <div class="px-6 py-8 text-center">
               <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -638,7 +638,7 @@
           </div>
         </div>
         <div class="divide-y divide-gray-200">
-          <% if current_user.is_guest %>
+          <% if viewing_as_user.is_guest %>
             <div class="px-6 py-8 text-center">
               <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -683,7 +683,7 @@
           <h2 class="text-lg font-bold text-gray-900">⭐ お気に入り機体</h2>
         </div>
         <div class="divide-y divide-gray-200">
-          <% if current_user.is_guest %>
+          <% if viewing_as_user.is_guest %>
             <div class="px-6 py-8 text-center">
               <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -394,48 +394,11 @@
     </nav>
 
     <!-- フラッシュメッセージ -->
-    <% if flash.any? %>
-      <div class="<%= 'main-content-with-sidebar' if user_signed_in? %> max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
-        <% flash.each do |type, message| %>
-          <%
-            alert_class = case type.to_s
-            when 'notice'
-              'bg-blue-50 border-blue-400 text-blue-800'
-            when 'success'
-              'bg-green-50 border-green-400 text-green-800'
-            when 'alert', 'error'
-              'bg-red-50 border-red-400 text-red-800'
-            when 'warning'
-              'bg-yellow-50 border-yellow-400 text-yellow-800'
-            else
-              'bg-gray-50 border-gray-400 text-gray-800'
-            end
-          %>
-          <div class="border-l-4 p-4 mb-4 <%= alert_class %> rounded shadow-sm">
-            <div class="flex items-center">
-              <div class="flex-shrink-0">
-                <% if type.to_s == 'notice' || type.to_s == 'success' %>
-                  <svg class="h-5 w-5 <%= type.to_s == 'notice' ? 'text-blue-400' : 'text-green-400' %>" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
-                  </svg>
-                <% elsif type.to_s == 'alert' || type.to_s == 'error' %>
-                  <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-                  </svg>
-                <% else %>
-                  <svg class="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-                  </svg>
-                <% end %>
-              </div>
-              <div class="ml-3">
-                <p class="text-sm font-medium"><%= message %></p>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
+    <div id="flash-messages" class="<%= 'main-content-with-sidebar' if user_signed_in? %> max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <% flash.each do |type, message| %>
+        <%= render "shared/flash_message", type: type, message: message %>
+      <% end %>
+    </div>
 
     <main class="<%= 'main-content-with-sidebar' if user_signed_in? %>">
       <%= yield %>

--- a/app/views/reactions/_reaction_bar.html.erb
+++ b/app/views/reactions/_reaction_bar.html.erb
@@ -7,7 +7,7 @@
     <%= render "reactions/reaction_button", match: match, emoji: emoji, compact: compact %>
   <% end %>
 
-  <% if user_signed_in? %>
+  <% if can_react? %>
     <button type="button"
             class="reaction-add-btn <%= compact ? 'w-7 h-7 text-sm' : 'w-8 h-8 text-lg' %> rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-gray-500 transition-colors"
             data-action="click->reaction-picker#togglePicker"

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,43 @@
+<%
+  alert_class = case type.to_s
+  when 'notice'
+    'bg-blue-50 border-blue-400 text-blue-800'
+  when 'success'
+    'bg-green-50 border-green-400 text-green-800'
+  when 'alert', 'error'
+    'bg-red-50 border-red-400 text-red-800'
+  when 'warning'
+    'bg-yellow-50 border-yellow-400 text-yellow-800'
+  else
+    'bg-gray-50 border-gray-400 text-gray-800'
+  end
+
+  icon_color = case type.to_s
+  when 'notice' then 'text-blue-400'
+  when 'success' then 'text-green-400'
+  when 'alert', 'error' then 'text-red-400'
+  else 'text-yellow-400'
+  end
+%>
+<div class="border-l-4 p-4 mb-4 <%= alert_class %> rounded shadow-sm mt-4" data-controller="auto-dismiss">
+  <div class="flex items-center">
+    <div class="flex-shrink-0">
+      <% if type.to_s == 'notice' || type.to_s == 'success' %>
+        <svg class="h-5 w-5 <%= icon_color %>" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+        </svg>
+      <% elsif type.to_s == 'alert' || type.to_s == 'error' %>
+        <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+        </svg>
+      <% else %>
+        <svg class="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+        </svg>
+      <% end %>
+    </div>
+    <div class="ml-3">
+      <p class="text-sm font-medium"><%= message %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -14,7 +14,7 @@
         <option value="overall" <%= 'selected' if @active_tab == 'overall' %>>全体統計</option>
       </optgroup>
       <optgroup label="個人">
-        <% if current_user.is_guest %>
+        <% if viewing_as_user.is_guest %>
           <option disabled>総合戦績（要アカウント）</option>
           <option disabled>イベント別戦績（要アカウント）</option>
           <option disabled>イベント内期間別戦績（要アカウント）</option>
@@ -66,7 +66,7 @@
 
       <!-- 個人統計カテゴリ -->
       <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider px-2 py-4">個人</span>
-      <% if current_user.is_guest %>
+      <% if viewing_as_user.is_guest %>
         <!-- ゲストユーザー: 個人統計タブを無効化 -->
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">総合戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">イベント別戦績</span>


### PR DESCRIPTION
## Summary
- スタンプ機能を一般ユーザーのみに制限（ゲスト・管理者は利用不可、警告アラート表示）
- 管理者の「視点切り替え」でダッシュボード・統計画面がゲスト表示に正しく反映されるよう修正
- ユーザー管理画面の種別カラム表示改善（管理者/一般/ゲスト）、ゲストユーザーを一覧から非表示
- ダッシュボードの登録ユーザー数から管理者・ゲストを除外
- フラッシュメッセージを共通パーシャルに抽出し、turbo_stream対応の自動消去機能を追加

## Changes
- `User#regular_user?` メソッド追加、`non_guest` → `regular_users` スコープ統一
- `can_react?` ヘルパー追加（ReactionsController + ビューで利用）
- 権限外スタンプクリック時にturbo_streamで警告アラート表示（ページ遷移なし、重複表示なし）
- `viewing_as_user` をダッシュボード・統計で一貫して使用
- ダッシュボードの `User.count` → `User.regular_users.count` に修正
- `shared/_flash_message` パーシャル + `auto_dismiss_controller.js` 新規作成

## Test plan
- [ ] 一般ユーザーでスタンプの追加・削除が正常に動作すること
- [ ] ゲスト・管理者でスタンプクリック時に警告アラートが表示され、ページ遷移しないこと
- [ ] 連続クリックしてもアラートが1つだけ表示されること
- [ ] 管理者がゲスト視点に切り替えた際、ダッシュボード・統計がゲスト表示になること
- [ ] ダッシュボードの登録ユーザー数に管理者・ゲストが含まれないこと
- [ ] ユーザー管理画面でゲストが非表示、種別カラムが正しく表示されること

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)