### PR TITLE
fix: 試合日がイベント日と1日ズレて表示されるタイムゾーン問題を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development" \
-    LD_PRELOAD="/usr/local/lib/libjemalloc.so"
+    LD_PRELOAD="/usr/local/lib/libjemalloc.so" \
+    TZ="Asia/Tokyo"
 
 # Throw-away build stage to reduce size of final image
 FROM base AS build

--- a/db/migrate/20260208030138_convert_utc_played_at_to_jst.rb
+++ b/db/migrate/20260208030138_convert_utc_played_at_to_jst.rb
@@ -1,0 +1,21 @@
+class ConvertUtcPlayedAtToJst < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE matches m
+      SET played_at = m.played_at + INTERVAL '9 hours'
+      FROM events e
+      WHERE m.event_id = e.id
+      AND DATE(m.played_at) = e.held_on - INTERVAL '1 day'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE matches m
+      SET played_at = m.played_at - INTERVAL '9 hours'
+      FROM events e
+      WHERE m.event_id = e.id
+      AND DATE(m.played_at) != e.held_on
+    SQL
+  end
+end


### PR DESCRIPTION
## Summary
- DockerfileにTZ=Asia/Tokyoを設定し、ビルド時もJSTを保証
- TZ設定前にUTCで保存された過去の`played_at`データを+9時間するマイグレーションを追加

## 原因
`deploy.yml`に`TZ=Asia/Tokyo`が追加される以前に保存されたデータがUTCで格納されていた。TZ設定後にそのUTCデータをJSTとして読み取るため、日付が1日ズレていた。

Closes #41

## Test plan
- [ ] マイグレーション実行後、過去の試合日がイベント日と一致することを確認
- [ ] 新規インポートした試合日にズレが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)