### PR TITLE
feat: イベント詳細画面の試合カードにスタンプ機能を追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,10 @@ class EventsController < ApplicationController
   end
 
   def show
-    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user).order(played_at: :asc, id: :asc)
+    @per_page = 20
+    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
+                     .order(played_at: :asc, id: :asc)
+                     .page(params[:page]).per(@per_page)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,7 @@ class EventsController < ApplicationController
   def show
     @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc, id: :asc)
     @rotations = @event.rotations.order(created_at: :asc)
+    @emojis = MasterEmoji.active.ordered
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc, id: :asc)
+    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user).order(played_at: :asc, id: :asc)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @per_page = 20
+    @per_page = [10, 20, 50].include?(params[:per].to_i) ? params[:per].to_i : 20
     @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
                      .order(played_at: :asc, id: :asc)
                      .page(params[:page]).per(@per_page)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -91,17 +91,18 @@
     <div class="bg-white shadow overflow-hidden sm:rounded-lg">
       <div class="px-4 py-5 sm:px-6">
         <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
-        <p class="mt-1 text-sm text-gray-500">全 <%= @matches.count %> 試合</p>
+        <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
       </div>
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
           <ul class="divide-y divide-gray-200">
+            <% match_offset = (@matches.current_page - 1) * @matches.limit_value %>
             <% @matches.each_with_index do |match, index| %>
               <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
                   <div class="flex items-center gap-2 mb-2">
-                    <span class="text-sm font-semibold text-gray-900">第<%= index + 1 %>試合</span>
+                    <span class="text-sm font-semibold text-gray-900">第<%= match_offset + index + 1 %>試合</span>
                     <% if match.rotation_match&.started_at %>
                       <span class="text-xs text-gray-500"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
                     <% elsif match.played_at %>
@@ -169,6 +170,11 @@
               <% end %>
             <% end %>
           </ul>
+          <% if @matches.total_pages > 1 %>
+            <div class="px-4 py-4 flex justify-center border-t border-gray-200">
+              <%= paginate @matches %>
+            </div>
+          <% end %>
         <% else %>
           <div class="px-4 py-3 text-center">
             <p class="text-sm text-gray-500">まだ対戦記録がありません</p>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -97,6 +97,7 @@
         <% if @matches.any? %>
           <ul class="divide-y divide-gray-200">
             <% @matches.each_with_index do |match, index| %>
+              <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
                   <div class="flex items-center gap-2 mb-2">
@@ -160,6 +161,9 @@
                         </div>
                       <% end %>
                     </div>
+                  </div>
+                  <div onclick="event.stopPropagation()">
+                    <%= render "reactions/reaction_bar", match: match, compact: true, emojis: @emojis %>
                   </div>
                 </li>
               <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -170,9 +170,19 @@
               <% end %>
             <% end %>
           </ul>
-          <% if @matches.total_pages > 1 %>
-            <div class="px-4 py-4 flex justify-center border-t border-gray-200">
-              <%= paginate @matches %>
+          <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
+            <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
+              <%= paginate @matches, params: { per: @per_page } %>
+              <div class="flex items-center gap-2 text-sm text-gray-600">
+                <span>表示件数:</span>
+                <% [10, 20, 50].each do |n| %>
+                  <% if n == @per_page %>
+                    <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
+                  <% else %>
+                    <%= link_to n, event_path(@event, per: n), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
+                  <% end %>
+                <% end %>
+              </div>
             </div>
           <% end %>
         <% else %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -117,8 +117,8 @@
                     </div>
                   <% end %>
                   <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
-                    <% team1_players = match.match_players.where(team_number: 1).order(:position) %>
-                    <% team2_players = match.match_players.where(team_number: 2).order(:position) %>
+                    <% team1_players = match.match_players.to_a.select { |p| p.team_number == 1 }.sort_by(&:position) %>
+                    <% team2_players = match.match_players.to_a.select { |p| p.team_number == 2 }.sort_by(&:position) %>
 
                     <!-- Team 1 -->
                     <div class="<%= match.winning_team == 1 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">


### PR DESCRIPTION
## Summary

- `EventsController#show` に `@emojis` を追加（N+1 対策）
- イベント詳細画面の各試合カードに `reaction_bar`（compact）を追加
- `turbo_stream_from` でリアルタイム更新に対応
- `onclick="event.stopPropagation()"` でリンク伝播を防止

## Test plan

- [ ] イベント詳細画面の試合カードにスタンプバーが表示されることを確認
- [ ] スタンプを押してもイベント詳細ページに遷移しないことを確認
- [ ] スタンプの追加・削除がリアルタイムで反映されることを確認

Closes #74