### PR TITLE
fix: フィルターボタンの文言短縮でスマホ表示崩れを解消

### DIFF
--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -57,8 +57,8 @@
       </div>
 
       <div class="flex space-x-3">
-        <%= form.submit "フィルター適用", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
-        <%= link_to "フィルターをクリア", matches_path, class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded" %>
+        <%= form.submit "適用", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
+        <%= link_to "クリア", matches_path, class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded" %>
       </div>
     <% end %>
   </div>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -167,8 +167,8 @@
         </div>
 
       <div class="flex space-x-3">
-        <%= form.submit "フィルター適用", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
-        <%= link_to "フィルターをクリア", statistics_path(tab: @active_tab), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded" %>
+        <%= form.submit "適用", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
+        <%= link_to "クリア", statistics_path(tab: @active_tab), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## 概要
- フィルターボタンの文言「フィルター適用」→「適用」、「フィルターをクリア」→「クリア」に短縮
- スマホ幅でボタンテキストが改行される表示崩れを解消

Closes #40

## テスト項目
- [ ] `/matches` のフィルターUIでボタン文言が「適用」「クリア」になっていること
- [ ] `/statistics` のフィルターUIでボタン文言が「適用」「クリア」になっていること
- [ ] スマホ幅（375px程度）でボタンが改行せず1行に収まること

🤖 Generated with [Claude Code](https://claude.com/claude-code)