### PR TITLE
fix: 対戦履歴の表示順が不安定になる問題の修正（hotfix）

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -5,7 +5,7 @@ class MatchesController < ApplicationController
   before_action :set_match, only: [:show, :edit, :update, :destroy]
 
   def index
-    @matches = Match.includes(:event, { match_players: [:user, :mobile_suit] }, { reactions: :user }).order(played_at: :desc)
+    @matches = Match.includes(:event, { match_players: [:user, :mobile_suit] }, { reactions: :user }).order(played_at: :desc, id: :desc)
 
     # フィルター: イベント（複数選択対応）
     if params[:events].present?


### PR DESCRIPTION
## Summary
- 同一 `played_at` の試合が多数存在する場合、対戦履歴一覧の表示順が不定になり、最新の試合が1ページ目に表示されない問題を修正
- `order(played_at: :desc)` に `id: :desc` を副次ソートとして追加

## 原因
- TZマイグレーション適用後、PostgreSQLの内部的な物理順序が変わり、同一 `played_at` の試合の表示順が変化した

## Test plan
- [ ] 対戦履歴一覧で最新の試合（最大ID）が1ページ目の先頭に表示されることを確認
- [ ] リアクション付きの試合（Match#224, #225）が正しく表示されることを確認

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)