### PR TITLE
feat: 試合別アーカイブ再生リンク機能の追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
   before_action :authenticate_user!
-  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy]
-  before_action :set_event, only: [:show, :edit, :update, :destroy]
+  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps]
+  before_action :set_event, only: [:show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps]
 
   def index
     @events = Event.includes(:matches).order(held_on: :desc)
@@ -37,6 +37,53 @@ class EventsController < ApplicationController
     end
   end
 
+  def edit_timestamps
+    @matches = @event.matches.includes(match_players: [:user, :mobile_suit]).order(:played_at, :id)
+    existing = @matches.map { |m| format_timestamp(m.video_timestamp) }
+    @timestamps_text = existing.any?(&:present?) ? existing.join("\n") : ''
+  end
+
+  def update_timestamps
+    @matches = @event.matches.includes(match_players: [:user, :mobile_suit]).order(:played_at, :id)
+    raw_text = params[:timestamps].to_s
+    lines = raw_text.split("\n").map(&:strip)
+
+    # 末尾の空行を除去
+    lines.pop while lines.last&.empty?
+
+    if lines.size != @matches.size
+      flash.now[:alert] = "行数（#{lines.size}）と試合数（#{@matches.size}）が一致しません。"
+      @timestamps_text = raw_text
+      render :edit_timestamps, status: :unprocessable_entity
+      return
+    end
+
+    timestamps = lines.map.with_index do |line, i|
+      if line.blank?
+        flash.now[:alert] = "#{i + 1}行目が空です。すべての行にタイムスタンプを入力してください。"
+        @timestamps_text = raw_text
+        render :edit_timestamps, status: :unprocessable_entity
+        return
+      end
+      seconds = parse_timestamp(line)
+      if seconds.nil?
+        flash.now[:alert] = "#{i + 1}行目「#{line}」の形式が不正です。H:MM:SS または MM:SS の形式で入力してください。"
+        @timestamps_text = raw_text
+        render :edit_timestamps, status: :unprocessable_entity
+        return
+      end
+      seconds
+    end
+
+    ActiveRecord::Base.transaction do
+      @matches.each_with_index do |match, i|
+        match.update!(video_timestamp: timestamps[i])
+      end
+    end
+
+    redirect_to event_path(@event), notice: "タイムスタンプを保存しました。"
+  end
+
   def destroy
     name = @event.name
 
@@ -62,5 +109,22 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(:name, :held_on, :description, :broadcast_url)
+  end
+
+  def parse_timestamp(str)
+    return nil if str.blank?
+    parts = str.strip.split(':').map(&:to_i)
+    case parts.size
+    when 3 then parts[0] * 3600 + parts[1] * 60 + parts[2]
+    when 2 then parts[0] * 60 + parts[1]
+    else nil
+    end
+  end
+
+  def format_timestamp(seconds)
+    return '' if seconds.nil?
+    h, remainder = seconds.divmod(3600)
+    m, s = remainder.divmod(60)
+    "#{h}:#{format('%02d', m)}:#{format('%02d', s)}"
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -159,7 +159,7 @@ class MatchesController < ApplicationController
   end
 
   def match_params
-    params.require(:match).permit(:winning_team, :played_at, match_players_attributes: [:id, :user_id, :mobile_suit_id, :team_number, :position])
+    params.require(:match).permit(:winning_team, :played_at, :video_timestamp_text, match_players_attributes: [:id, :user_id, :mobile_suit_id, :team_number, :position])
   end
 
   # Find the next unrecorded match starting from current position

--- a/app/views/events/edit_timestamps.html.erb
+++ b/app/views/events/edit_timestamps.html.erb
@@ -1,0 +1,62 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="mb-6">
+    <%= link_to "← イベントに戻る", event_path(@event), class: "text-blue-600 hover:text-blue-500" %>
+  </div>
+
+  <h1 class="text-2xl font-bold text-gray-900 mb-2"><%= @event.name %></h1>
+  <h2 class="text-lg font-medium text-gray-700 mb-6">タイムスタンプ一括設定</h2>
+
+  <% if flash[:alert] %>
+    <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
+      <p class="text-sm text-red-700"><%= flash[:alert] %></p>
+    </div>
+  <% end %>
+
+  <%= form_with url: update_timestamps_event_path(@event), method: :patch, local: true do |f| %>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <!-- 左カラム: テキストエリア -->
+      <div class="bg-white shadow sm:rounded-lg p-6">
+        <label for="timestamps" class="block text-sm font-medium text-gray-700 mb-2">
+          タイムスタンプ（1行1試合）
+        </label>
+        <textarea
+          name="timestamps"
+          id="timestamps"
+          class="w-full h-[60vh] font-mono text-sm pl-3 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 resize-none"
+          placeholder="0:03:20&#10;0:07:45&#10;0:12:10"
+        ><%= @timestamps_text %></textarea>
+        <p class="mt-2 text-sm text-gray-500">
+          配信開始からの経過時間を1行1試合で入力してください（例: 0:03:20）
+        </p>
+      </div>
+
+      <!-- 右カラム: 試合一覧 -->
+      <div class="bg-white shadow sm:rounded-lg p-6">
+        <h3 class="text-sm font-medium text-gray-700 mb-3">試合一覧（<%= @matches.size %>試合）</h3>
+        <div class="space-y-2 text-sm h-[60vh] overflow-y-auto">
+          <% @matches.each_with_index do |match, i| %>
+            <div class="flex items-start gap-2 py-1 <%= i.even? ? 'bg-gray-50' : '' %> px-2 rounded">
+              <span class="text-gray-400 font-mono w-6 flex-shrink-0 text-right"><%= i + 1 %>.</span>
+              <div class="flex-1 min-w-0">
+                <% team1 = match.match_players.select { |p| p.team_number == 1 }.sort_by(&:position) %>
+                <% team2 = match.match_players.select { |p| p.team_number == 2 }.sort_by(&:position) %>
+                <span class="<%= match.winning_team == 1 ? 'font-bold' : '' %>">
+                  <%= team1.map { |p| p.user.nickname }.join(' & ') %>
+                </span>
+                <span class="text-gray-400 mx-1">vs</span>
+                <span class="<%= match.winning_team == 2 ? 'font-bold' : '' %>">
+                  <%= team2.map { |p| p.user.nickname }.join(' & ') %>
+                </span>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-6 flex gap-3">
+      <%= f.submit "保存", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-6 rounded cursor-pointer" %>
+      <%= link_to "キャンセル", event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,6 +20,9 @@
         <div class="flex flex-wrap gap-2 mt-4">
           <%= link_to "試合を登録", new_event_match_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= link_to "ローテーション作成", new_event_rotation_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+          <% if @event.broadcast_url.present? %>
+            <%= link_to "タイムスタンプ一括設定", edit_timestamps_event_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+          <% end %>
           <%= link_to "編集", edit_event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= button_to "削除", event_path(@event), method: :delete, data: { turbo_confirm: "イベント「#{@event.name}」を削除してもよろしいですか？関連する試合やローテーションもすべて削除されます。" }, class: "bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
         </div>

--- a/app/views/matches/edit.html.erb
+++ b/app/views/matches/edit.html.erb
@@ -80,6 +80,12 @@
     </div>
 
     <div class="bg-white shadow sm:rounded-lg p-6">
+      <h2 class="text-lg font-medium text-gray-900 mb-4">アーカイブタイムスタンプ</h2>
+      <%= form.text_field :video_timestamp_text, placeholder: "0:03:20", class: "w-full sm:w-48 px-3 py-2 font-mono border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+      <p class="mt-1 text-sm text-gray-500">配信開始からの経過時間（例: 0:03:20）。空欄で解除。</p>
+    </div>
+
+    <div class="bg-white shadow sm:rounded-lg p-6">
       <h2 class="text-lg font-medium text-gray-900 mb-4">勝利チーム</h2>
       <div class="flex space-x-4">
         <label class="flex items-center">

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -96,6 +96,11 @@
                 <%= link_to match_path(match), class: "text-sm text-gray-500 hover:text-blue-600" do %>
                   <%= match.played_at.strftime('%Y年%m月%d日') %>
                 <% end %>
+                <% if match.video_url %>
+                  <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "アーカイブを見る" do %>
+                    <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-5">
+                  <% end %>
+                <% end %>
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
                   <%= match.event.name %>
                 </span>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -10,9 +10,16 @@
       <div class="flex justify-between items-center">
         <div>
           <h1 class="text-2xl font-bold text-gray-900">対戦詳細</h1>
-          <p class="mt-1 text-sm text-gray-500">
-            <%= @match.played_at.strftime('%Y年%m月%d日') %>
-          </p>
+          <div class="mt-1 flex items-center gap-2">
+            <p class="text-sm text-gray-500">
+              <%= @match.played_at.strftime('%Y年%m月%d日') %>
+            </p>
+            <% if @match.video_url %>
+              <%= link_to @match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "アーカイブを見る" do %>
+                <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-6 sm:h-7">
+              <% end %>
+            <% end %>
+          </div>
         </div>
         <% if current_user.is_admin? %>
           <div class="flex space-x-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,10 @@ Rails.application.routes.draw do
 
   # Events
   resources :events do
+    member do
+      get :edit_timestamps
+      patch :update_timestamps
+    end
     resources :matches, only: [:new, :create]
     resources :rotations, only: [:new, :create]
   end

--- a/db/migrate/20260215124012_add_video_timestamp_to_matches.rb
+++ b/db/migrate/20260215124012_add_video_timestamp_to_matches.rb
@@ -1,0 +1,5 @@
+class AddVideoTimestampToMatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :matches, :video_timestamp, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_08_030138) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_15_124012) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_08_030138) do
     t.datetime "played_at", null: false
     t.bigint "rotation_match_id"
     t.datetime "updated_at", null: false
+    t.integer "video_timestamp"
     t.integer "winning_team", null: false
     t.index ["event_id", "played_at"], name: "index_matches_on_event_id_and_played_at"
     t.index ["event_id"], name: "index_matches_on_event_id"


### PR DESCRIPTION
## 概要
- イベントのアーカイブ配信を試合ごとに見返せる機能を追加
- YouTubeアーカイブのタイムスタンプ（H:MM:SS形式）をテキストエリアで一括入力し、各試合にリンクを生成

## 変更内容
- `matches`テーブルに`video_timestamp`カラム（integer）を追加
- `Match#video_url`メソッドで`broadcast_url?t={秒数}s`形式のURLを生成
- イベント詳細にadmin向け「タイムスタンプ一括設定」ボタン・専用編集画面を追加
- 試合一覧・詳細にYouTubeアイコンリンクを表示
- 試合編集画面から個別にタイムスタンプを設定・解除可能

## 対応Issue
Closes #14

## テスト方法
- [ ] イベント詳細 →「タイムスタンプ一括設定」ボタンが表示されること（admin + broadcast_url設定時のみ）
- [ ] タイムスタンプ編集画面でH:MM:SS形式を入力 → 保存成功
- [ ] 試合一覧/詳細でYouTubeアイコンが表示されること
- [ ] アイコンクリック → 正しいURLに遷移すること
- [ ] 行数不一致・空行・不正形式でエラーメッセージが表示されること
- [ ] 試合編集画面から個別にタイムスタンプを変更・解除できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)