### PR TITLE
fix: スタンプピッカーの表示位置ズレを修正

### DIFF
--- a/app/javascript/controllers/reaction_picker_controller.js
+++ b/app/javascript/controllers/reaction_picker_controller.js
@@ -98,18 +98,44 @@ export default class extends Controller {
     if (this.hasPickerTarget) {
       this.pickerTarget.classList.toggle('hidden')
 
-      // Position the picker within viewport
+      // ボタンの位置に合わせてピッカーを表示
       if (!this.pickerTarget.classList.contains('hidden')) {
+        const button = event.currentTarget
         const barRect = this.element.getBoundingClientRect()
-        const pickerRect = this.pickerTarget.getBoundingClientRect()
+        const gap = 4 // ボタンとの隙間(px)
 
-        // Default: right-aligned. If it overflows left, switch to left-aligned.
-        if (barRect.right - pickerRect.width < 0) {
-          this.pickerTarget.style.right = 'auto'
+        // 横位置: モバイルではバー全幅、デスクトップではボタン位置に揃える
+        if (window.innerWidth < 640) {
           this.pickerTarget.style.left = '0'
-        } else {
           this.pickerTarget.style.right = '0'
-          this.pickerTarget.style.left = 'auto'
+        } else {
+          this.pickerTarget.style.left = button.offsetLeft + 'px'
+          this.pickerTarget.style.right = 'auto'
+        }
+
+        // 縦位置: スペースが広い方に表示
+        const pickerHeight = this.pickerTarget.offsetHeight
+        const spaceBelow = window.innerHeight - barRect.bottom
+        const spaceAbove = barRect.top
+        if (spaceBelow >= pickerHeight + gap) {
+          this.pickerTarget.style.top = '100%'
+          this.pickerTarget.style.bottom = 'auto'
+          this.pickerTarget.style.marginTop = gap + 'px'
+          this.pickerTarget.style.marginBottom = '0'
+        } else {
+          this.pickerTarget.style.top = 'auto'
+          this.pickerTarget.style.bottom = '100%'
+          this.pickerTarget.style.marginTop = '0'
+          this.pickerTarget.style.marginBottom = gap + 'px'
+        }
+
+        // デスクトップ: 右にはみ出す場合はバー右端に揃える
+        if (window.innerWidth >= 640) {
+          const pickerRect = this.pickerTarget.getBoundingClientRect()
+          if (pickerRect.right > window.innerWidth) {
+            this.pickerTarget.style.left = 'auto'
+            this.pickerTarget.style.right = '0'
+          }
         }
       }
     }

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -81,7 +81,7 @@
     <% end %>
   <% end %>
 
-  <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+  <div class="bg-white shadow sm:rounded-lg">
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
         <li class="<%= current_user.is_admin? ? 'pl-10' : '' %> relative">

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -5,7 +5,7 @@
     <%= link_to "← 対戦履歴に戻る", matches_path, class: "text-blue-600 hover:text-blue-500" %>
   </div>
 
-  <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+  <div class="bg-white shadow sm:rounded-lg">
     <div class="px-6 py-5 border-b border-gray-200">
       <div class="flex justify-between items-center">
         <div>

--- a/app/views/reactions/_reaction_bar.html.erb
+++ b/app/views/reactions/_reaction_bar.html.erb
@@ -15,7 +15,7 @@
       +
     </button>
 
-    <div class="reaction-picker hidden absolute z-20 right-0 bg-white shadow-lg rounded-lg p-2 border border-gray-200"
+    <div class="reaction-picker hidden absolute z-20 bg-white shadow-lg rounded-lg p-2 border border-gray-200"
          data-reaction-picker-target="picker">
       <div class="flex flex-wrap gap-1 max-w-sm">
         <% emojis.each do |emoji| %>


### PR DESCRIPTION
## Summary
- スタンプピッカーの `right-0` 固定を削除し、＋ボタンの位置に合わせて表示するよう変更
- モバイル（< 640px）ではピッカーをバー全幅に広げ、スタンプが横並びになるよう調整
- 下にスペースがない場合はバーの上に表示し、画面端での見切れを防止
- 一覧・詳細画面の `overflow-hidden` を削除し、ピッカーがコンテナ境界でクリップされる問題を修正

## 原因
- `_reaction_bar.html.erb` のピッカーに `absolute right-0` が指定されており、バー右端に固定表示されていた
- `show.html.erb` / `index.html.erb` のカードコンテナに `overflow-hidden` があり、ピッカーがクリップされていた

Closes #43

## Test plan
- [ ] 一覧画面で＋ボタンをクリック → ピッカーがボタン付近に表示されること
- [ ] 詳細画面で＋ボタンをクリック → ピッカーがボタン付近に表示されること
- [ ] 画面下部の＋ボタン → ピッカーがバーの上に表示され、見切れないこと
- [ ] モバイル幅（375px）→ ピッカーがバー全幅に広がり、スタンプが横並びになること
- [ ] デスクトップ幅 → ピッカーがボタン位置に揃い、右端はみ出し時は右揃えになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)