### PR TITLE
chore: v1.2.0 リリース

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,8 +8,8 @@ class EventsController < ApplicationController
   end
 
   def show
-    @matches = @event.matches.includes(:event, match_players: [:user, :mobile_suit]).order(played_at: :desc)
-    @rotations = @event.rotations.order(created_at: :desc)
+    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc)
+    @rotations = @event.rotations.order(created_at: :asc)
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
   before_action :authenticate_user!
-  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy]
-  before_action :set_event, only: [:show, :edit, :update, :destroy]
+  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps]
+  before_action :set_event, only: [:show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps]
 
   def index
     @events = Event.includes(:matches).order(held_on: :desc)
@@ -37,6 +37,53 @@ class EventsController < ApplicationController
     end
   end
 
+  def edit_timestamps
+    @matches = @event.matches.includes(match_players: [:user, :mobile_suit]).order(:played_at, :id)
+    existing = @matches.map { |m| format_timestamp(m.video_timestamp) }
+    @timestamps_text = existing.any?(&:present?) ? existing.join("\n") : ''
+  end
+
+  def update_timestamps
+    @matches = @event.matches.includes(match_players: [:user, :mobile_suit]).order(:played_at, :id)
+    raw_text = params[:timestamps].to_s
+    lines = raw_text.split("\n").map(&:strip)
+
+    # 末尾の空行を除去
+    lines.pop while lines.last&.empty?
+
+    if lines.size != @matches.size
+      flash.now[:alert] = "行数（#{lines.size}）と試合数（#{@matches.size}）が一致しません。"
+      @timestamps_text = raw_text
+      render :edit_timestamps, status: :unprocessable_entity
+      return
+    end
+
+    timestamps = lines.map.with_index do |line, i|
+      if line.blank?
+        flash.now[:alert] = "#{i + 1}行目が空です。すべての行にタイムスタンプを入力してください。"
+        @timestamps_text = raw_text
+        render :edit_timestamps, status: :unprocessable_entity
+        return
+      end
+      seconds = parse_timestamp(line)
+      if seconds.nil?
+        flash.now[:alert] = "#{i + 1}行目「#{line}」の形式が不正です。H:MM:SS または MM:SS の形式で入力してください。"
+        @timestamps_text = raw_text
+        render :edit_timestamps, status: :unprocessable_entity
+        return
+      end
+      seconds
+    end
+
+    ActiveRecord::Base.transaction do
+      @matches.each_with_index do |match, i|
+        match.update!(video_timestamp: timestamps[i])
+      end
+    end
+
+    redirect_to event_path(@event), notice: "タイムスタンプを保存しました。"
+  end
+
   def destroy
     name = @event.name
 
@@ -62,5 +109,22 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(:name, :held_on, :description, :broadcast_url)
+  end
+
+  def parse_timestamp(str)
+    return nil if str.blank?
+    parts = str.strip.split(':').map(&:to_i)
+    case parts.size
+    when 3 then parts[0] * 3600 + parts[1] * 60 + parts[2]
+    when 2 then parts[0] * 60 + parts[1]
+    else nil
+    end
+  end
+
+  def format_timestamp(seconds)
+    return '' if seconds.nil?
+    h, remainder = seconds.divmod(3600)
+    m, s = remainder.divmod(60)
+    "#{h}:#{format('%02d', m)}:#{format('%02d', s)}"
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -159,7 +159,7 @@ class MatchesController < ApplicationController
   end
 
   def match_params
-    params.require(:match).permit(:winning_team, :played_at, match_players_attributes: [:id, :user_id, :mobile_suit_id, :team_number, :position])
+    params.require(:match).permit(:winning_team, :played_at, :video_timestamp_text, match_players_attributes: [:id, :user_id, :mobile_suit_id, :team_number, :position])
   end
 
   # Find the next unrecorded match starting from current position

--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -147,7 +147,8 @@ class RotationsController < ApplicationController
     # Create match record
     match = @rotation.event.matches.build(
       played_at: Time.current,
-      winning_team: params[:winning_team].to_i
+      winning_team: params[:winning_team].to_i,
+      rotation_match: rotation_match
     )
 
     # Build match players before saving

--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -268,7 +268,6 @@ class RotationsController < ApplicationController
     @rotation = Rotation.find(params[:id])
 
     new_rotation = @rotation.event.rotations.create!(
-      name: @rotation.name,
       round_number: @rotation.round_number + 1,
       base_rotation_id: @rotation.id
     )
@@ -308,7 +307,7 @@ class RotationsController < ApplicationController
   end
 
   def rotation_params
-    params.require(:rotation).permit(:name, :round_number)
+    params.require(:rotation).permit(:round_number)
   end
 
   # Find the next unrecorded match starting from current position

--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -81,6 +81,9 @@ class RotationsController < ApplicationController
     # Send push notifications to all players
     PushNotificationService.notify_rotation_activated(rotation: @rotation)
 
+    # Send upcoming match notifications (1試合目の出番通知含む)
+    notify_upcoming_players(@rotation)
+
     redirect_to @rotation, notice: 'ローテーションをアクティブにしました。'
   end
 
@@ -285,6 +288,10 @@ class RotationsController < ApplicationController
 
     # Activate the new rotation
     new_rotation.update!(is_active: true)
+
+    # Send push notifications for new round
+    PushNotificationService.notify_rotation_activated(rotation: new_rotation)
+    notify_upcoming_players(new_rotation)
 
     redirect_to new_rotation, notice: "#{new_rotation.round_number}周目のローテーションを作成しました。"
   end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -50,7 +50,7 @@ class StatisticsController < ApplicationController
     # ログインユーザーの試合を基準に開始
     @filtered_matches = MatchPlayer.where(user_id: viewing_as_user.id)
                                    .joins(:match)
-                                   .includes(:match, :mobile_suit, :user)
+                                   .includes(:match, :mobile_suit, :user, match: { rotation_match: :rotation })
 
     # イベントフィルター
     if @filter_events.any?
@@ -458,9 +458,9 @@ class StatisticsController < ApplicationController
       if match.rotation_match && match.rotation_match.rotation
         event_progression_data[event_id][:has_rotation] = true
         rotation_id = match.rotation_match.rotation_id
-        rotation_name = match.rotation_match.rotation.name
+        round_number = match.rotation_match.rotation.round_number
 
-        event_progression_data[event_id][:rotations][rotation_id][:rotation_name] = rotation_name
+        event_progression_data[event_id][:rotations][rotation_id][:rotation_name] = "#{round_number}周目"
         event_progression_data[event_id][:rotations][rotation_id][:total] += 1
         event_progression_data[event_id][:rotations][rotation_id][:wins] += 1 if match.winning_team == my_team
         event_progression_data[event_id][:rotations][rotation_id][:matches] << my_mp

--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -6,9 +6,12 @@ class Rotation < ApplicationRecord
   has_many :rotation_matches, dependent: :destroy
 
   # Validations
-  validates :name, presence: true
   validates :round_number, presence: true, numericality: { greater_than: 0 }
   validates :current_match_index, presence: true, numericality: { greater_than_or_equal_to: 0 }
+
+  def display_name
+    "#{round_number}周目"
+  end
 
   # Get all unique players in this rotation
   def players

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -39,7 +39,7 @@ class PushNotificationService
         SendPushNotificationJob.perform_later(
           user_id: user.id,
           title: "ローテーションが開始されました",
-          body: "#{rotation.name}が開始されました",
+          body: "#{rotation.display_name}が開始されました",
           path: "/dashboard"
         )
       end

--- a/app/views/dashboard/admin_dashboard.html.erb
+++ b/app/views/dashboard/admin_dashboard.html.erb
@@ -35,7 +35,7 @@
             <!-- アクティブなローテーション -->
             <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm">
               <div class="text-sm font-semibold mb-2 text-purple-700">🔴 アクティブなローテーション</div>
-              <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.name %></div>
+              <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.display_name %></div>
               <div class="text-sm mt-1 text-gray-600">
                 進捗: <%= @active_rotation.current_match_index + 1 %> / <%= @rotation_matches.count %> 試合
               </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -64,7 +64,7 @@
           <!-- アクティブなローテーション -->
           <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm">
             <div class="text-sm font-semibold mb-2 text-purple-700">🔴 アクティブなローテーション</div>
-            <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.name %></div>
+            <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.display_name %></div>
             <div class="text-sm mt-1 text-gray-600">
               進捗: <%= @rotation_current_match_index + 1 %> / <%= @rotation_total_matches %> 試合
             </div>

--- a/app/views/events/edit_timestamps.html.erb
+++ b/app/views/events/edit_timestamps.html.erb
@@ -1,0 +1,62 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="mb-6">
+    <%= link_to "← イベントに戻る", event_path(@event), class: "text-blue-600 hover:text-blue-500" %>
+  </div>
+
+  <h1 class="text-2xl font-bold text-gray-900 mb-2"><%= @event.name %></h1>
+  <h2 class="text-lg font-medium text-gray-700 mb-6">タイムスタンプ一括設定</h2>
+
+  <% if flash[:alert] %>
+    <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
+      <p class="text-sm text-red-700"><%= flash[:alert] %></p>
+    </div>
+  <% end %>
+
+  <%= form_with url: update_timestamps_event_path(@event), method: :patch, local: true do |f| %>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <!-- 左カラム: テキストエリア -->
+      <div class="bg-white shadow sm:rounded-lg p-6">
+        <label for="timestamps" class="block text-sm font-medium text-gray-700 mb-2">
+          タイムスタンプ（1行1試合）
+        </label>
+        <textarea
+          name="timestamps"
+          id="timestamps"
+          class="w-full h-[60vh] font-mono text-sm pl-3 border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 resize-none"
+          placeholder="0:03:20&#10;0:07:45&#10;0:12:10"
+        ><%= @timestamps_text %></textarea>
+        <p class="mt-2 text-sm text-gray-500">
+          配信開始からの経過時間を1行1試合で入力してください（例: 0:03:20）
+        </p>
+      </div>
+
+      <!-- 右カラム: 試合一覧 -->
+      <div class="bg-white shadow sm:rounded-lg p-6">
+        <h3 class="text-sm font-medium text-gray-700 mb-3">試合一覧（<%= @matches.size %>試合）</h3>
+        <div class="space-y-2 text-sm h-[60vh] overflow-y-auto">
+          <% @matches.each_with_index do |match, i| %>
+            <div class="flex items-start gap-2 py-1 <%= i.even? ? 'bg-gray-50' : '' %> px-2 rounded">
+              <span class="text-gray-400 font-mono w-6 flex-shrink-0 text-right"><%= i + 1 %>.</span>
+              <div class="flex-1 min-w-0">
+                <% team1 = match.match_players.select { |p| p.team_number == 1 }.sort_by(&:position) %>
+                <% team2 = match.match_players.select { |p| p.team_number == 2 }.sort_by(&:position) %>
+                <span class="<%= match.winning_team == 1 ? 'font-bold' : '' %>">
+                  <%= team1.map { |p| p.user.nickname }.join(' & ') %>
+                </span>
+                <span class="text-gray-400 mx-1">vs</span>
+                <span class="<%= match.winning_team == 2 ? 'font-bold' : '' %>">
+                  <%= team2.map { |p| p.user.nickname }.join(' & ') %>
+                </span>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-6 flex gap-3">
+      <%= f.submit "保存", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-6 rounded cursor-pointer" %>
+      <%= link_to "キャンセル", event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-6 rounded" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -17,13 +17,8 @@
       <% @events.each do |event| %>
         <div class="bg-white shadow rounded-lg p-4">
           <div class="mb-2">
-            <div class="flex items-center gap-2 mb-1">
+            <div class="mb-1">
               <%= link_to event.name, event_path(event), class: "text-sm font-medium text-blue-600 hover:text-blue-800" %>
-              <% if event.broadcast_url.present? %>
-                <%= link_to event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity flex-shrink-0", title: "配信を見る" do %>
-                  <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-4">
-                <% end %>
-              <% end %>
             </div>
             <div class="flex items-center gap-2 text-xs text-gray-500">
               <span class="px-2 py-0.5 font-semibold rounded-full bg-blue-100 text-blue-800">
@@ -31,6 +26,14 @@
               </span>
               <span><%= event.matches.count %> 件の試合</span>
             </div>
+            <% if event.broadcast_url.present? %>
+              <div class="mt-2">
+                <%= link_to event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                  <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                  配信を見る
+                <% end %>
+              </div>
+            <% end %>
           </div>
           <% if event.description.present? %>
             <div class="text-xs text-gray-500 mb-2 line-clamp-2"><%= event.description %></div>
@@ -53,6 +56,9 @@
               イベント名
             </th>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              配信リンク
+            </th>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               開催日
             </th>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -70,14 +76,17 @@
           <% @events.each do |event| %>
             <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='<%= event_path(event) %>'">
               <td class="px-6 py-4 whitespace-nowrap">
-                <div class="flex items-center gap-2">
-                  <span class="text-sm font-medium text-blue-600"><%= event.name %></span>
-                  <% if event.broadcast_url.present? %>
-                    <%= link_to event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "配信を見る", onclick: "event.stopPropagation()" do %>
-                      <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-5">
-                    <% end %>
+                <span class="text-sm font-medium text-blue-600"><%= event.name %></span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap" onclick="event.stopPropagation()">
+                <% if event.broadcast_url.present? %>
+                  <%= link_to event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                    <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                    配信を見る
                   <% end %>
-                </div>
+                <% else %>
+                  <span class="text-sm text-gray-400">-</span>
+                <% end %>
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -132,7 +132,7 @@
                 <li class="px-4 py-3">
                   <div class="flex items-center justify-between">
                     <div>
-                      <p class="text-sm font-medium text-gray-900"><%= rotation.name %></p>
+                      <p class="text-sm font-medium text-gray-900"><%= rotation.display_name %></p>
                       <div class="mt-1 flex items-center space-x-2">
                         <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
                           <%= rotation.round_number %>周目

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -8,8 +8,9 @@
       <div class="flex items-center gap-3 mb-1">
         <h1 class="text-2xl font-bold text-gray-900"><%= @event.name %></h1>
         <% if @event.broadcast_url.present? %>
-          <%= link_to @event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity flex-shrink-0", title: "配信を見る" do %>
-            <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-6 sm:h-7">
+          <%= link_to @event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-3 py-1 rounded-full bg-red-50 text-red-700 text-sm font-semibold hover:bg-red-100 transition-colors flex-shrink-0" do %>
+            <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-4">
+            配信を見る
           <% end %>
         <% end %>
       </div>
@@ -47,6 +48,14 @@
             <% @matches.first(10).each do |match| %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
+                  <% if match.video_url %>
+                    <div class="mb-2" onclick="event.stopPropagation()">
+                      <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                        <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                        配信を見る
+                      <% end %>
+                    </div>
+                  <% end %>
                   <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
                     <% team1_players = match.match_players.where(team_number: 1).order(:position) %>
                     <% team2_players = match.match_players.where(team_number: 2).order(:position) %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,6 +20,9 @@
         <div class="flex flex-wrap gap-2 mt-4">
           <%= link_to "試合を登録", new_event_match_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= link_to "ローテーション作成", new_event_rotation_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+          <% if @event.broadcast_url.present? %>
+            <%= link_to "タイムスタンプ一括設定", edit_timestamps_event_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+          <% end %>
           <%= link_to "編集", edit_event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= button_to "削除", event_path(@event), method: :delete, data: { turbo_confirm: "イベント「#{@event.name}」を削除してもよろしいですか？関連する試合やローテーションもすべて削除されます。" }, class: "bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
         </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -36,7 +36,57 @@
     <% end %>
   </div>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+  <div class="space-y-6">
+    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+      <div class="px-4 py-5 sm:px-6">
+        <h2 class="text-lg font-medium text-gray-900">ローテーション</h2>
+        <p class="mt-1 text-sm text-gray-500">全 <%= @rotations.count %> 個</p>
+      </div>
+      <div class="border-t border-gray-200">
+        <% if @rotations.any? %>
+          <ul class="divide-y divide-gray-200">
+            <% @rotations.each do |rotation| %>
+              <%= link_to rotation_path(rotation), class: "block hover:bg-gray-50" do %>
+                <li class="px-4 py-3">
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <p class="text-sm font-medium text-gray-900"><%= rotation.display_name %></p>
+                      <div class="mt-1 flex items-center space-x-2">
+                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
+                          <%= rotation.round_number %>周目
+                        </span>
+                        <% if rotation.is_active %>
+                          <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
+                            アクティブ
+                          </span>
+                        <% end %>
+                      </div>
+                    </div>
+                    <div class="text-right">
+                      <p class="text-xs text-gray-500">
+                        <%= rotation.current_match_index + 1 %> / <%= rotation.rotation_matches.count %> 試合
+                      </p>
+                      <div class="w-24 bg-gray-200 rounded-full h-1.5 mt-1">
+                        <% progress = rotation.rotation_matches.count > 0 ? ((rotation.current_match_index + 1).to_f / rotation.rotation_matches.count * 100) : 0 %>
+                        <div class="bg-blue-600 h-1.5 rounded-full" style="width: <%= progress %>%"></div>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              <% end %>
+            <% end %>
+          </ul>
+        <% else %>
+          <div class="px-4 py-3 text-center">
+            <p class="text-sm text-gray-500">まだローテーションがありません</p>
+            <% if current_user.is_admin? %>
+              <%= link_to "ローテーションを作成", new_event_rotation_path(@event), class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-500" %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
     <div class="bg-white shadow overflow-hidden sm:rounded-lg">
       <div class="px-4 py-5 sm:px-6">
         <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
@@ -45,9 +95,17 @@
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
           <ul class="divide-y divide-gray-200">
-            <% @matches.first(10).each do |match| %>
+            <% @matches.each_with_index do |match, index| %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
+                  <div class="flex items-center gap-2 mb-2">
+                    <span class="text-sm font-semibold text-gray-900">第<%= index + 1 %>試合</span>
+                    <% if match.rotation_match&.started_at %>
+                      <span class="text-xs text-gray-500"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
+                    <% elsif match.played_at %>
+                      <span class="text-xs text-gray-500"><%= match.played_at.strftime('%H:%M') %> 終了</span>
+                    <% end %>
+                  </div>
                   <% if match.video_url %>
                     <div class="mb-2" onclick="event.stopPropagation()">
                       <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
@@ -106,64 +164,9 @@
               <% end %>
             <% end %>
           </ul>
-          <% if @matches.count > 10 %>
-            <div class="px-4 py-3 bg-gray-50 text-center">
-              <%= link_to "全 #{@matches.count} 試合を表示", matches_path(event_id: @event.id), class: "text-sm text-blue-600 hover:text-blue-500" %>
-            </div>
-          <% end %>
         <% else %>
           <div class="px-4 py-3 text-center">
             <p class="text-sm text-gray-500">まだ対戦記録がありません</p>
-          </div>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
-      <div class="px-4 py-5 sm:px-6">
-        <h2 class="text-lg font-medium text-gray-900">ローテーション</h2>
-        <p class="mt-1 text-sm text-gray-500">全 <%= @rotations.count %> 個</p>
-      </div>
-      <div class="border-t border-gray-200">
-        <% if @rotations.any? %>
-          <ul class="divide-y divide-gray-200">
-            <% @rotations.each do |rotation| %>
-              <%= link_to rotation_path(rotation), class: "block hover:bg-gray-50" do %>
-                <li class="px-4 py-3">
-                  <div class="flex items-center justify-between">
-                    <div>
-                      <p class="text-sm font-medium text-gray-900"><%= rotation.display_name %></p>
-                      <div class="mt-1 flex items-center space-x-2">
-                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
-                          <%= rotation.round_number %>周目
-                        </span>
-                        <% if rotation.is_active %>
-                          <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
-                            アクティブ
-                          </span>
-                        <% end %>
-                      </div>
-                    </div>
-                    <div class="text-right">
-                      <p class="text-xs text-gray-500">
-                        <%= rotation.current_match_index + 1 %> / <%= rotation.rotation_matches.count %> 試合
-                      </p>
-                      <div class="w-24 bg-gray-200 rounded-full h-1.5 mt-1">
-                        <% progress = rotation.rotation_matches.count > 0 ? ((rotation.current_match_index + 1).to_f / rotation.rotation_matches.count * 100) : 0 %>
-                        <div class="bg-blue-600 h-1.5 rounded-full" style="width: <%= progress %>%"></div>
-                      </div>
-                    </div>
-                  </div>
-                </li>
-              <% end %>
-            <% end %>
-          </ul>
-        <% else %>
-          <div class="px-4 py-3 text-center">
-            <p class="text-sm text-gray-500">まだローテーションがありません</p>
-            <% if current_user.is_admin? %>
-              <%= link_to "ローテーションを作成", new_event_rotation_path(@event), class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-500" %>
-            <% end %>
           </div>
         <% end %>
       </div>

--- a/app/views/matches/edit.html.erb
+++ b/app/views/matches/edit.html.erb
@@ -80,6 +80,12 @@
     </div>
 
     <div class="bg-white shadow sm:rounded-lg p-6">
+      <h2 class="text-lg font-medium text-gray-900 mb-4">アーカイブタイムスタンプ</h2>
+      <%= form.text_field :video_timestamp_text, placeholder: "0:03:20", class: "w-full sm:w-48 px-3 py-2 font-mono border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+      <p class="mt-1 text-sm text-gray-500">配信開始からの経過時間（例: 0:03:20）。空欄で解除。</p>
+    </div>
+
+    <div class="bg-white shadow sm:rounded-lg p-6">
       <h2 class="text-lg font-medium text-gray-900 mb-4">勝利チーム</h2>
       <div class="flex space-x-4">
         <label class="flex items-center">

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -96,6 +96,11 @@
                 <%= link_to match_path(match), class: "text-sm text-gray-500 hover:text-blue-600" do %>
                   <%= match.played_at.strftime('%Y年%m月%d日') %>
                 <% end %>
+                <% if match.video_url %>
+                  <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "アーカイブを見る" do %>
+                    <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-5">
+                  <% end %>
+                <% end %>
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
                   <%= match.event.name %>
                 </span>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -96,14 +96,15 @@
                 <%= link_to match_path(match), class: "text-sm text-gray-500 hover:text-blue-600" do %>
                   <%= match.played_at.strftime('%Y年%m月%d日') %>
                 <% end %>
-                <% if match.video_url %>
-                  <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "アーカイブを見る" do %>
-                    <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-5">
-                  <% end %>
-                <% end %>
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
                   <%= match.event.name %>
                 </span>
+                <% if match.video_url %>
+                  <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                    <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                    配信を見る
+                  <% end %>
+                <% end %>
               </div>
             </div>
 

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -10,9 +10,16 @@
       <div class="flex justify-between items-center">
         <div>
           <h1 class="text-2xl font-bold text-gray-900">対戦詳細</h1>
-          <p class="mt-1 text-sm text-gray-500">
-            <%= @match.played_at.strftime('%Y年%m月%d日') %>
-          </p>
+          <div class="mt-1 flex items-center gap-2">
+            <p class="text-sm text-gray-500">
+              <%= @match.played_at.strftime('%Y年%m月%d日') %>
+            </p>
+            <% if @match.video_url %>
+              <%= link_to @match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "アーカイブを見る" do %>
+                <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-6 sm:h-7">
+              <% end %>
+            <% end %>
+          </div>
         </div>
         <% if current_user.is_admin? %>
           <div class="flex space-x-3">

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -15,8 +15,9 @@
               <%= @match.played_at.strftime('%Y年%m月%d日') %>
             </p>
             <% if @match.video_url %>
-              <%= link_to @match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center hover:opacity-80 transition-opacity", title: "アーカイブを見る" do %>
-                <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-6 sm:h-7">
+              <%= link_to @match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-3 py-1 rounded-full bg-red-50 text-red-700 text-sm font-semibold hover:bg-red-100 transition-colors" do %>
+                <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-4">
+                配信を見る
               <% end %>
             <% end %>
           </div>

--- a/app/views/rotations/index.html.erb
+++ b/app/views/rotations/index.html.erb
@@ -12,7 +12,7 @@
         <% progress = rotation.rotation_matches.count > 0 ? (completed_count.to_f / rotation.rotation_matches.count * 100) : 0 %>
         <%= link_to rotation_path(rotation), class: "block bg-white shadow rounded-lg p-4 hover:bg-gray-50" do %>
           <div class="flex items-center justify-between mb-2">
-            <div class="text-sm font-medium text-blue-600"><%= rotation.name %></div>
+            <div class="text-sm font-medium text-blue-600"><%= rotation.display_name %></div>
             <% if rotation.is_active %>
               <span class="px-2 py-0.5 text-xs font-semibold rounded-full bg-purple-100 text-purple-800">アクティブ</span>
             <% else %>
@@ -38,9 +38,6 @@
         <thead class="bg-gray-50">
           <tr>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              ローテーション名
-            </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               イベント
             </th>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -63,11 +60,6 @@
         <tbody class="bg-white divide-y divide-gray-200">
           <% @rotations.each do |rotation| %>
             <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='<%= rotation_path(rotation) %>'">
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm font-medium text-blue-600">
-                  <%= rotation.name %>
-                </div>
-              </td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <div class="text-sm text-gray-900">
                   <%= rotation.event.name %>

--- a/app/views/rotations/new.html.erb
+++ b/app/views/rotations/new.html.erb
@@ -18,12 +18,6 @@
       <% end %>
 
       <div class="space-y-6">
-        <!-- Rotation Name -->
-        <div>
-          <%= f.label :name, "ローテーション名", class: "block text-sm font-medium text-gray-700 mb-2" %>
-          <%= f.text_field :name, value: @event.name, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 第1回大会 1周目" %>
-        </div>
-
         <!-- Round Number -->
         <div>
           <%= f.label :round_number, "周回数", class: "block text-sm font-medium text-gray-700 mb-2" %>

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -10,7 +10,7 @@
         </div>
         <h3 class="text-lg font-bold text-gray-900 text-center mb-2">全試合完了しました！</h3>
         <p class="text-sm text-gray-600 text-center mb-6">
-          <%= @rotation.name %>の全試合が記録されました。<br>
+          <%= @rotation.display_name %>の全試合が記録されました。<br>
           同じローテーション設定で<%= @rotation.round_number + 1 %>周目を作成しますか？
         </p>
         <div class="flex flex-col space-y-3">
@@ -63,7 +63,7 @@
   <div class="mb-6">
     <div class="flex justify-between items-start">
       <div>
-        <h1 class="text-3xl font-bold text-gray-900"><%= @rotation.name %></h1>
+        <h1 class="text-3xl font-bold text-gray-900"><%= @rotation.display_name %></h1>
         <p class="mt-2 text-sm text-gray-600">
           イベント: <%= link_to @rotation.event.name, @rotation.event, class: "text-blue-600 hover:text-blue-800" %>
           (<%= @rotation.event.held_on.strftime('%Y/%m/%d') %>)
@@ -104,7 +104,7 @@
                   </svg>
                   周回をコピー
                 <% end %>
-                <%= button_to rotation_path(@rotation), method: :delete, data: { turbo_confirm: "ローテーション「#{@rotation.name}」を削除してもよろしいですか？関連する試合データは削除されません。" }, class: "w-full text-left px-4 py-2 text-sm text-red-700 hover:bg-gray-100 flex items-center" do %>
+                <%= button_to rotation_path(@rotation), method: :delete, data: { turbo_confirm: "ローテーション「#{@rotation.display_name}」を削除してもよろしいですか？関連する試合データは削除されません。" }, class: "w-full text-left px-4 py-2 text-sm text-red-700 hover:bg-gray-100 flex items-center" do %>
                   <svg class="mr-3 h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
                   </svg>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -740,7 +740,7 @@
                 <table class="min-w-full divide-y divide-gray-200">
                   <thead class="bg-gray-50">
                     <tr>
-                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><%= event_prog[:has_rotation] ? 'ローテーション' : 'ターム' %></th>
+                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><%= event_prog[:has_rotation] ? '周回' : 'ターム' %></th>
                       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">試合数</th>
                       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">勝利</th>
                       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">敗北</th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,10 @@ Rails.application.routes.draw do
 
   # Events
   resources :events do
+    member do
+      get :edit_timestamps
+      patch :update_timestamps
+    end
     resources :matches, only: [:new, :create]
     resources :rotations, only: [:new, :create]
   end

--- a/db/migrate/20260215124012_add_video_timestamp_to_matches.rb
+++ b/db/migrate/20260215124012_add_video_timestamp_to_matches.rb
@@ -1,0 +1,5 @@
+class AddVideoTimestampToMatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :matches, :video_timestamp, :integer
+  end
+end

--- a/db/migrate/20260215232735_remove_name_from_rotations.rb
+++ b/db/migrate/20260215232735_remove_name_from_rotations.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromRotations < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :rotations, :name, :string
+  end
+end

--- a/db/migrate/20260215234121_add_started_at_to_rotation_matches.rb
+++ b/db/migrate/20260215234121_add_started_at_to_rotation_matches.rb
@@ -1,0 +1,5 @@
+class AddStartedAtToRotationMatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :rotation_matches, :started_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_15_232735) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_15_234121) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -106,6 +106,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_15_232735) do
     t.bigint "match_id"
     t.integer "match_index", null: false
     t.bigint "rotation_id", null: false
+    t.datetime "started_at"
     t.bigint "team1_player1_id", null: false
     t.bigint "team1_player2_id", null: false
     t.bigint "team2_player1_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_08_030138) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_15_124012) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_08_030138) do
     t.datetime "played_at", null: false
     t.bigint "rotation_match_id"
     t.datetime "updated_at", null: false
+    t.integer "video_timestamp"
     t.integer "winning_team", null: false
     t.index ["event_id", "played_at"], name: "index_matches_on_event_id_and_played_at"
     t.index ["event_id"], name: "index_matches_on_event_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_15_124012) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_15_232735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -122,7 +122,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_15_124012) do
     t.integer "current_match_index", default: 0, null: false
     t.bigint "event_id", null: false
     t.boolean "is_active", default: false, null: false
-    t.string "name", null: false
     t.integer "round_number", default: 1, null: false
     t.datetime "updated_at", null: false
     t.index ["base_rotation_id"], name: "index_rotations_on_base_rotation_id"

--- a/lib/tasks/fix_rotation_match_links.rake
+++ b/lib/tasks/fix_rotation_match_links.rake
@@ -1,0 +1,17 @@
+namespace :maintenance do
+  desc "Fix matches missing rotation_match_id (one-shot task for Issue #57)"
+  task fix_rotation_match_links: :environment do
+    fixed = 0
+
+    RotationMatch.where.not(match_id: nil).find_each do |rm|
+      match = Match.find_by(id: rm.match_id)
+      next unless match
+      next unless match.rotation_match_id.nil?
+
+      match.update_column(:rotation_match_id, rm.id)
+      fixed += 1
+    end
+
+    puts "Fixed #{fixed} match(es) with missing rotation_match_id."
+  end
+end


### PR DESCRIPTION
## Summary
release/v1.2.0 を main にマージするリリースPRです。

## 主な変更
- 試合別アーカイブ再生リンク機能の追加
- ローテーション1試合目・2周目以降の通知修正
- ローテーション定義ありイベントの期間別戦績がターム別になるバグを修正
- 配信リンクの視認性を改善（バッジ型デザイン）
- ローテーション名カラムの廃止とround_numberベースの表示への統一
- イベント詳細画面のUI/UX改善と試合開始時刻の記録

## 関連Issue・PR
- #55
- #60
- #62
- #63
- #65
- #66