### PR TITLE
feat: タイムスタンプ自動登録APIと解析開始ボタンの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@
 # Ignore Claude Code files
 /claude_conversations.md
 /CLAUDE.md
+
+# Ignore Kamal secrets (contains credentials)
+/.kamal/secrets

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 
-# Ignore Claude conversation logs
+# Ignore Claude Code files
 /claude_conversations.md
+/CLAUDE.md

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  class BaseController < ActionController::API
+    before_action :authenticate_api_token!
+
+    private
+
+    def authenticate_api_token!
+      token = request.headers["Authorization"]&.sub(/\ABearer /, "")
+      api_token = ENV["TIMESTAMP_API_TOKEN"].presence
+
+      if api_token.blank? || token != api_token
+        render json: { error: "Unauthorized" }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,40 @@
+module Api
+  class EventsController < BaseController
+    include TimestampParseable
+
+    def timestamps
+      event = Event.find_by(id: params[:id])
+      return render json: { error: "Event not found" }, status: :not_found unless event
+
+      raw_text = params[:timestamps].to_s
+      lines = raw_text.split("\n").map(&:strip)
+      lines.pop while lines.last&.empty?
+
+      matches = event.matches.order(:played_at, :id)
+
+      if lines.size != matches.size
+        return render json: {
+          error: "行数（#{lines.size}）と試合数（#{matches.size}）が一致しません。"
+        }, status: :unprocessable_entity
+      end
+
+      parsed = lines.map.with_index do |line, i|
+        seconds = parse_timestamp(line)
+        unless seconds
+          return render json: {
+            error: "#{i + 1}行目「#{line}」の形式が不正です。H:MM:SS または MM:SS の形式で入力してください。"
+          }, status: :unprocessable_entity
+        end
+        seconds
+      end
+
+      ActiveRecord::Base.transaction do
+        matches.each_with_index do |match, i|
+          match.update!(video_timestamp: parsed[i])
+        end
+      end
+
+      render json: { message: "OK", updated: matches.size }
+    end
+  end
+end

--- a/app/controllers/concerns/timestamp_parseable.rb
+++ b/app/controllers/concerns/timestamp_parseable.rb
@@ -1,0 +1,22 @@
+module TimestampParseable
+  extend ActiveSupport::Concern
+
+  private
+
+  def parse_timestamp(str)
+    return nil if str.blank?
+    parts = str.strip.split(":").map(&:to_i)
+    case parts.size
+    when 3 then parts[0] * 3600 + parts[1] * 60 + parts[2]
+    when 2 then parts[0] * 60 + parts[1]
+    else nil
+    end
+  end
+
+  def format_timestamp(seconds)
+    return "" if seconds.nil?
+    h, remainder = seconds.divmod(3600)
+    m, s = remainder.divmod(60)
+    "#{h}:#{format('%02d', m)}:#{format('%02d', s)}"
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,10 @@
+require "net/http"
+
 class EventsController < ApplicationController
+  include TimestampParseable
   before_action :authenticate_user!
-  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps]
-  before_action :set_event, only: [:show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps]
+  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis]
+  before_action :set_event, only: [:show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis]
 
   def index
     @events = Event.includes(:matches).order(held_on: :desc)
@@ -84,6 +87,44 @@ class EventsController < ApplicationController
     redirect_to event_path(@event), notice: "タイムスタンプを保存しました。"
   end
 
+  def trigger_analysis
+    repo = ENV["GITHUB_REPO"].presence
+    workflow_id = ENV["GITHUB_WORKFLOW_ID"].presence
+    token = ENV["GITHUB_TOKEN"].presence
+
+    if repo.blank? || workflow_id.blank? || token.blank?
+      return redirect_to event_path(@event), alert: "GitHub Actions の設定が不完全です（GITHUB_REPO / GITHUB_WORKFLOW_ID / GITHUB_TOKEN を確認してください）。"
+    end
+
+    uri = URI("https://api.github.com/repos/#{repo}/actions/workflows/#{workflow_id}/dispatches")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    req = Net::HTTP::Post.new(uri.path, {
+      "Authorization" => "Bearer #{token}",
+      "Accept" => "application/vnd.github+json",
+      "Content-Type" => "application/json",
+      "X-GitHub-Api-Version" => "2022-11-28"
+    })
+    req.body = {
+      ref: "main",
+      inputs: {
+        event_id: @event.id.to_s,
+        broadcast_url: @event.broadcast_url
+      }
+    }.to_json
+
+    res = http.request(req)
+
+    if res.is_a?(Net::HTTPNoContent)
+      redirect_to event_path(@event), notice: "解析を開始しました。完了後にタイムスタンプが自動登録されます。"
+    else
+      redirect_to event_path(@event), alert: "GitHub Actions のトリガーに失敗しました（HTTP #{res.code}）。"
+    end
+  rescue => e
+    redirect_to event_path(@event), alert: "解析開始でエラーが発生しました: #{e.message}"
+  end
+
   def destroy
     name = @event.name
 
@@ -111,20 +152,4 @@ class EventsController < ApplicationController
     params.require(:event).permit(:name, :held_on, :description, :broadcast_url)
   end
 
-  def parse_timestamp(str)
-    return nil if str.blank?
-    parts = str.strip.split(':').map(&:to_i)
-    case parts.size
-    when 3 then parts[0] * 3600 + parts[1] * 60 + parts[2]
-    when 2 then parts[0] * 60 + parts[1]
-    else nil
-    end
-  end
-
-  def format_timestamp(seconds)
-    return '' if seconds.nil?
-    h, remainder = seconds.divmod(3600)
-    m, s = remainder.divmod(60)
-    "#{h}:#{format('%02d', m)}:#{format('%02d', s)}"
-  end
 end

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -29,6 +29,32 @@ class PushNotificationService
       )
     end
 
+    def notify_timestamps_registered(event:, count:)
+      User.where(is_admin: true).find_each do |user|
+        next unless user.push_notifications_enabled?
+
+        SendPushNotificationJob.perform_later(
+          user_id: user.id,
+          title: "タイムスタンプ登録完了",
+          body: "#{event.name} の #{count} 試合分が登録されました",
+          path: "/events/#{event.id}"
+        )
+      end
+    end
+
+    def notify_timestamps_failed(event:, error:)
+      User.where(is_admin: true).find_each do |user|
+        next unless user.push_notifications_enabled?
+
+        SendPushNotificationJob.perform_later(
+          user_id: user.id,
+          title: "タイムスタンプ登録失敗",
+          body: "#{event.name}: #{error}",
+          path: "/events/#{event.id}"
+        )
+      end
+    end
+
     def notify_rotation_activated(rotation:)
       player_ids = collect_player_ids(rotation)
       return if player_ids.empty?

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -23,6 +23,7 @@
           <%= link_to "ローテーション作成", new_event_rotation_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <% if @event.broadcast_url.present? %>
             <%= link_to "タイムスタンプ一括設定", edit_timestamps_event_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+            <%= button_to "解析開始", trigger_analysis_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で動画解析を開始しますか？完了後にタイムスタンプが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <% end %>
           <%= link_to "編集", edit_event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= button_to "削除", event_path(@event), method: :delete, data: { turbo_confirm: "イベント「#{@event.name}」を削除してもよろしいですか？関連する試合やローテーションもすべて削除されます。" }, class: "bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-sm" %>

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -25,6 +25,10 @@ env:
   secret:
     - RAILS_MASTER_KEY
     - POSTGRES_PASSWORD
+    - TIMESTAMP_API_TOKEN
+    - GITHUB_TOKEN
+    - GITHUB_REPO
+    - GITHUB_WORKFLOW_ID
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     SOLID_QUEUE_IN_PUMA: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,11 +37,21 @@ Rails.application.routes.draw do
   # Statistics
   get "statistics", to: "statistics#index", as: :statistics
 
+  # API
+  namespace :api do
+    resources :events, only: [] do
+      member do
+        post :timestamps
+      end
+    end
+  end
+
   # Events
   resources :events do
     member do
       get :edit_timestamps
       patch :update_timestamps
+      post :trigger_analysis
     end
     resources :matches, only: [:new, :create]
     resources :rotations, only: [:new, :create]


### PR DESCRIPTION
## Summary

- `TimestampParseable` Concern を新設し、`parse_timestamp` / `format_timestamp` を共有化
- `Api::BaseController` を新設（`ActionController::API` 継承、Bearer トークン認証）
- `POST /api/events/:id/timestamps` を追加（GitHub Actions からタイムスタンプを一括登録）
- `EventsController#trigger_analysis` を追加（GitHub Actions `workflow_dispatch` API を呼び出し）
- イベント詳細画面に「解析開始」ボタンを追加（管理者 + `broadcast_url` 設定済みのみ表示）
- タイムスタンプ登録の成功・失敗時に管理者へ Web Push 通知を送信
- `config/deploy.yml` に `TIMESTAMP_API_TOKEN` / `GITHUB_TOKEN` / `GITHUB_REPO` / `GITHUB_WORKFLOW_ID` を secret 追加

## Test plan

- [ ] `curl -X POST https://vsm-kgy.com/api/events/{id}/timestamps -H "Authorization: Bearer {token}" -d '{"timestamps":"0:01:00\n0:05:00"}' で API が動作することを確認
- [ ] 登録成功後に管理者へ「タイムスタンプ登録完了」の Web Push が届くことを確認
- [ ] 行数不一致・形式不正の場合に 422 が返り、「タイムスタンプ登録失敗」の Web Push が届くことを確認
- [ ] トークン未設定・不正時に 401 が返ることを確認
- [ ] 「解析開始」ボタンが管理者 + `broadcast_url` 有りの場合のみ表示されることを確認
- [ ] 「解析開始」ボタン押下で GitHub Actions が起動することを確認

Closes #68
Closes #71