### PR TITLE
chore: スキーマファイルの更新漏れを反映

### DIFF
--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,9 +1,24 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 1) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
   create_table "solid_cable_messages", force: :cascade do |t|
-    t.binary "channel", limit: 1024, null: false
-    t.binary "payload", limit: 536870912, null: false
+    t.binary "channel", null: false
+    t.bigint "channel_hash", null: false
     t.datetime "created_at", null: false
-    t.integer "channel_hash", limit: 8, null: false
+    t.binary "payload", null: false
     t.index ["channel"], name: "index_solid_cable_messages_on_channel"
     t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
     t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_05_122912) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_08_030138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## Summary
- `db/schema.rb` のバージョンを最新マイグレーション（`2026_02_08_030138`）に更新
- `db/cable_schema.rb` を Rails 7.1 → 8.1 形式に再生成

## 原因
- PR #45 でマイグレーション追加時に `schema.rb` の更新がコミットに含まれていなかった
- `cable_schema.rb` はプロジェクト初期化時から Rails 7.1 形式のままだった

Closes #47

## Test plan
- [ ] `rails db:migrate:status` でマイグレーションが全て `up` であること
- [ ] アプリケーションが正常に起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)