### PR TITLE
feat: 配信リンクの視認性を改善（バッジ型デザイン）

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -17,13 +17,8 @@
       <% @events.each do |event| %>
         <div class="bg-white shadow rounded-lg p-4">
           <div class="mb-2">
-            <div class="flex items-center gap-2 mb-1">
+            <div class="mb-1">
               <%= link_to event.name, event_path(event), class: "text-sm font-medium text-blue-600 hover:text-blue-800" %>
-              <% if event.broadcast_url.present? %>
-                <%= link_to event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity flex-shrink-0", title: "配信を見る" do %>
-                  <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-4">
-                <% end %>
-              <% end %>
             </div>
             <div class="flex items-center gap-2 text-xs text-gray-500">
               <span class="px-2 py-0.5 font-semibold rounded-full bg-blue-100 text-blue-800">
@@ -31,6 +26,14 @@
               </span>
               <span><%= event.matches.count %> 件の試合</span>
             </div>
+            <% if event.broadcast_url.present? %>
+              <div class="mt-2">
+                <%= link_to event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                  <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                  配信を見る
+                <% end %>
+              </div>
+            <% end %>
           </div>
           <% if event.description.present? %>
             <div class="text-xs text-gray-500 mb-2 line-clamp-2"><%= event.description %></div>
@@ -53,6 +56,9 @@
               イベント名
             </th>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              配信リンク
+            </th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               開催日
             </th>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -70,14 +76,17 @@
           <% @events.each do |event| %>
             <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='<%= event_path(event) %>'">
               <td class="px-6 py-4 whitespace-nowrap">
-                <div class="flex items-center gap-2">
-                  <span class="text-sm font-medium text-blue-600"><%= event.name %></span>
-                  <% if event.broadcast_url.present? %>
-                    <%= link_to event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "配信を見る", onclick: "event.stopPropagation()" do %>
-                      <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-5">
-                    <% end %>
+                <span class="text-sm font-medium text-blue-600"><%= event.name %></span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap" onclick="event.stopPropagation()">
+                <% if event.broadcast_url.present? %>
+                  <%= link_to event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                    <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                    配信を見る
                   <% end %>
-                </div>
+                <% else %>
+                  <span class="text-sm text-gray-400">-</span>
+                <% end %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -8,8 +8,9 @@
       <div class="flex items-center gap-3 mb-1">
         <h1 class="text-2xl font-bold text-gray-900"><%= @event.name %></h1>
         <% if @event.broadcast_url.present? %>
-          <%= link_to @event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity flex-shrink-0", title: "配信を見る" do %>
-            <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-6 sm:h-7">
+          <%= link_to @event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-3 py-1 rounded-full bg-red-50 text-red-700 text-sm font-semibold hover:bg-red-100 transition-colors flex-shrink-0" do %>
+            <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-4">
+            配信を見る
           <% end %>
         <% end %>
       </div>
@@ -47,6 +48,14 @@
             <% @matches.first(10).each do |match| %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
+                  <% if match.video_url %>
+                    <div class="mb-2" onclick="event.stopPropagation()">
+                      <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                        <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                        配信を見る
+                      <% end %>
+                    </div>
+                  <% end %>
                   <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
                     <% team1_players = match.match_players.where(team_number: 1).order(:position) %>
                     <% team2_players = match.match_players.where(team_number: 2).order(:position) %>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -96,14 +96,15 @@
                 <%= link_to match_path(match), class: "text-sm text-gray-500 hover:text-blue-600" do %>
                   <%= match.played_at.strftime('%Y年%m月%d日') %>
                 <% end %>
-                <% if match.video_url %>
-                  <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "アーカイブを見る" do %>
-                    <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-5">
-                  <% end %>
-                <% end %>
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
                   <%= match.event.name %>
                 </span>
+                <% if match.video_url %>
+                  <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                    <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                    配信を見る
+                  <% end %>
+                <% end %>
               </div>
             </div>
 

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -15,8 +15,9 @@
               <%= @match.played_at.strftime('%Y年%m月%d日') %>
             </p>
             <% if @match.video_url %>
-              <%= link_to @match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "アーカイブを見る" do %>
-                <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-6 sm:h-7">
+              <%= link_to @match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-3 py-1 rounded-full bg-red-50 text-red-700 text-sm font-semibold hover:bg-red-100 transition-colors" do %>
+                <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-4">
+                配信を見る
               <% end %>
             <% end %>
           </div>


### PR DESCRIPTION
## Summary
- イベント一覧に「配信リンク」列を新設し、アイコン＋テキストのバッジ型リンクを表示
- イベント詳細ヘッダー・対戦記録行にも同じバッジ型リンクを追加
- 対戦履歴一覧・対戦詳細のYouTubeリンクも同じバッジスタイルに統一
- 配信URLがないイベントではテーブルに「-」、カード・詳細では非表示

## Test plan
- [ ] `/events` でデスクトップ幅：「配信リンク」列にバッジが表示されることを確認
- [ ] `/events` でモバイル幅：カード内に配信バッジが表示されることを確認
- [ ] 配信URLがないイベントではテーブルに「-」、カードでは非表示であることを確認
- [ ] イベント詳細ヘッダーに配信バッジが表示されることを確認
- [ ] イベント詳細の対戦記録各行に配信バッジが表示されることを確認
- [ ] 対戦履歴一覧で日時→イベント名→配信バッジの順に表示されることを確認
- [ ] 対戦詳細に配信バッジが表示されることを確認
- [ ] 各バッジクリックで新しいタブでYouTubeが開くことを確認
- [ ] テーブル行クリック時にイベント詳細に遷移し、配信バッジは独立動作することを確認

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)