### PR TITLE
feat: イベント詳細画面のUI/UX改善と試合開始時刻の記録

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,8 +8,8 @@ class EventsController < ApplicationController
   end
 
   def show
-    @matches = @event.matches.includes(:event, match_players: [:user, :mobile_suit]).order(played_at: :desc)
-    @rotations = @event.rotations.order(created_at: :desc)
+    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc)
+    @rotations = @event.rotations.order(created_at: :asc)
   end
 
   def new

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -36,7 +36,57 @@
     <% end %>
   </div>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <div class="space-y-6">
+    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+      <div class="px-4 py-5 sm:px-6">
+        <h2 class="text-lg font-medium text-gray-900">ローテーション</h2>
+        <p class="mt-1 text-sm text-gray-500">全 <%= @rotations.count %> 個</p>
+      </div>
+      <div class="border-t border-gray-200">
+        <% if @rotations.any? %>
+          <ul class="divide-y divide-gray-200">
+            <% @rotations.each do |rotation| %>
+              <%= link_to rotation_path(rotation), class: "block hover:bg-gray-50" do %>
+                <li class="px-4 py-3">
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <p class="text-sm font-medium text-gray-900"><%= rotation.display_name %></p>
+                      <div class="mt-1 flex items-center space-x-2">
+                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
+                          <%= rotation.round_number %>周目
+                        </span>
+                        <% if rotation.is_active %>
+                          <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
+                            アクティブ
+                          </span>
+                        <% end %>
+                      </div>
+                    </div>
+                    <div class="text-right">
+                      <p class="text-xs text-gray-500">
+                        <%= rotation.current_match_index + 1 %> / <%= rotation.rotation_matches.count %> 試合
+                      </p>
+                      <div class="w-24 bg-gray-200 rounded-full h-1.5 mt-1">
+                        <% progress = rotation.rotation_matches.count > 0 ? ((rotation.current_match_index + 1).to_f / rotation.rotation_matches.count * 100) : 0 %>
+                        <div class="bg-blue-600 h-1.5 rounded-full" style="width: <%= progress %>%"></div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              <% end %>
+            <% end %>
+          </ul>
+        <% else %>
+          <div class="px-4 py-3 text-center">
+            <p class="text-sm text-gray-500">まだローテーションがありません</p>
+            <% if current_user.is_admin? %>
+              <%= link_to "ローテーションを作成", new_event_rotation_path(@event), class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-500" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
     <div class="bg-white shadow overflow-hidden sm:rounded-lg">
       <div class="px-4 py-5 sm:px-6">
         <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
@@ -45,9 +95,17 @@
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
           <ul class="divide-y divide-gray-200">
-            <% @matches.first(10).each do |match| %>
+            <% @matches.each_with_index do |match, index| %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
+                  <div class="flex items-center gap-2 mb-2">
+                    <span class="text-sm font-semibold text-gray-900">第<%= index + 1 %>試合</span>
+                    <% if match.rotation_match&.started_at %>
+                      <span class="text-xs text-gray-500"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
+                    <% elsif match.played_at %>
+                      <span class="text-xs text-gray-500"><%= match.played_at.strftime('%H:%M') %> 終了</span>
+                    <% end %>
+                  </div>
                   <% if match.video_url %>
                     <div class="mb-2" onclick="event.stopPropagation()">
                       <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
@@ -106,64 +164,9 @@
               <% end %>
             <% end %>
           </ul>
-          <% if @matches.count > 10 %>
-            <div class="px-4 py-3 bg-gray-50 text-center">
-              <%= link_to "全 #{@matches.count} 試合を表示", matches_path(event_id: @event.id), class: "text-sm text-blue-600 hover:text-blue-500" %>
-            </div>
-          <% end %>
         <% else %>
           <div class="px-4 py-3 text-center">
             <p class="text-sm text-gray-500">まだ対戦記録がありません</p>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
-      <div class="px-4 py-5 sm:px-6">
-        <h2 class="text-lg font-medium text-gray-900">ローテーション</h2>
-        <p class="mt-1 text-sm text-gray-500">全 <%= @rotations.count %> 個</p>
-      </div>
-      <div class="border-t border-gray-200">
-        <% if @rotations.any? %>
-          <ul class="divide-y divide-gray-200">
-            <% @rotations.each do |rotation| %>
-              <%= link_to rotation_path(rotation), class: "block hover:bg-gray-50" do %>
-                <li class="px-4 py-3">
-                  <div class="flex items-center justify-between">
-                    <div>
-                      <p class="text-sm font-medium text-gray-900"><%= rotation.display_name %></p>
-                      <div class="mt-1 flex items-center space-x-2">
-                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
-                          <%= rotation.round_number %>周目
-                        </span>
-                        <% if rotation.is_active %>
-                          <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
-                            アクティブ
-                          </span>
-                        <% end %>
-                      </div>
-                    </div>
-                    <div class="text-right">
-                      <p class="text-xs text-gray-500">
-                        <%= rotation.current_match_index + 1 %> / <%= rotation.rotation_matches.count %> 試合
-                      </p>
-                      <div class="w-24 bg-gray-200 rounded-full h-1.5 mt-1">
-                        <% progress = rotation.rotation_matches.count > 0 ? ((rotation.current_match_index + 1).to_f / rotation.rotation_matches.count * 100) : 0 %>
-                        <div class="bg-blue-600 h-1.5 rounded-full" style="width: <%= progress %>%"></div>
-                      </div>
-                    </div>
-                  </div>
-                </li>
-              <% end %>
-            <% end %>
-          </ul>
-        <% else %>
-          <div class="px-4 py-3 text-center">
-            <p class="text-sm text-gray-500">まだローテーションがありません</p>
-            <% if current_user.is_admin? %>
-              <%= link_to "ローテーションを作成", new_event_rotation_path(@event), class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-500" %>
-            <% end %>
           </div>
         <% end %>
       </div>

--- a/db/migrate/20260215234121_add_started_at_to_rotation_matches.rb
+++ b/db/migrate/20260215234121_add_started_at_to_rotation_matches.rb
@@ -1,0 +1,5 @@
+class AddStartedAtToRotationMatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :rotation_matches, :started_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_15_232735) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_15_234121) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -106,6 +106,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_15_232735) do
     t.bigint "match_id"
     t.integer "match_index", null: false
     t.bigint "rotation_id", null: false
+    t.datetime "started_at"
     t.bigint "team1_player1_id", null: false
     t.bigint "team1_player2_id", null: false
     t.bigint "team2_player1_id", null: false


### PR DESCRIPTION
## Summary
- イベント詳細画面のレイアウトを2カラム横並びから1カラム縦並びに変更（ローテーション→対戦記録の順）
- 対戦記録を全件表示・古い順ソートに変更し、試合番号と開始/終了時刻を表示
- ローテーションも古い順ソートに変更
- `rotation_matches`テーブルに`started_at`カラムを追加し、ローテーションで試合が「現在の試合」になった時刻を自動記録

## Test plan
- [ ] イベント詳細画面でローテーションが上・対戦記録が下の1カラムレイアウトになっていること
- [ ] ローテーション・対戦記録が古い順にソートされていること
- [ ] 対戦記録が全件表示され、各試合に「第N試合」と時刻が表示されること
- [ ] ローテーションのactivate/next_match/go_to_match/record_match操作で`started_at`が記録されること
- [ ] `started_at`がある場合は「HH:MM 開始」、ない場合は`played_at`で「HH:MM 終了」と表示されること

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)