### PR TITLE
fix: ローテーション1試合目・2周目以降の通知修正

### DIFF
--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -81,6 +81,9 @@ class RotationsController < ApplicationController
     # Send push notifications to all players
     PushNotificationService.notify_rotation_activated(rotation: @rotation)
 
+    # Send upcoming match notifications (1試合目の出番通知含む)
+    notify_upcoming_players(@rotation)
+
     redirect_to @rotation, notice: 'ローテーションをアクティブにしました。'
   end
 
@@ -285,6 +288,10 @@ class RotationsController < ApplicationController
 
     # Activate the new rotation
     new_rotation.update!(is_active: true)
+
+    # Send push notifications for new round
+    PushNotificationService.notify_rotation_activated(rotation: new_rotation)
+    notify_upcoming_players(new_rotation)
 
     redirect_to new_rotation, notice: "#{new_rotation.round_number}周目のローテーションを作成しました。"
   end


### PR DESCRIPTION
## 概要
- ローテーションの`activate`時に、1試合目の出番通知（「出番です！」「あとX試合です」）が送信されていなかった問題を修正
- `copy_for_next_round`（2周目以降）で通知が一切送信されていなかった問題を修正

## 変更内容
- `activate`アクション: `notify_rotation_activated`の後に`notify_upcoming_players`を追加
- `copy_for_next_round`アクション: 新ローテーションのアクティブ化後に`notify_rotation_activated`と`notify_upcoming_players`を追加

## テスト計画
- [ ] `activate`を呼んだ際に、開始通知＋第1試合の出番通知＋第2〜3試合の予告通知が送信されること
- [ ] `copy_for_next_round`を呼んだ際に、同様の通知が送信されること
- [ ] 既存の`record_match`/`next_match`時の通知に影響がないこと

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)