### PR TITLE
fix: イベント詳細画面の試合順が不安定になるバグを修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc)
+    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc, id: :asc)
     @rotations = @event.rotations.order(created_at: :asc)
   end
 


### PR DESCRIPTION
## Summary

- イベント詳細画面の対戦記録ソートに `id: :asc` をタイブレーカーとして追加

## 原因

`played_at` は `Time.current`（秒単位）で記録されるため、短時間に連続登録すると同じ秒のレコードが複数生まれる。`order(played_at: :asc)` のみでは `id` が未指定のため、同一秒内の並び順が DB 任せの不定順になっていた。

## 変更内容

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `EventsController#show` の order | `order(played_at: :asc)` | `order(played_at: :asc, id: :asc)` |

## Test plan

- [ ] イベント詳細画面で試合が古い順（第1試合→第N試合）に正しく並ぶことを確認
- [ ] 配信リンクをクリックして正しい試合のタイムスタンプに飛ぶことを確認

Closes #72