### PR TITLE
feat: アプリ起動時のお知らせモーダル機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem "csv"
 # Web Push notifications [https://github.com/pushpad/web-push]
 gem "web-push", "~> 3.0"
 
+# Markdown rendering [https://github.com/vmg/redcarpet]
+gem "redcarpet"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,7 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redcarpet (3.6.1)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -412,6 +413,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)
+  redcarpet
   rubocop-rails-omakase
   solid_cable
   solid_cache

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,0 +1,49 @@
+module Admin
+  class AnnouncementsController < BaseController
+    before_action :set_announcement, only: [:edit, :update, :destroy]
+
+    def index
+      @announcements = Announcement.order(published_at: :desc)
+    end
+
+    def new
+      @announcement = Announcement.new(published_at: Time.current)
+    end
+
+    def create
+      @announcement = Announcement.new(announcement_params)
+      if @announcement.save
+        redirect_to admin_announcements_path, notice: "お知らせ「#{@announcement.title}」を作成しました。"
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @announcement.update(announcement_params)
+        redirect_to admin_announcements_path, notice: "お知らせ「#{@announcement.title}」を更新しました。"
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      title = @announcement.title
+      @announcement.destroy
+      redirect_to admin_announcements_path, notice: "お知らせ「#{title}」を削除しました。"
+    end
+
+    private
+
+    def set_announcement
+      @announcement = Announcement.find(params[:id])
+    end
+
+    def announcement_params
+      params.require(:announcement).permit(:title, :body, :published_at, :expires_at, :is_active)
+    end
+  end
+end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,0 +1,12 @@
+class AnnouncementsController < ApplicationController
+  before_action :authenticate_user!
+
+  def mark_as_read
+    announcement = Announcement.find(params[:id])
+    current_user.user_announcement_reads.find_or_create_by!(announcement: announcement)
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.remove("announcement-modal") }
+      format.html { redirect_back fallback_location: root_path }
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,9 @@ class ApplicationController < ActionController::Base
   # Set user_id in cookies for Action Cable authentication
   before_action :set_user_cookie
 
+  # お知らせモーダル
+  before_action :set_unread_announcement
+
   # ユーザー視点切り替え機能
   helper_method :viewing_as_user, :viewing_as_someone_else?, :can_react?
 
@@ -46,5 +49,14 @@ class ApplicationController < ActionController::Base
     unless current_user&.is_admin?
       redirect_to root_path, alert: "管理者権限が必要です。"
     end
+  end
+
+  # 未読のお知らせを取得（ログイン中のみ）
+  def set_unread_announcement
+    return unless user_signed_in?
+    read_ids = current_user.user_announcement_reads.pluck(:announcement_id)
+    @unread_announcement = Announcement.active
+                                       .where.not(id: read_ids)
+                                       .first
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,23 @@
 module ApplicationHelper
+  MARKDOWN_RENDERER = Redcarpet::Markdown.new(
+    Redcarpet::Render::HTML.new(hard_wrap: true, safe_links_only: true),
+    autolink: true,
+    tables: true,
+    fenced_code_blocks: true,
+    strikethrough: true,
+    no_intra_emphasis: true
+  )
+
+  def render_markdown(text)
+    return "" if text.blank?
+    sanitize(
+      MARKDOWN_RENDERER.render(text),
+      tags: %w[p br strong em a ul ol li h1 h2 h3 h4 h5 blockquote code pre s del table thead tbody tr th td hr],
+      attributes: %w[href]
+    )
+  end
+
+
   def cost_badge(cost)
     style = case cost.to_i
     when 3000

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,19 @@
+class Announcement < ApplicationRecord
+  has_many :user_announcement_reads, dependent: :destroy
+  has_many :read_by_users, through: :user_announcement_reads, source: :user
+
+  validates :title, presence: true
+  validates :body, presence: true
+  validates :published_at, presence: true
+
+  scope :active, -> {
+    where(is_active: true)
+      .where("published_at <= ?", Time.current)
+      .where("expires_at IS NULL OR expires_at >= ?", Time.current)
+      .order(published_at: :desc)
+  }
+
+  def read_by?(user)
+    user_announcement_reads.exists?(user: user)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :match_players, dependent: :destroy
   has_many :push_subscriptions, dependent: :destroy
   has_many :reactions, dependent: :destroy
+  has_many :user_announcement_reads, dependent: :destroy
+  has_many :read_announcements, through: :user_announcement_reads, source: :announcement
 
   # Validations
   validates :username, presence: true, uniqueness: { case_sensitive: false },

--- a/app/models/user_announcement_read.rb
+++ b/app/models/user_announcement_read.rb
@@ -1,0 +1,6 @@
+class UserAnnouncementRead < ApplicationRecord
+  belongs_to :user
+  belongs_to :announcement
+
+  validates :user_id, uniqueness: { scope: :announcement_id }
+end

--- a/app/views/admin/announcements/_form.html.erb
+++ b/app/views/admin/announcements/_form.html.erb
@@ -16,7 +16,8 @@
 
   <div>
     <%= form.label :body, "本文", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= form.text_area :body, rows: 8, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "お知らせの内容を入力してください。改行はそのまま表示されます。" %>
+    <%= form.text_area :body, rows: 8, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono", placeholder: "お知らせの内容を入力してください。Markdown が使えます。" %>
+    <p class="mt-1 text-xs text-gray-500">Markdown 対応: **太字** / *斜体* / # 見出し / - リスト / `コード` / [リンク](URL) など</p>
   </div>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/app/views/admin/announcements/_form.html.erb
+++ b/app/views/admin/announcements/_form.html.erb
@@ -1,0 +1,43 @@
+<%= form_with model: [:admin, announcement], class: "space-y-6" do |form| %>
+  <% if announcement.errors.any? %>
+    <div class="bg-red-50 border border-red-200 rounded-md p-4">
+      <ul class="list-disc list-inside text-sm text-red-600">
+        <% announcement.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :title, "タイトル", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.text_field :title, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "例: v1.3.0 アップデートのお知らせ" %>
+  </div>
+
+  <div>
+    <%= form.label :body, "本文", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.text_area :body, rows: 8, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "お知らせの内容を入力してください。改行はそのまま表示されます。" %>
+  </div>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div>
+      <%= form.label :published_at, "公開開始日時", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.datetime_local_field :published_at, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", value: announcement.published_at&.strftime("%Y-%m-%dT%H:%M") %>
+    </div>
+    <div>
+      <%= form.label :expires_at, "公開終了日時（任意）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.datetime_local_field :expires_at, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", value: announcement.expires_at&.strftime("%Y-%m-%dT%H:%M") %>
+      <p class="mt-1 text-xs text-gray-500">空白の場合は期限なし</p>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-3">
+    <%= form.check_box :is_active, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 h-4 w-4" %>
+    <%= form.label :is_active, "有効にする（チェックで表示ON）", class: "text-sm font-medium text-gray-700" %>
+  </div>
+
+  <div class="flex gap-3">
+    <%= form.submit announcement.new_record? ? "作成" : "更新", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+    <%= link_to "キャンセル", admin_announcements_path, class: "bg-gray-100 hover:bg-gray-200 text-gray-700 font-semibold py-2 px-4 rounded text-sm" %>
+  </div>
+<% end %>

--- a/app/views/admin/announcements/edit.html.erb
+++ b/app/views/admin/announcements/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="mb-6">
+    <%= link_to "← お知らせ一覧に戻る", admin_announcements_path, class: "text-blue-600 hover:text-blue-500 text-sm" %>
+  </div>
+  <h1 class="text-2xl font-bold text-gray-900 mb-6">お知らせを編集</h1>
+  <div class="bg-white shadow rounded-lg p-6">
+    <%= render "form", announcement: @announcement %>
+  </div>
+</div>

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -1,0 +1,53 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+    <div>
+      <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">お知らせ管理</h1>
+      <p class="mt-2 text-sm text-gray-600">アプリ起動時に表示されるお知らせを管理できます</p>
+    </div>
+    <%= link_to "新規作成", new_admin_announcement_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+  </div>
+
+  <% if @announcements.any? %>
+    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">タイトル</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">状態</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">公開期間</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">既読数</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">操作</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% @announcements.each do |announcement| %>
+            <tr>
+              <td class="px-6 py-4 text-sm font-medium text-gray-900"><%= announcement.title %></td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <% if announcement.is_active %>
+                  <span class="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">有効</span>
+                <% else %>
+                  <span class="px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-500">無効</span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-500">
+                <%= announcement.published_at.strftime('%Y/%m/%d %H:%M') %> 〜
+                <%= announcement.expires_at ? announcement.expires_at.strftime('%Y/%m/%d %H:%M') : "期限なし" %>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-500"><%= announcement.user_announcement_reads.count %>人</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                <%= link_to "編集", edit_admin_announcement_path(announcement), class: "text-blue-600 hover:text-blue-900 mr-3" %>
+                <%= button_to "削除", admin_announcement_path(announcement), method: :delete, data: { turbo_confirm: "お知らせ「#{announcement.title}」を削除しますか？" }, class: "text-red-600 hover:text-red-900" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="text-center py-12 bg-white rounded-lg shadow">
+      <p class="text-gray-500">お知らせがまだありません</p>
+      <%= link_to "最初のお知らせを作成する", new_admin_announcement_path, class: "mt-4 inline-block text-indigo-600 hover:text-indigo-500" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/announcements/new.html.erb
+++ b/app/views/admin/announcements/new.html.erb
@@ -1,0 +1,9 @@
+<div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="mb-6">
+    <%= link_to "← お知らせ一覧に戻る", admin_announcements_path, class: "text-blue-600 hover:text-blue-500 text-sm" %>
+  </div>
+  <h1 class="text-2xl font-bold text-gray-900 mb-6">お知らせを作成</h1>
+  <div class="bg-white shadow rounded-lg p-6">
+    <%= render "form", announcement: @announcement %>
+  </div>
+</div>

--- a/app/views/announcements/_modal.html.erb
+++ b/app/views/announcements/_modal.html.erb
@@ -1,0 +1,28 @@
+<div id="announcement-modal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+  <%# オーバーレイ（背景） %>
+  <div class="absolute inset-0 bg-black/50"></div>
+
+  <%# モーダル本体 %>
+  <div class="relative bg-white rounded-2xl shadow-2xl w-full max-w-md mx-auto overflow-hidden">
+    <%# ヘッダー %>
+    <div class="bg-indigo-600 px-6 py-4">
+      <div class="flex items-center gap-2">
+        <span class="text-white text-lg">📢</span>
+        <h2 class="text-white font-bold text-lg leading-tight"><%= announcement.title %></h2>
+      </div>
+    </div>
+
+    <%# 本文 %>
+    <div class="px-6 py-5">
+      <div class="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed"><%= announcement.body %></div>
+    </div>
+
+    <%# フッター %>
+    <div class="px-6 pb-6 flex justify-end">
+      <%= button_to "閉じる",
+            mark_as_read_announcement_path(announcement),
+            method: :post,
+            class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-6 rounded-lg text-sm transition" %>
+    </div>
+  </div>
+</div>

--- a/app/views/announcements/_modal.html.erb
+++ b/app/views/announcements/_modal.html.erb
@@ -13,9 +13,30 @@
     </div>
 
     <%# 本文 %>
-    <div class="px-6 py-5">
-      <div class="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed"><%= announcement.body %></div>
+    <div class="px-6 py-5 max-h-96 overflow-y-auto">
+      <div class="announcement-body text-sm text-gray-700 leading-relaxed"><%= render_markdown(announcement.body) %></div>
     </div>
+
+    <style>
+      .announcement-body p { margin-bottom: 0.75em; }
+      .announcement-body p:last-child { margin-bottom: 0; }
+      .announcement-body h1, .announcement-body h2, .announcement-body h3 { font-weight: 700; margin-bottom: 0.5em; margin-top: 1em; }
+      .announcement-body h1 { font-size: 1.25em; }
+      .announcement-body h2 { font-size: 1.1em; }
+      .announcement-body h3 { font-size: 1em; }
+      .announcement-body strong { font-weight: 700; }
+      .announcement-body em { font-style: italic; }
+      .announcement-body ul { list-style-type: disc; padding-left: 1.5em; margin-bottom: 0.75em; }
+      .announcement-body ol { list-style-type: decimal; padding-left: 1.5em; margin-bottom: 0.75em; }
+      .announcement-body li { margin-bottom: 0.25em; }
+      .announcement-body a { color: #4F46E5; text-decoration: underline; }
+      .announcement-body code { background: #F3F4F6; padding: 0.1em 0.3em; border-radius: 0.25em; font-family: monospace; font-size: 0.9em; }
+      .announcement-body pre { background: #F3F4F6; padding: 0.75em; border-radius: 0.5em; overflow-x: auto; margin-bottom: 0.75em; }
+      .announcement-body pre code { background: none; padding: 0; }
+      .announcement-body blockquote { border-left: 3px solid #E5E7EB; padding-left: 1em; color: #6B7280; margin-bottom: 0.75em; }
+      .announcement-body hr { border: none; border-top: 1px solid #E5E7EB; margin: 1em 0; }
+      .announcement-body del, .announcement-body s { text-decoration: line-through; }
+    </style>
 
     <%# フッター %>
     <div class="px-6 pb-6 flex justify-end">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,6 +61,7 @@
                 </div>
               </div>
 
+              <%= link_to "お知らせ管理", admin_announcements_path, class: "sidebar-nav-item #{current_page?(admin_announcements_path) ? 'active' : ''}" %>
               <%= link_to "機体マスタ", admin_mobile_suits_path, class: "sidebar-nav-item #{current_page?(admin_mobile_suits_path) ? 'active' : ''}" %>
               <%= link_to "スタンプマスタ", admin_master_emojis_path, class: "sidebar-nav-item #{current_page?(admin_master_emojis_path) ? 'active' : ''}" %>
               <%= link_to "ユーザー管理", admin_users_path, class: "sidebar-nav-item #{current_page?(admin_users_path) ? 'active' : ''}" %>
@@ -306,6 +307,7 @@
             <% if current_user.is_admin? %>
               <div class="border-t border-indigo-400 mt-3 pt-3">
                 <div class="px-4 py-2 text-xs font-semibold text-indigo-200 uppercase tracking-wider">管理者メニュー</div>
+                <%= link_to "お知らせ管理", admin_announcements_path, class: "mobile-menu-item #{current_page?(admin_announcements_path) ? 'active' : ''}" %>
                 <%= link_to "機体マスタ", admin_mobile_suits_path, class: "mobile-menu-item #{current_page?(admin_mobile_suits_path) ? 'active' : ''}" %>
                 <%= link_to "スタンプマスタ", admin_master_emojis_path, class: "mobile-menu-item #{current_page?(admin_master_emojis_path) ? 'active' : ''}" %>
                 <%= link_to "ユーザー管理", admin_users_path, class: "mobile-menu-item #{current_page?(admin_users_path) ? 'active' : ''}" %>
@@ -403,5 +405,10 @@
     <main class="<%= 'main-content-with-sidebar' if user_signed_in? %>">
       <%= yield %>
     </main>
+
+    <%# お知らせモーダル %>
+    <% if @unread_announcement %>
+      <%= render "announcements/modal", announcement: @unread_announcement %>
+    <% end %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,8 +83,16 @@ Rails.application.routes.draw do
     end
   end
 
+  # Announcements
+  resources :announcements, only: [] do
+    member do
+      post :mark_as_read
+    end
+  end
+
   # Admin
   namespace :admin do
+    resources :announcements, except: [:show]
     resources :users, except: [:show] do
       member do
         post :switch_view

--- a/db/migrate/20260219235249_create_announcements.rb
+++ b/db/migrate/20260219235249_create_announcements.rb
@@ -1,0 +1,13 @@
+class CreateAnnouncements < ActiveRecord::Migration[8.1]
+  def change
+    create_table :announcements do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.datetime :published_at, null: false
+      t.datetime :expires_at
+      t.boolean :is_active, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260219235250_create_user_announcement_reads.rb
+++ b/db/migrate/20260219235250_create_user_announcement_reads.rb
@@ -1,0 +1,11 @@
+class CreateUserAnnouncementReads < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_announcement_reads do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :announcement, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :user_announcement_reads, [:user_id, :announcement_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_19_232110) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_235250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "announcements", force: :cascade do |t|
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at"
+    t.boolean "is_active", default: false, null: false
+    t.datetime "published_at", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "broadcast_url"
@@ -131,6 +141,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_232110) do
     t.index ["event_id"], name: "index_rotations_on_event_id"
   end
 
+  create_table "user_announcement_reads", force: :cascade do |t|
+    t.bigint "announcement_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["announcement_id"], name: "index_user_announcement_reads_on_announcement_id"
+    t.index ["user_id", "announcement_id"], name: "index_user_announcement_reads_on_user_id_and_announcement_id", unique: true
+    t.index ["user_id"], name: "index_user_announcement_reads_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "encrypted_password", default: "", null: false
@@ -161,4 +181,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_232110) do
   add_foreign_key "rotation_matches", "users", column: "team2_player2_id"
   add_foreign_key "rotations", "events"
   add_foreign_key "rotations", "rotations", column: "base_rotation_id"
+  add_foreign_key "user_announcement_reads", "announcements"
+  add_foreign_key "user_announcement_reads", "users"
 end


### PR DESCRIPTION
## Summary
- `announcements` / `user_announcement_reads` テーブルを追加
- 管理者が `/admin/announcements` でお知らせを CRUD 管理できる
- ログイン後の全ページで、未読のアクティブなお知らせがあればモーダル表示
- 「閉じる」ボタンで既読記録（Turbo Stream でモーダルを即時除去）
- 次回アクセス時は表示されない（デバイスをまたいで既読が引き継がれる）
- サイドバー・モバイルメニューに「お知らせ管理」リンクを追加

## Test plan
- [ ] `/admin/announcements` でお知らせを新規作成できること
- [ ] `is_active: true` + `published_at` が過去のお知らせがログイン後に表示されること
- [ ] `is_active: false` のお知らせは表示されないこと
- [ ] `expires_at` が過去のお知らせは表示されないこと
- [ ] 「閉じる」でモーダルが消え、再読み込みしても表示されないこと
- [ ] 別ユーザーには引き続き表示されること（既読は個人単位）

Closes #80