### PR TITLE
fix: ローテーション定義ありイベントの期間別戦績がターム別になるバグを修正

### DIFF
--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -147,7 +147,8 @@ class RotationsController < ApplicationController
     # Create match record
     match = @rotation.event.matches.build(
       played_at: Time.current,
-      winning_team: params[:winning_team].to_i
+      winning_team: params[:winning_team].to_i,
+      rotation_match: rotation_match
     )
 
     # Build match players before saving

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -50,7 +50,7 @@ class StatisticsController < ApplicationController
     # ログインユーザーの試合を基準に開始
     @filtered_matches = MatchPlayer.where(user_id: viewing_as_user.id)
                                    .joins(:match)
-                                   .includes(:match, :mobile_suit, :user)
+                                   .includes(:match, :mobile_suit, :user, match: { rotation_match: :rotation })
 
     # イベントフィルター
     if @filter_events.any?
@@ -458,9 +458,9 @@ class StatisticsController < ApplicationController
       if match.rotation_match && match.rotation_match.rotation
         event_progression_data[event_id][:has_rotation] = true
         rotation_id = match.rotation_match.rotation_id
-        rotation_name = match.rotation_match.rotation.name
+        round_number = match.rotation_match.rotation.round_number
 
-        event_progression_data[event_id][:rotations][rotation_id][:rotation_name] = rotation_name
+        event_progression_data[event_id][:rotations][rotation_id][:rotation_name] = "#{round_number}周目"
         event_progression_data[event_id][:rotations][rotation_id][:total] += 1
         event_progression_data[event_id][:rotations][rotation_id][:wins] += 1 if match.winning_team == my_team
         event_progression_data[event_id][:rotations][rotation_id][:matches] << my_mp

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -740,7 +740,7 @@
                 <table class="min-w-full divide-y divide-gray-200">
                   <thead class="bg-gray-50">
                     <tr>
-                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><%= event_prog[:has_rotation] ? 'ローテーション' : 'ターム' %></th>
+                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><%= event_prog[:has_rotation] ? '周回' : 'ターム' %></th>
                       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">試合数</th>
                       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">勝利</th>
                       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">敗北</th>

--- a/lib/tasks/fix_rotation_match_links.rake
+++ b/lib/tasks/fix_rotation_match_links.rake
@@ -1,0 +1,17 @@
+namespace :maintenance do
+  desc "Fix matches missing rotation_match_id (one-shot task for Issue #57)"
+  task fix_rotation_match_links: :environment do
+    fixed = 0
+
+    RotationMatch.where.not(match_id: nil).find_each do |rm|
+      match = Match.find_by(id: rm.match_id)
+      next unless match
+      next unless match.rotation_match_id.nil?
+
+      match.update_column(:rotation_match_id, rm.id)
+      fixed += 1
+    end
+
+    puts "Fixed #{fixed} match(es) with missing rotation_match_id."
+  end
+end


### PR DESCRIPTION
## Summary
- 試合記録時に `matches.rotation_match_id` が設定されず、統計ページの期間別戦績が常にターム別表示になるバグを修正
- 統計ページのローテーション表示を「ローテーション名」から「N周目」に変更
- 既存データ修正用のRakeタスク（`rake maintenance:fix_rotation_match_links`）を追加

## 変更内容
- `rotations_controller.rb`: match作成時に `rotation_match` を設定して双方向リンクを確立
- `statistics_controller.rb`: eager loadingの追加（N+1防止）+ `round_number` ベースの表示に変更
- `statistics/index.html.erb`: テーブルヘッダーを「ローテーション」→「周回」に変更
- `lib/tasks/fix_rotation_match_links.rake`: 既存データ修正用ワンショットRakeタスク

## デプロイ後の作業
デプロイ後、以下のRakeタスクを **1回** 実行して既存データを修正する必要があります：
```
bin/rails maintenance:fix_rotation_match_links
```
※ 実行しないと既存の試合データで期間別戦績がターム別表示のままになります

## Test plan
- [x] Rakeタスクで既存データを修正済み（118件）
- [x] 戦績ページの「イベント内期間別戦績」タブでローテーション別表示になることを確認
- [x] 表・グラフのラベルが「N周目」表示になることを確認

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)