### PR TITLE
fix: 視点切り替え時のスタンプハイライト色が反映されない問題を修正

### DIFF
--- a/app/views/reactions/_reaction_button.html.erb
+++ b/app/views/reactions/_reaction_button.html.erb
@@ -9,7 +9,7 @@
   else
     # 通常のリクエスト時のみ current_user を使用（Deviseコンテキストがある場合）
     begin
-      defined?(current_user) && respond_to?(:current_user) ? current_user : nil
+      defined?(viewing_as_user) && respond_to?(:viewing_as_user) ? viewing_as_user : nil
     rescue
       nil
     end


### PR DESCRIPTION
## Summary
- `_reaction_button.html.erb` のハイライト判定で `current_user`（Devise = 管理者自身）を参照していたため、`viewing_as_user` に変更
- 非管理者の場合は `viewing_as_user` = `current_user` を返すため既存動作に影響なし

## 原因
管理者が `viewing_as_user` で一般ユーザーの視点に切り替えた際、スタンプのハイライト判定に `current_user`（管理者自身）を使用していたため、切り替え先ユーザーが押済みのスタンプがハイライトされなかった。

Closes #42

## Test plan
- [ ] 一般ユーザーでログインし、押済みスタンプが青色ハイライトされること
- [ ] 管理者でログインし、試合履歴のスタンプがグレー表示であること
- [ ] 管理者が一般ユーザーの視点に切り替え → 押済みスタンプが青色ハイライトになること
- [ ] 視点切り替えを解除 → 管理者自身のリアクション状態に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)