### PR TITLE
fix: サイドバーのローテーション・イベントメニューの左端位置ズレ修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html style="scrollbar-gutter: stable;">
   <head>
     <title><%= content_for(:title) || "VS.モバイル for KGY" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
## Summary
- スクロールバーの有無によるページ間のコンテンツ左端位置のズレを修正
- `<html>` 要素に `scrollbar-gutter: stable` を追加し、スクロールバーの有無にかかわらず常にスペースを確保

## 原因
- イベント・ローテーションページはコンテンツが短くスクロールバー非表示
- ダッシュボード・対戦履歴・統計ページはコンテンツが長くスクロールバー表示
- スクロールバー幅（約15px）分、`mx-auto` の中央計算結果がページ間でズレていた

## Test plan
- [ ] イベント一覧(`/events`)とダッシュボード(`/dashboard`)を行き来して、コンテナ左端位置が揃っていることを確認
- [ ] ローテーション一覧(`/rotations`)と対戦履歴(`/matches`)でも同様に確認
- [ ] モバイル表示で問題がないことを確認

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)