### PR TITLE
feat: 試合一覧・イベント詳細にリアクション数順ソートを追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,7 +15,7 @@ class EventsController < ApplicationController
     @sort = sort
     @per_page = [10, 20, 50].include?(params[:per].to_i) ? params[:per].to_i : 20
 
-    base_scope = sort == "reactions" ? @event.matches.by_reactions : @event.matches.by_oldest
+    base_scope = sort == "reactions" ? @event.matches.by_reactions_oldest : @event.matches.by_oldest
     @matches = base_scope
                  .includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
                  .page(params[:page]).per(@per_page)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,10 +11,14 @@ class EventsController < ApplicationController
   end
 
   def show
+    sort = params[:sort].presence_in(%w[oldest reactions]) || "oldest"
+    @sort = sort
     @per_page = [10, 20, 50].include?(params[:per].to_i) ? params[:per].to_i : 20
-    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
-                     .order(played_at: :asc, id: :asc)
-                     .page(params[:page]).per(@per_page)
+
+    base_scope = sort == "reactions" ? @event.matches.by_reactions : @event.matches.by_oldest
+    @matches = base_scope
+                 .includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
+                 .page(params[:page]).per(@per_page)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
   end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -5,7 +5,11 @@ class MatchesController < ApplicationController
   before_action :set_match, only: [:show, :edit, :update, :destroy]
 
   def index
-    @matches = Match.includes(:event, { match_players: [:user, :mobile_suit] }, { reactions: :user }).order(played_at: :desc, id: :desc)
+    sort = params[:sort].presence_in(%w[latest reactions]) || "latest"
+    @sort = sort
+
+    base_scope = sort == "reactions" ? Match.by_reactions : Match.by_latest
+    @matches = base_scope.includes(:event, { match_players: [:user, :mobile_suit] }, { reactions: :user })
 
     # フィルター: イベント（複数選択対応）
     if params[:events].present?

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -7,6 +7,11 @@ class Match < ApplicationRecord
 
   accepts_nested_attributes_for :match_players
 
+  # Scopes
+  scope :by_latest,    -> { order(played_at: :desc, id: :desc) }
+  scope :by_reactions, -> { order(reactions_count: :desc, played_at: :desc, id: :desc) }
+  scope :by_oldest,    -> { order(played_at: :asc, id: :asc) }
+
   # Validations
   validates :played_at, presence: true
   validates :winning_team, presence: true, inclusion: { in: [1, 2] }

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -8,9 +8,10 @@ class Match < ApplicationRecord
   accepts_nested_attributes_for :match_players
 
   # Scopes
-  scope :by_latest,    -> { order(played_at: :desc, id: :desc) }
-  scope :by_reactions, -> { order(reactions_count: :desc, played_at: :desc, id: :desc) }
-  scope :by_oldest,    -> { order(played_at: :asc, id: :asc) }
+  scope :by_latest,           -> { order(played_at: :desc, id: :desc) }
+  scope :by_reactions,        -> { order(reactions_count: :desc, played_at: :desc, id: :desc) }
+  scope :by_reactions_oldest, -> { order(reactions_count: :desc, played_at: :asc, id: :asc) }
+  scope :by_oldest,           -> { order(played_at: :asc, id: :asc) }
 
   # Validations
   validates :played_at, presence: true

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,7 +1,7 @@
 class Reaction < ApplicationRecord
   # Associations
   belongs_to :user
-  belongs_to :match
+  belongs_to :match, counter_cache: true
   belongs_to :master_emoji
 
   # Validations

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -94,8 +94,20 @@
           <div>
             <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
             <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
+            <div class="flex items-center gap-2 text-sm text-gray-600 mt-2">
+              <span>ソート:</span>
+              <% [["oldest", "試合順"], ["reactions", "リアクション順"]].each do |value, label| %>
+                <% if value == @sort %>
+                  <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
+                <% else %>
+                  <%= link_to label,
+                        event_path(@event, sort: value, per: @per_page),
+                        class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
+                <% end %>
+              <% end %>
+            </div>
           </div>
-          <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, per: n) } %>
+          <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, sort: @sort, per: n) } %>
         </div>
       </div>
       <div class="border-t border-gray-200">
@@ -177,8 +189,8 @@
           </ul>
           <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
             <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
-              <%= paginate @matches, params: { per: @per_page } %>
-              <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, per: n) } %>
+              <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
+              <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, sort: @sort, per: n) } %>
             </div>
           <% end %>
         <% else %>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -83,8 +83,22 @@
 
   <div class="bg-white shadow sm:rounded-lg">
     <div class="px-4 py-3 border-b border-gray-200 flex flex-wrap items-center justify-between gap-2">
-      <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
-      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
+      <div class="flex flex-wrap items-center gap-4">
+        <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
+        <div class="flex items-center gap-2 text-sm text-gray-600">
+          <span>ソート:</span>
+          <% [["latest", "最新順"], ["reactions", "リアクション順"]].each do |value, label| %>
+            <% if value == @sort %>
+              <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
+            <% else %>
+              <%= link_to label,
+                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]),
+                    class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -170,8 +184,8 @@
     </ul>
     <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
       <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
-        <%= paginate @matches, params: { per: @per_page } %>
-        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
+        <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
       </div>
     <% end %>
   </div>

--- a/db/migrate/20260219232110_add_reactions_count_to_matches.rb
+++ b/db/migrate/20260219232110_add_reactions_count_to_matches.rb
@@ -1,0 +1,11 @@
+class AddReactionsCountToMatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :matches, :reactions_count, :integer, default: 0, null: false
+    execute <<~SQL
+      UPDATE matches
+      SET reactions_count = (
+        SELECT COUNT(*) FROM reactions WHERE reactions.match_id = matches.id
+      )
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_15_234121) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_232110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_15_234121) do
     t.datetime "created_at", null: false
     t.bigint "event_id", null: false
     t.datetime "played_at", null: false
+    t.integer "reactions_count", default: 0, null: false
     t.bigint "rotation_match_id"
     t.datetime "updated_at", null: false
     t.integer "video_timestamp"


### PR DESCRIPTION
## Summary
- `matches` テーブルに `reactions_count` カラムを追加（counter_cache 方式）
- リアクション追加・削除時にカウントが自動更新される
- 試合一覧（`/matches`）にリアクション順ソートを追加（同数は新しい順）
- イベント詳細（`/events/:id`）にリアクション順ソートを追加（同数は古い順）
- ページ送り・件数変更時にソート選択が維持される

## Test plan
- [ ] `bin/rails db:migrate` を実行し、`matches.reactions_count` が正しいカウントで埋まっていることを確認
- [ ] `/matches?sort=reactions` でリアクション数の多い試合が上位に表示されること
- [ ] `/events/:id?sort=reactions` でイベント詳細でも同様に動作すること
- [ ] ページ件数変更・ページネーション移動後もソートが保持されること
- [ ] リアクションを追加・削除したとき `reactions_count` が即時更新されること
- [ ] デフォルトは試合一覧=最新順、イベント詳細=試合順（変更なし）であること

Closes #16