### PR TITLE
refactor: ローテーション名カラムの廃止とround_numberベースの表示への統一

### DIFF
--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -268,7 +268,6 @@ class RotationsController < ApplicationController
     @rotation = Rotation.find(params[:id])
 
     new_rotation = @rotation.event.rotations.create!(
-      name: @rotation.name,
       round_number: @rotation.round_number + 1,
       base_rotation_id: @rotation.id
     )
@@ -308,7 +307,7 @@ class RotationsController < ApplicationController
   end
 
   def rotation_params
-    params.require(:rotation).permit(:name, :round_number)
+    params.require(:rotation).permit(:round_number)
   end
 
   # Find the next unrecorded match starting from current position

--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -6,9 +6,12 @@ class Rotation < ApplicationRecord
   has_many :rotation_matches, dependent: :destroy
 
   # Validations
-  validates :name, presence: true
   validates :round_number, presence: true, numericality: { greater_than: 0 }
   validates :current_match_index, presence: true, numericality: { greater_than_or_equal_to: 0 }
+
+  def display_name
+    "#{round_number}周目"
+  end
 
   # Get all unique players in this rotation
   def players

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -39,7 +39,7 @@ class PushNotificationService
         SendPushNotificationJob.perform_later(
           user_id: user.id,
           title: "ローテーションが開始されました",
-          body: "#{rotation.name}が開始されました",
+          body: "#{rotation.display_name}が開始されました",
           path: "/dashboard"
         )
       end

--- a/app/views/dashboard/admin_dashboard.html.erb
+++ b/app/views/dashboard/admin_dashboard.html.erb
@@ -35,7 +35,7 @@
             <!-- アクティブなローテーション -->
             <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm">
               <div class="text-sm font-semibold mb-2 text-purple-700">🔴 アクティブなローテーション</div>
-              <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.name %></div>
+              <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.display_name %></div>
               <div class="text-sm mt-1 text-gray-600">
                 進捗: <%= @active_rotation.current_match_index + 1 %> / <%= @rotation_matches.count %> 試合
               </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -64,7 +64,7 @@
           <!-- アクティブなローテーション -->
           <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm">
             <div class="text-sm font-semibold mb-2 text-purple-700">🔴 アクティブなローテーション</div>
-            <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.name %></div>
+            <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.display_name %></div>
             <div class="text-sm mt-1 text-gray-600">
               進捗: <%= @rotation_current_match_index + 1 %> / <%= @rotation_total_matches %> 試合
             </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -132,7 +132,7 @@
                 <li class="px-4 py-3">
                   <div class="flex items-center justify-between">
                     <div>
-                      <p class="text-sm font-medium text-gray-900"><%= rotation.name %></p>
+                      <p class="text-sm font-medium text-gray-900"><%= rotation.display_name %></p>
                       <div class="mt-1 flex items-center space-x-2">
                         <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
                           <%= rotation.round_number %>周目

--- a/app/views/rotations/index.html.erb
+++ b/app/views/rotations/index.html.erb
@@ -12,7 +12,7 @@
         <% progress = rotation.rotation_matches.count > 0 ? (completed_count.to_f / rotation.rotation_matches.count * 100) : 0 %>
         <%= link_to rotation_path(rotation), class: "block bg-white shadow rounded-lg p-4 hover:bg-gray-50" do %>
           <div class="flex items-center justify-between mb-2">
-            <div class="text-sm font-medium text-blue-600"><%= rotation.name %></div>
+            <div class="text-sm font-medium text-blue-600"><%= rotation.display_name %></div>
             <% if rotation.is_active %>
               <span class="px-2 py-0.5 text-xs font-semibold rounded-full bg-purple-100 text-purple-800">アクティブ</span>
             <% else %>
@@ -38,9 +38,6 @@
         <thead class="bg-gray-50">
           <tr>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              ローテーション名
-            </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               イベント
             </th>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -63,11 +60,6 @@
         <tbody class="bg-white divide-y divide-gray-200">
           <% @rotations.each do |rotation| %>
             <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='<%= rotation_path(rotation) %>'">
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm font-medium text-blue-600">
-                  <%= rotation.name %>
-                </div>
-              </td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <div class="text-sm text-gray-900">
                   <%= rotation.event.name %>

--- a/app/views/rotations/new.html.erb
+++ b/app/views/rotations/new.html.erb
@@ -18,12 +18,6 @@
       <% end %>
 
       <div class="space-y-6">
-        <!-- Rotation Name -->
-        <div>
-          <%= f.label :name, "ローテーション名", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.text_field :name, value: @event.name, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 第1回大会 1周目" %>
-        </div>
-
         <!-- Round Number -->
         <div>
           <%= f.label :round_number, "周回数", class: "block text-sm font-medium text-gray-700 mb-2" %>

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -10,7 +10,7 @@
         </div>
         <h3 class="text-lg font-bold text-gray-900 text-center mb-2">全試合完了しました！</h3>
         <p class="text-sm text-gray-600 text-center mb-6">
-          <%= @rotation.name %>の全試合が記録されました。<br>
+          <%= @rotation.display_name %>の全試合が記録されました。<br>
           同じローテーション設定で<%= @rotation.round_number + 1 %>周目を作成しますか？
         </p>
         <div class="flex flex-col space-y-3">
@@ -63,7 +63,7 @@
   <div class="mb-6">
     <div class="flex justify-between items-start">
       <div>
-        <h1 class="text-3xl font-bold text-gray-900"><%= @rotation.name %></h1>
+        <h1 class="text-3xl font-bold text-gray-900"><%= @rotation.display_name %></h1>
         <p class="mt-2 text-sm text-gray-600">
           イベント: <%= link_to @rotation.event.name, @rotation.event, class: "text-blue-600 hover:text-blue-800" %>
           (<%= @rotation.event.held_on.strftime('%Y/%m/%d') %>)
@@ -104,7 +104,7 @@
                   </svg>
                   周回をコピー
                 <% end %>
-                <%= button_to rotation_path(@rotation), method: :delete, data: { turbo_confirm: "ローテーション「#{@rotation.name}」を削除してもよろしいですか？関連する試合データは削除されません。" }, class: "w-full text-left px-4 py-2 text-sm text-red-700 hover:bg-gray-100 flex items-center" do %>
+                <%= button_to rotation_path(@rotation), method: :delete, data: { turbo_confirm: "ローテーション「#{@rotation.display_name}」を削除してもよろしいですか？関連する試合データは削除されません。" }, class: "w-full text-left px-4 py-2 text-sm text-red-700 hover:bg-gray-100 flex items-center" do %>
                   <svg class="mr-3 h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
                   </svg>

--- a/db/migrate/20260215232735_remove_name_from_rotations.rb
+++ b/db/migrate/20260215232735_remove_name_from_rotations.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromRotations < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :rotations, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_15_124012) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_15_232735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -122,7 +122,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_15_124012) do
     t.integer "current_match_index", default: 0, null: false
     t.bigint "event_id", null: false
     t.boolean "is_active", default: false, null: false
-    t.string "name", null: false
     t.integer "round_number", default: 1, null: false
     t.datetime "updated_at", null: false
     t.index ["base_rotation_id"], name: "index_rotations_on_base_rotation_id"


### PR DESCRIPTION
## Summary
- `rotations.name` カラムを廃止し、`round_number` から自動生成する `display_name` メソッド（「N周目」形式）に統一
- ビュー・コントローラ・プッシュ通知の全箇所を `display_name` に置換
- ローテーション作成フォームからname入力欄を削除
- ローテーション一覧テーブルから「ローテーション名」列を削除

## Test plan
- [ ] `rails db:migrate` が正常に完了すること
- [ ] ローテーション一覧・詳細・ダッシュボードで「N周目」表示になること
- [ ] 新規ローテーション作成時にname入力欄がないこと
- [ ] 次周回作成（copy_for_next_round）が正常に動作すること
- [ ] プッシュ通知のメッセージが正しく表示されること

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)