### PR TITLE
feat: 対戦履歴：表示件数セレクターをリスト上部にも追加

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -90,8 +90,13 @@
 
     <div class="bg-white shadow overflow-hidden sm:rounded-lg">
       <div class="px-4 py-5 sm:px-6">
-        <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
-        <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
+            <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
+          </div>
+          <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, per: n) } %>
+        </div>
       </div>
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
@@ -173,16 +178,7 @@
           <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
             <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
               <%= paginate @matches, params: { per: @per_page } %>
-              <div class="flex items-center gap-2 text-sm text-gray-600">
-                <span>表示件数:</span>
-                <% [10, 20, 50].each do |n| %>
-                  <% if n == @per_page %>
-                    <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
-                  <% else %>
-                    <%= link_to n, event_path(@event, per: n), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
-                  <% end %>
-                <% end %>
-              </div>
+              <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, per: n) } %>
             </div>
           <% end %>
         <% else %>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -84,16 +84,7 @@
   <div class="bg-white shadow sm:rounded-lg">
     <div class="px-4 py-3 border-b border-gray-200 flex flex-wrap items-center justify-between gap-2">
       <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
-      <div class="flex items-center gap-2 text-sm text-gray-600">
-        <span>表示件数:</span>
-        <% [10, 20, 50].each do |n| %>
-          <% if n == @per_page %>
-            <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
-          <% else %>
-            <%= link_to n, matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
-          <% end %>
-        <% end %>
-      </div>
+      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -177,28 +168,17 @@
         </li>
       <% end %>
     </ul>
+    <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
+      <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
+        <%= paginate @matches, params: { per: @per_page } %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
+      </div>
+    <% end %>
   </div>
 
   <% if @matches.empty? %>
     <div class="text-center py-12">
       <p class="text-gray-500">対戦記録がまだありません</p>
-    </div>
-  <% end %>
-
-  <!-- Pagination -->
-  <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
-    <div class="mt-6 flex flex-col items-center gap-4">
-      <%= paginate @matches, params: { per: @per_page } %>
-      <div class="flex items-center gap-2 text-sm text-gray-600">
-        <span>表示件数:</span>
-        <% [10, 20, 50].each do |n| %>
-          <% if n == @per_page %>
-            <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
-          <% else %>
-            <%= link_to n, matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
-          <% end %>
-        <% end %>
-      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -82,6 +82,19 @@
   <% end %>
 
   <div class="bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-3 border-b border-gray-200 flex flex-wrap items-center justify-between gap-2">
+      <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
+      <div class="flex items-center gap-2 text-sm text-gray-600">
+        <span>表示件数:</span>
+        <% [10, 20, 50].each do |n| %>
+          <% if n == @per_page %>
+            <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
+          <% else %>
+            <%= link_to n, matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
         <li class="<%= current_user.is_admin? ? 'pl-10' : '' %> relative">

--- a/app/views/shared/_per_page_selector.html.erb
+++ b/app/views/shared/_per_page_selector.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (per_page:, url_builder:) %>
+<div class="flex items-center gap-2 text-sm text-gray-600">
+  <span>表示件数:</span>
+  <% [10, 20, 50].each do |n| %>
+    <% if n == per_page %>
+      <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
+    <% else %>
+      <%= link_to n, url_builder.call(n), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
+    <% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
## Summary
- 試合リストの直上に「全N試合 / 表示件数: 10 20 50」行を追加
- 現在の選択値をハイライト表示
- フィルターパラメータ（イベント・ユーザー等）を維持したリンク
- 下部のセレクターはそのまま残存

## Test plan
- [ ] リスト上部に「全N試合 / 表示件数」行が表示される
- [ ] 10/20/50 を切り替えると件数が変わる
- [ ] フィルター適用中に件数を切り替えてもフィルターが維持される
- [ ] 現在の選択値がインジゴ色でハイライトされる

Closes #76