### PR TITLE
chore: v1.3.0 リリース

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@
 # Ignore Claude Code files
 /claude_conversations.md
 /CLAUDE.md
+
+# Ignore Kamal secrets (contains credentials)
+/.kamal/secrets

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 
-# Ignore Claude conversation logs
+# Ignore Claude Code files
 /claude_conversations.md
+/CLAUDE.md

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem "csv"
 # Web Push notifications [https://github.com/pushpad/web-push]
 gem "web-push", "~> 3.0"
 
+# Markdown rendering [https://github.com/vmg/redcarpet]
+gem "redcarpet"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,7 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redcarpet (3.6.1)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -412,6 +413,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)
+  redcarpet
   rubocop-rails-omakase
   solid_cable
   solid_cache

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,0 +1,49 @@
+module Admin
+  class AnnouncementsController < BaseController
+    before_action :set_announcement, only: [:edit, :update, :destroy]
+
+    def index
+      @announcements = Announcement.order(published_at: :desc)
+    end
+
+    def new
+      @announcement = Announcement.new(published_at: Time.current)
+    end
+
+    def create
+      @announcement = Announcement.new(announcement_params)
+      if @announcement.save
+        redirect_to admin_announcements_path, notice: "お知らせ「#{@announcement.title}」を作成しました。"
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @announcement.update(announcement_params)
+        redirect_to admin_announcements_path, notice: "お知らせ「#{@announcement.title}」を更新しました。"
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      title = @announcement.title
+      @announcement.destroy
+      redirect_to admin_announcements_path, notice: "お知らせ「#{title}」を削除しました。"
+    end
+
+    private
+
+    def set_announcement
+      @announcement = Announcement.find(params[:id])
+    end
+
+    def announcement_params
+      params.require(:announcement).permit(:title, :body, :published_at, :expires_at, :is_active)
+    end
+  end
+end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,0 +1,12 @@
+class AnnouncementsController < ApplicationController
+  before_action :authenticate_user!
+
+  def mark_as_read
+    announcement = Announcement.find(params[:id])
+    current_user.user_announcement_reads.find_or_create_by!(announcement: announcement)
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.remove("announcement-modal") }
+      format.html { redirect_back fallback_location: root_path }
+    end
+  end
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  class BaseController < ActionController::API
+    before_action :authenticate_api_token!
+
+    private
+
+    def authenticate_api_token!
+      token = request.headers["Authorization"]&.sub(/\ABearer /, "")
+      api_token = ENV["TIMESTAMP_API_TOKEN"].presence
+
+      if api_token.blank? || token != api_token
+        render json: { error: "Unauthorized" }, status: :unauthorized
+      end
+    end
+  end
+end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,0 +1,40 @@
+module Api
+  class EventsController < BaseController
+    include TimestampParseable
+
+    def timestamps
+      event = Event.find_by(id: params[:id])
+      return render json: { error: "Event not found" }, status: :not_found unless event
+
+      raw_text = params[:timestamps].to_s
+      lines = raw_text.split("\n").map(&:strip)
+      lines.pop while lines.last&.empty?
+
+      matches = event.matches.order(:played_at, :id)
+
+      if lines.size != matches.size
+        return render json: {
+          error: "行数（#{lines.size}）と試合数（#{matches.size}）が一致しません。"
+        }, status: :unprocessable_entity
+      end
+
+      parsed = lines.map.with_index do |line, i|
+        seconds = parse_timestamp(line)
+        unless seconds
+          return render json: {
+            error: "#{i + 1}行目「#{line}」の形式が不正です。H:MM:SS または MM:SS の形式で入力してください。"
+          }, status: :unprocessable_entity
+        end
+        seconds
+      end
+
+      ActiveRecord::Base.transaction do
+        matches.each_with_index do |match, i|
+          match.update!(video_timestamp: parsed[i])
+        end
+      end
+
+      render json: { message: "OK", updated: matches.size }
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,9 @@ class ApplicationController < ActionController::Base
   # Set user_id in cookies for Action Cable authentication
   before_action :set_user_cookie
 
+  # お知らせモーダル
+  before_action :set_unread_announcement
+
   # ユーザー視点切り替え機能
   helper_method :viewing_as_user, :viewing_as_someone_else?, :can_react?
 
@@ -46,5 +49,14 @@ class ApplicationController < ActionController::Base
     unless current_user&.is_admin?
       redirect_to root_path, alert: "管理者権限が必要です。"
     end
+  end
+
+  # 未読のお知らせを取得（ログイン中のみ）
+  def set_unread_announcement
+    return unless user_signed_in?
+    read_ids = current_user.user_announcement_reads.pluck(:announcement_id)
+    @unread_announcement = Announcement.active
+                                       .where.not(id: read_ids)
+                                       .first
   end
 end

--- a/app/controllers/concerns/timestamp_parseable.rb
+++ b/app/controllers/concerns/timestamp_parseable.rb
@@ -1,0 +1,22 @@
+module TimestampParseable
+  extend ActiveSupport::Concern
+
+  private
+
+  def parse_timestamp(str)
+    return nil if str.blank?
+    parts = str.strip.split(":").map(&:to_i)
+    case parts.size
+    when 3 then parts[0] * 3600 + parts[1] * 60 + parts[2]
+    when 2 then parts[0] * 60 + parts[1]
+    else nil
+    end
+  end
+
+  def format_timestamp(seconds)
+    return "" if seconds.nil?
+    h, remainder = seconds.divmod(3600)
+    m, s = remainder.divmod(60)
+    "#{h}:#{format('%02d', m)}:#{format('%02d', s)}"
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,10 @@ class EventsController < ApplicationController
   end
 
   def show
-    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user).order(played_at: :asc, id: :asc)
+    @per_page = 20
+    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
+                     .order(played_at: :asc, id: :asc)
+                     .page(params[:page]).per(@per_page)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc)
+    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc, id: :asc)
     @rotations = @event.rotations.order(created_at: :asc)
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,7 @@ class EventsController < ApplicationController
   def show
     @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc, id: :asc)
     @rotations = @event.rotations.order(created_at: :asc)
+    @emojis = MasterEmoji.active.ordered
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,7 +15,7 @@ class EventsController < ApplicationController
     @sort = sort
     @per_page = [10, 20, 50].include?(params[:per].to_i) ? params[:per].to_i : 20
 
-    base_scope = sort == "reactions" ? @event.matches.by_reactions : @event.matches.by_oldest
+    base_scope = sort == "reactions" ? @event.matches.by_reactions_oldest : @event.matches.by_oldest
     @matches = base_scope
                  .includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
                  .page(params[:page]).per(@per_page)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,10 @@
+require "net/http"
+
 class EventsController < ApplicationController
+  include TimestampParseable
   before_action :authenticate_user!
-  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps]
-  before_action :set_event, only: [:show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps]
+  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis]
+  before_action :set_event, only: [:show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis]
 
   def index
     @events = Event.includes(:matches).order(held_on: :desc)
@@ -84,6 +87,44 @@ class EventsController < ApplicationController
     redirect_to event_path(@event), notice: "タイムスタンプを保存しました。"
   end
 
+  def trigger_analysis
+    repo = ENV["GITHUB_REPO"].presence
+    workflow_id = ENV["GITHUB_WORKFLOW_ID"].presence
+    token = ENV["GITHUB_TOKEN"].presence
+
+    if repo.blank? || workflow_id.blank? || token.blank?
+      return redirect_to event_path(@event), alert: "GitHub Actions の設定が不完全です（GITHUB_REPO / GITHUB_WORKFLOW_ID / GITHUB_TOKEN を確認してください）。"
+    end
+
+    uri = URI("https://api.github.com/repos/#{repo}/actions/workflows/#{workflow_id}/dispatches")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    req = Net::HTTP::Post.new(uri.path, {
+      "Authorization" => "Bearer #{token}",
+      "Accept" => "application/vnd.github+json",
+      "Content-Type" => "application/json",
+      "X-GitHub-Api-Version" => "2022-11-28"
+    })
+    req.body = {
+      ref: "main",
+      inputs: {
+        event_id: @event.id.to_s,
+        broadcast_url: @event.broadcast_url
+      }
+    }.to_json
+
+    res = http.request(req)
+
+    if res.is_a?(Net::HTTPNoContent)
+      redirect_to event_path(@event), notice: "解析を開始しました。完了後にタイムスタンプが自動登録されます。"
+    else
+      redirect_to event_path(@event), alert: "GitHub Actions のトリガーに失敗しました（HTTP #{res.code}）。"
+    end
+  rescue => e
+    redirect_to event_path(@event), alert: "解析開始でエラーが発生しました: #{e.message}"
+  end
+
   def destroy
     name = @event.name
 
@@ -111,20 +152,4 @@ class EventsController < ApplicationController
     params.require(:event).permit(:name, :held_on, :description, :broadcast_url)
   end
 
-  def parse_timestamp(str)
-    return nil if str.blank?
-    parts = str.strip.split(':').map(&:to_i)
-    case parts.size
-    when 3 then parts[0] * 3600 + parts[1] * 60 + parts[2]
-    when 2 then parts[0] * 60 + parts[1]
-    else nil
-    end
-  end
-
-  def format_timestamp(seconds)
-    return '' if seconds.nil?
-    h, remainder = seconds.divmod(3600)
-    m, s = remainder.divmod(60)
-    "#{h}:#{format('%02d', m)}:#{format('%02d', s)}"
-  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit]).order(played_at: :asc, id: :asc)
+    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user).order(played_at: :asc, id: :asc)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,10 +11,14 @@ class EventsController < ApplicationController
   end
 
   def show
+    sort = params[:sort].presence_in(%w[oldest reactions]) || "oldest"
+    @sort = sort
     @per_page = [10, 20, 50].include?(params[:per].to_i) ? params[:per].to_i : 20
-    @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
-                     .order(played_at: :asc, id: :asc)
-                     .page(params[:page]).per(@per_page)
+
+    base_scope = sort == "reactions" ? @event.matches.by_reactions : @event.matches.by_oldest
+    @matches = base_scope
+                 .includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
+                 .page(params[:page]).per(@per_page)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @per_page = 20
+    @per_page = [10, 20, 50].include?(params[:per].to_i) ? params[:per].to_i : 20
     @matches = @event.matches.includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
                      .order(played_at: :asc, id: :asc)
                      .page(params[:page]).per(@per_page)

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -5,7 +5,11 @@ class MatchesController < ApplicationController
   before_action :set_match, only: [:show, :edit, :update, :destroy]
 
   def index
-    @matches = Match.includes(:event, { match_players: [:user, :mobile_suit] }, { reactions: :user }).order(played_at: :desc, id: :desc)
+    sort = params[:sort].presence_in(%w[latest reactions]) || "latest"
+    @sort = sort
+
+    base_scope = sort == "reactions" ? Match.by_reactions : Match.by_latest
+    @matches = base_scope.includes(:event, { match_players: [:user, :mobile_suit] }, { reactions: :user })
 
     # フィルター: イベント（複数選択対応）
     if params[:events].present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,23 @@
 module ApplicationHelper
+  MARKDOWN_RENDERER = Redcarpet::Markdown.new(
+    Redcarpet::Render::HTML.new(hard_wrap: true, safe_links_only: true),
+    autolink: true,
+    tables: true,
+    fenced_code_blocks: true,
+    strikethrough: true,
+    no_intra_emphasis: true
+  )
+
+  def render_markdown(text)
+    return "" if text.blank?
+    sanitize(
+      MARKDOWN_RENDERER.render(text),
+      tags: %w[p br strong em a ul ol li h1 h2 h3 h4 h5 blockquote code pre s del table thead tbody tr th td hr],
+      attributes: %w[href]
+    )
+  end
+
+
   def cost_badge(cost)
     style = case cost.to_i
     when 3000

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,19 @@
+class Announcement < ApplicationRecord
+  has_many :user_announcement_reads, dependent: :destroy
+  has_many :read_by_users, through: :user_announcement_reads, source: :user
+
+  validates :title, presence: true
+  validates :body, presence: true
+  validates :published_at, presence: true
+
+  scope :active, -> {
+    where(is_active: true)
+      .where("published_at <= ?", Time.current)
+      .where("expires_at IS NULL OR expires_at >= ?", Time.current)
+      .order(published_at: :desc)
+  }
+
+  def read_by?(user)
+    user_announcement_reads.exists?(user: user)
+  end
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -7,6 +7,11 @@ class Match < ApplicationRecord
 
   accepts_nested_attributes_for :match_players
 
+  # Scopes
+  scope :by_latest,    -> { order(played_at: :desc, id: :desc) }
+  scope :by_reactions, -> { order(reactions_count: :desc, played_at: :desc, id: :desc) }
+  scope :by_oldest,    -> { order(played_at: :asc, id: :asc) }
+
   # Validations
   validates :played_at, presence: true
   validates :winning_team, presence: true, inclusion: { in: [1, 2] }

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -8,9 +8,10 @@ class Match < ApplicationRecord
   accepts_nested_attributes_for :match_players
 
   # Scopes
-  scope :by_latest,    -> { order(played_at: :desc, id: :desc) }
-  scope :by_reactions, -> { order(reactions_count: :desc, played_at: :desc, id: :desc) }
-  scope :by_oldest,    -> { order(played_at: :asc, id: :asc) }
+  scope :by_latest,           -> { order(played_at: :desc, id: :desc) }
+  scope :by_reactions,        -> { order(reactions_count: :desc, played_at: :desc, id: :desc) }
+  scope :by_reactions_oldest, -> { order(reactions_count: :desc, played_at: :asc, id: :asc) }
+  scope :by_oldest,           -> { order(played_at: :asc, id: :asc) }
 
   # Validations
   validates :played_at, presence: true

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,7 +1,7 @@
 class Reaction < ApplicationRecord
   # Associations
   belongs_to :user
-  belongs_to :match
+  belongs_to :match, counter_cache: true
   belongs_to :master_emoji
 
   # Validations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
   has_many :match_players, dependent: :destroy
   has_many :push_subscriptions, dependent: :destroy
   has_many :reactions, dependent: :destroy
+  has_many :user_announcement_reads, dependent: :destroy
+  has_many :read_announcements, through: :user_announcement_reads, source: :announcement
 
   # Validations
   validates :username, presence: true, uniqueness: { case_sensitive: false },

--- a/app/models/user_announcement_read.rb
+++ b/app/models/user_announcement_read.rb
@@ -1,0 +1,6 @@
+class UserAnnouncementRead < ApplicationRecord
+  belongs_to :user
+  belongs_to :announcement
+
+  validates :user_id, uniqueness: { scope: :announcement_id }
+end

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -29,6 +29,32 @@ class PushNotificationService
       )
     end
 
+    def notify_timestamps_registered(event:, count:)
+      User.where(is_admin: true).find_each do |user|
+        next unless user.push_notifications_enabled?
+
+        SendPushNotificationJob.perform_later(
+          user_id: user.id,
+          title: "タイムスタンプ登録完了",
+          body: "#{event.name} の #{count} 試合分が登録されました",
+          path: "/events/#{event.id}"
+        )
+      end
+    end
+
+    def notify_timestamps_failed(event:, error:)
+      User.where(is_admin: true).find_each do |user|
+        next unless user.push_notifications_enabled?
+
+        SendPushNotificationJob.perform_later(
+          user_id: user.id,
+          title: "タイムスタンプ登録失敗",
+          body: "#{event.name}: #{error}",
+          path: "/events/#{event.id}"
+        )
+      end
+    end
+
     def notify_rotation_activated(rotation:)
       player_ids = collect_player_ids(rotation)
       return if player_ids.empty?

--- a/app/views/admin/announcements/_form.html.erb
+++ b/app/views/admin/announcements/_form.html.erb
@@ -16,7 +16,8 @@
 
   <div>
     <%= form.label :body, "本文", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= form.text_area :body, rows: 8, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "お知らせの内容を入力してください。改行はそのまま表示されます。" %>
+    <%= form.text_area :body, rows: 8, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 font-mono", placeholder: "お知らせの内容を入力してください。Markdown が使えます。" %>
+    <p class="mt-1 text-xs text-gray-500">Markdown 対応: **太字** / *斜体* / # 見出し / - リスト / `コード` / [リンク](URL) など</p>
   </div>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/app/views/admin/announcements/_form.html.erb
+++ b/app/views/admin/announcements/_form.html.erb
@@ -1,0 +1,43 @@
+<%= form_with model: [:admin, announcement], class: "space-y-6" do |form| %>
+  <% if announcement.errors.any? %>
+    <div class="bg-red-50 border border-red-200 rounded-md p-4">
+      <ul class="list-disc list-inside text-sm text-red-600">
+        <% announcement.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :title, "タイトル", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.text_field :title, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "例: v1.3.0 アップデートのお知らせ" %>
+  </div>
+
+  <div>
+    <%= form.label :body, "本文", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.text_area :body, rows: 8, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", placeholder: "お知らせの内容を入力してください。改行はそのまま表示されます。" %>
+  </div>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div>
+      <%= form.label :published_at, "公開開始日時", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.datetime_local_field :published_at, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", value: announcement.published_at&.strftime("%Y-%m-%dT%H:%M") %>
+    </div>
+    <div>
+      <%= form.label :expires_at, "公開終了日時（任意）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.datetime_local_field :expires_at, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500", value: announcement.expires_at&.strftime("%Y-%m-%dT%H:%M") %>
+      <p class="mt-1 text-xs text-gray-500">空白の場合は期限なし</p>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-3">
+    <%= form.check_box :is_active, class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 h-4 w-4" %>
+    <%= form.label :is_active, "有効にする（チェックで表示ON）", class: "text-sm font-medium text-gray-700" %>
+  </div>
+
+  <div class="flex gap-3">
+    <%= form.submit announcement.new_record? ? "作成" : "更新", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+    <%= link_to "キャンセル", admin_announcements_path, class: "bg-gray-100 hover:bg-gray-200 text-gray-700 font-semibold py-2 px-4 rounded text-sm" %>
+  </div>
+<% end %>

--- a/app/views/admin/announcements/edit.html.erb
+++ b/app/views/admin/announcements/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="mb-6">
+    <%= link_to "← お知らせ一覧に戻る", admin_announcements_path, class: "text-blue-600 hover:text-blue-500 text-sm" %>
+  </div>
+  <h1 class="text-2xl font-bold text-gray-900 mb-6">お知らせを編集</h1>
+  <div class="bg-white shadow rounded-lg p-6">
+    <%= render "form", announcement: @announcement %>
+  </div>
+</div>

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -1,0 +1,53 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+    <div>
+      <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">お知らせ管理</h1>
+      <p class="mt-2 text-sm text-gray-600">アプリ起動時に表示されるお知らせを管理できます</p>
+    </div>
+    <%= link_to "新規作成", new_admin_announcement_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+  </div>
+
+  <% if @announcements.any? %>
+    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">タイトル</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">状態</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">公開期間</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">既読数</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">操作</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <% @announcements.each do |announcement| %>
+            <tr>
+              <td class="px-6 py-4 text-sm font-medium text-gray-900"><%= announcement.title %></td>
+              <td class="px-6 py-4 whitespace-nowrap">
+                <% if announcement.is_active %>
+                  <span class="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">有効</span>
+                <% else %>
+                  <span class="px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-500">無効</span>
+                <% end %>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-500">
+                <%= announcement.published_at.strftime('%Y/%m/%d %H:%M') %> 〜
+                <%= announcement.expires_at ? announcement.expires_at.strftime('%Y/%m/%d %H:%M') : "期限なし" %>
+              </td>
+              <td class="px-6 py-4 text-sm text-gray-500"><%= announcement.user_announcement_reads.count %>人</td>
+              <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                <%= link_to "編集", edit_admin_announcement_path(announcement), class: "text-blue-600 hover:text-blue-900 mr-3" %>
+                <%= button_to "削除", admin_announcement_path(announcement), method: :delete, data: { turbo_confirm: "お知らせ「#{announcement.title}」を削除しますか？" }, class: "text-red-600 hover:text-red-900" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <div class="text-center py-12 bg-white rounded-lg shadow">
+      <p class="text-gray-500">お知らせがまだありません</p>
+      <%= link_to "最初のお知らせを作成する", new_admin_announcement_path, class: "mt-4 inline-block text-indigo-600 hover:text-indigo-500" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/announcements/new.html.erb
+++ b/app/views/admin/announcements/new.html.erb
@@ -1,0 +1,9 @@
+<div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="mb-6">
+    <%= link_to "← お知らせ一覧に戻る", admin_announcements_path, class: "text-blue-600 hover:text-blue-500 text-sm" %>
+  </div>
+  <h1 class="text-2xl font-bold text-gray-900 mb-6">お知らせを作成</h1>
+  <div class="bg-white shadow rounded-lg p-6">
+    <%= render "form", announcement: @announcement %>
+  </div>
+</div>

--- a/app/views/announcements/_modal.html.erb
+++ b/app/views/announcements/_modal.html.erb
@@ -1,0 +1,28 @@
+<div id="announcement-modal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+  <%# オーバーレイ（背景） %>
+  <div class="absolute inset-0 bg-black/50"></div>
+
+  <%# モーダル本体 %>
+  <div class="relative bg-white rounded-2xl shadow-2xl w-full max-w-md mx-auto overflow-hidden">
+    <%# ヘッダー %>
+    <div class="bg-indigo-600 px-6 py-4">
+      <div class="flex items-center gap-2">
+        <span class="text-white text-lg">📢</span>
+        <h2 class="text-white font-bold text-lg leading-tight"><%= announcement.title %></h2>
+      </div>
+    </div>
+
+    <%# 本文 %>
+    <div class="px-6 py-5">
+      <div class="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed"><%= announcement.body %></div>
+    </div>
+
+    <%# フッター %>
+    <div class="px-6 pb-6 flex justify-end">
+      <%= button_to "閉じる",
+            mark_as_read_announcement_path(announcement),
+            method: :post,
+            class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-6 rounded-lg text-sm transition" %>
+    </div>
+  </div>
+</div>

--- a/app/views/announcements/_modal.html.erb
+++ b/app/views/announcements/_modal.html.erb
@@ -13,9 +13,30 @@
     </div>
 
     <%# 本文 %>
-    <div class="px-6 py-5">
-      <div class="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed"><%= announcement.body %></div>
+    <div class="px-6 py-5 max-h-96 overflow-y-auto">
+      <div class="announcement-body text-sm text-gray-700 leading-relaxed"><%= render_markdown(announcement.body) %></div>
     </div>
+
+    <style>
+      .announcement-body p { margin-bottom: 0.75em; }
+      .announcement-body p:last-child { margin-bottom: 0; }
+      .announcement-body h1, .announcement-body h2, .announcement-body h3 { font-weight: 700; margin-bottom: 0.5em; margin-top: 1em; }
+      .announcement-body h1 { font-size: 1.25em; }
+      .announcement-body h2 { font-size: 1.1em; }
+      .announcement-body h3 { font-size: 1em; }
+      .announcement-body strong { font-weight: 700; }
+      .announcement-body em { font-style: italic; }
+      .announcement-body ul { list-style-type: disc; padding-left: 1.5em; margin-bottom: 0.75em; }
+      .announcement-body ol { list-style-type: decimal; padding-left: 1.5em; margin-bottom: 0.75em; }
+      .announcement-body li { margin-bottom: 0.25em; }
+      .announcement-body a { color: #4F46E5; text-decoration: underline; }
+      .announcement-body code { background: #F3F4F6; padding: 0.1em 0.3em; border-radius: 0.25em; font-family: monospace; font-size: 0.9em; }
+      .announcement-body pre { background: #F3F4F6; padding: 0.75em; border-radius: 0.5em; overflow-x: auto; margin-bottom: 0.75em; }
+      .announcement-body pre code { background: none; padding: 0; }
+      .announcement-body blockquote { border-left: 3px solid #E5E7EB; padding-left: 1em; color: #6B7280; margin-bottom: 0.75em; }
+      .announcement-body hr { border: none; border-top: 1px solid #E5E7EB; margin: 1em 0; }
+      .announcement-body del, .announcement-body s { text-decoration: line-through; }
+    </style>
 
     <%# フッター %>
     <div class="px-6 pb-6 flex justify-end">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -94,8 +94,20 @@
           <div>
             <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
             <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
+            <div class="flex items-center gap-2 text-sm text-gray-600 mt-2">
+              <span>ソート:</span>
+              <% [["oldest", "試合順"], ["reactions", "リアクション順"]].each do |value, label| %>
+                <% if value == @sort %>
+                  <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
+                <% else %>
+                  <%= link_to label,
+                        event_path(@event, sort: value, per: @per_page),
+                        class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
+                <% end %>
+              <% end %>
+            </div>
           </div>
-          <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, per: n) } %>
+          <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, sort: @sort, per: n) } %>
         </div>
       </div>
       <div class="border-t border-gray-200">
@@ -177,8 +189,8 @@
           </ul>
           <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
             <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
-              <%= paginate @matches, params: { per: @per_page } %>
-              <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, per: n) } %>
+              <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
+              <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, sort: @sort, per: n) } %>
             </div>
           <% end %>
         <% else %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -23,6 +23,7 @@
           <%= link_to "ローテーション作成", new_event_rotation_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <% if @event.broadcast_url.present? %>
             <%= link_to "タイムスタンプ一括設定", edit_timestamps_event_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+            <%= button_to "解析開始", trigger_analysis_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で動画解析を開始しますか？完了後にタイムスタンプが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <% end %>
           <%= link_to "編集", edit_event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= button_to "削除", event_path(@event), method: :delete, data: { turbo_confirm: "イベント「#{@event.name}」を削除してもよろしいですか？関連する試合やローテーションもすべて削除されます。" }, class: "bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-sm" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -90,8 +90,13 @@
 
     <div class="bg-white shadow overflow-hidden sm:rounded-lg">
       <div class="px-4 py-5 sm:px-6">
-        <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
-        <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
+            <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
+          </div>
+          <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, per: n) } %>
+        </div>
       </div>
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
@@ -173,16 +178,7 @@
           <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
             <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
               <%= paginate @matches, params: { per: @per_page } %>
-              <div class="flex items-center gap-2 text-sm text-gray-600">
-                <span>表示件数:</span>
-                <% [10, 20, 50].each do |n| %>
-                  <% if n == @per_page %>
-                    <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
-                  <% else %>
-                    <%= link_to n, event_path(@event, per: n), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
-                  <% end %>
-                <% end %>
-              </div>
+              <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, per: n) } %>
             </div>
           <% end %>
         <% else %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -91,17 +91,18 @@
     <div class="bg-white shadow overflow-hidden sm:rounded-lg">
       <div class="px-4 py-5 sm:px-6">
         <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
-        <p class="mt-1 text-sm text-gray-500">全 <%= @matches.count %> 試合</p>
+        <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
       </div>
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
           <ul class="divide-y divide-gray-200">
+            <% match_offset = (@matches.current_page - 1) * @matches.limit_value %>
             <% @matches.each_with_index do |match, index| %>
               <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
                   <div class="flex items-center gap-2 mb-2">
-                    <span class="text-sm font-semibold text-gray-900">第<%= index + 1 %>試合</span>
+                    <span class="text-sm font-semibold text-gray-900">第<%= match_offset + index + 1 %>試合</span>
                     <% if match.rotation_match&.started_at %>
                       <span class="text-xs text-gray-500"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
                     <% elsif match.played_at %>
@@ -169,6 +170,11 @@
               <% end %>
             <% end %>
           </ul>
+          <% if @matches.total_pages > 1 %>
+            <div class="px-4 py-4 flex justify-center border-t border-gray-200">
+              <%= paginate @matches %>
+            </div>
+          <% end %>
         <% else %>
           <div class="px-4 py-3 text-center">
             <p class="text-sm text-gray-500">まだ対戦記録がありません</p>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -97,6 +97,7 @@
         <% if @matches.any? %>
           <ul class="divide-y divide-gray-200">
             <% @matches.each_with_index do |match, index| %>
+              <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
                   <div class="flex items-center gap-2 mb-2">
@@ -160,6 +161,9 @@
                         </div>
                       <% end %>
                     </div>
+                  </div>
+                  <div onclick="event.stopPropagation()">
+                    <%= render "reactions/reaction_bar", match: match, compact: true, emojis: @emojis %>
                   </div>
                 </li>
               <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -170,9 +170,19 @@
               <% end %>
             <% end %>
           </ul>
-          <% if @matches.total_pages > 1 %>
-            <div class="px-4 py-4 flex justify-center border-t border-gray-200">
-              <%= paginate @matches %>
+          <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
+            <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
+              <%= paginate @matches, params: { per: @per_page } %>
+              <div class="flex items-center gap-2 text-sm text-gray-600">
+                <span>表示件数:</span>
+                <% [10, 20, 50].each do |n| %>
+                  <% if n == @per_page %>
+                    <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
+                  <% else %>
+                    <%= link_to n, event_path(@event, per: n), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
+                  <% end %>
+                <% end %>
+              </div>
             </div>
           <% end %>
         <% else %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -117,8 +117,8 @@
                     </div>
                   <% end %>
                   <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
-                    <% team1_players = match.match_players.where(team_number: 1).order(:position) %>
-                    <% team2_players = match.match_players.where(team_number: 2).order(:position) %>
+                    <% team1_players = match.match_players.to_a.select { |p| p.team_number == 1 }.sort_by(&:position) %>
+                    <% team2_players = match.match_players.to_a.select { |p| p.team_number == 2 }.sort_by(&:position) %>
 
                     <!-- Team 1 -->
                     <div class="<%= match.winning_team == 1 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,6 +61,7 @@
                 </div>
               </div>
 
+              <%= link_to "お知らせ管理", admin_announcements_path, class: "sidebar-nav-item #{current_page?(admin_announcements_path) ? 'active' : ''}" %>
               <%= link_to "機体マスタ", admin_mobile_suits_path, class: "sidebar-nav-item #{current_page?(admin_mobile_suits_path) ? 'active' : ''}" %>
               <%= link_to "スタンプマスタ", admin_master_emojis_path, class: "sidebar-nav-item #{current_page?(admin_master_emojis_path) ? 'active' : ''}" %>
               <%= link_to "ユーザー管理", admin_users_path, class: "sidebar-nav-item #{current_page?(admin_users_path) ? 'active' : ''}" %>
@@ -306,6 +307,7 @@
             <% if current_user.is_admin? %>
               <div class="border-t border-indigo-400 mt-3 pt-3">
                 <div class="px-4 py-2 text-xs font-semibold text-indigo-200 uppercase tracking-wider">管理者メニュー</div>
+                <%= link_to "お知らせ管理", admin_announcements_path, class: "mobile-menu-item #{current_page?(admin_announcements_path) ? 'active' : ''}" %>
                 <%= link_to "機体マスタ", admin_mobile_suits_path, class: "mobile-menu-item #{current_page?(admin_mobile_suits_path) ? 'active' : ''}" %>
                 <%= link_to "スタンプマスタ", admin_master_emojis_path, class: "mobile-menu-item #{current_page?(admin_master_emojis_path) ? 'active' : ''}" %>
                 <%= link_to "ユーザー管理", admin_users_path, class: "mobile-menu-item #{current_page?(admin_users_path) ? 'active' : ''}" %>
@@ -403,5 +405,10 @@
     <main class="<%= 'main-content-with-sidebar' if user_signed_in? %>">
       <%= yield %>
     </main>
+
+    <%# お知らせモーダル %>
+    <% if @unread_announcement %>
+      <%= render "announcements/modal", announcement: @unread_announcement %>
+    <% end %>
   </body>
 </html>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -83,8 +83,22 @@
 
   <div class="bg-white shadow sm:rounded-lg">
     <div class="px-4 py-3 border-b border-gray-200 flex flex-wrap items-center justify-between gap-2">
-      <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
-      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
+      <div class="flex flex-wrap items-center gap-4">
+        <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
+        <div class="flex items-center gap-2 text-sm text-gray-600">
+          <span>ソート:</span>
+          <% [["latest", "最新順"], ["reactions", "リアクション順"]].each do |value, label| %>
+            <% if value == @sort %>
+              <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
+            <% else %>
+              <%= link_to label,
+                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]),
+                    class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -170,8 +184,8 @@
     </ul>
     <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
       <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
-        <%= paginate @matches, params: { per: @per_page } %>
-        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
+        <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
       </div>
     <% end %>
   </div>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -84,16 +84,7 @@
   <div class="bg-white shadow sm:rounded-lg">
     <div class="px-4 py-3 border-b border-gray-200 flex flex-wrap items-center justify-between gap-2">
       <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
-      <div class="flex items-center gap-2 text-sm text-gray-600">
-        <span>表示件数:</span>
-        <% [10, 20, 50].each do |n| %>
-          <% if n == @per_page %>
-            <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
-          <% else %>
-            <%= link_to n, matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
-          <% end %>
-        <% end %>
-      </div>
+      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -177,28 +168,17 @@
         </li>
       <% end %>
     </ul>
+    <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
+      <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
+        <%= paginate @matches, params: { per: @per_page } %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
+      </div>
+    <% end %>
   </div>
 
   <% if @matches.empty? %>
     <div class="text-center py-12">
       <p class="text-gray-500">対戦記録がまだありません</p>
-    </div>
-  <% end %>
-
-  <!-- Pagination -->
-  <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
-    <div class="mt-6 flex flex-col items-center gap-4">
-      <%= paginate @matches, params: { per: @per_page } %>
-      <div class="flex items-center gap-2 text-sm text-gray-600">
-        <span>表示件数:</span>
-        <% [10, 20, 50].each do |n| %>
-          <% if n == @per_page %>
-            <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
-          <% else %>
-            <%= link_to n, matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
-          <% end %>
-        <% end %>
-      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -82,6 +82,19 @@
   <% end %>
 
   <div class="bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-3 border-b border-gray-200 flex flex-wrap items-center justify-between gap-2">
+      <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
+      <div class="flex items-center gap-2 text-sm text-gray-600">
+        <span>表示件数:</span>
+        <% [10, 20, 50].each do |n| %>
+          <% if n == @per_page %>
+            <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
+          <% else %>
+            <%= link_to n, matches_path(per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
         <li class="<%= current_user.is_admin? ? 'pl-10' : '' %> relative">

--- a/app/views/shared/_per_page_selector.html.erb
+++ b/app/views/shared/_per_page_selector.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (per_page:, url_builder:) %>
+<div class="flex items-center gap-2 text-sm text-gray-600">
+  <span>表示件数:</span>
+  <% [10, 20, 50].each do |n| %>
+    <% if n == per_page %>
+      <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
+    <% else %>
+      <%= link_to n, url_builder.call(n), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -25,6 +25,10 @@ env:
   secret:
     - RAILS_MASTER_KEY
     - POSTGRES_PASSWORD
+    - TIMESTAMP_API_TOKEN
+    - GITHUB_TOKEN
+    - GITHUB_REPO
+    - GITHUB_WORKFLOW_ID
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     SOLID_QUEUE_IN_PUMA: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,11 +37,21 @@ Rails.application.routes.draw do
   # Statistics
   get "statistics", to: "statistics#index", as: :statistics
 
+  # API
+  namespace :api do
+    resources :events, only: [] do
+      member do
+        post :timestamps
+      end
+    end
+  end
+
   # Events
   resources :events do
     member do
       get :edit_timestamps
       patch :update_timestamps
+      post :trigger_analysis
     end
     resources :matches, only: [:new, :create]
     resources :rotations, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,8 +83,16 @@ Rails.application.routes.draw do
     end
   end
 
+  # Announcements
+  resources :announcements, only: [] do
+    member do
+      post :mark_as_read
+    end
+  end
+
   # Admin
   namespace :admin do
+    resources :announcements, except: [:show]
     resources :users, except: [:show] do
       member do
         post :switch_view

--- a/db/migrate/20260219232110_add_reactions_count_to_matches.rb
+++ b/db/migrate/20260219232110_add_reactions_count_to_matches.rb
@@ -1,0 +1,11 @@
+class AddReactionsCountToMatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :matches, :reactions_count, :integer, default: 0, null: false
+    execute <<~SQL
+      UPDATE matches
+      SET reactions_count = (
+        SELECT COUNT(*) FROM reactions WHERE reactions.match_id = matches.id
+      )
+    SQL
+  end
+end

--- a/db/migrate/20260219235249_create_announcements.rb
+++ b/db/migrate/20260219235249_create_announcements.rb
@@ -1,0 +1,13 @@
+class CreateAnnouncements < ActiveRecord::Migration[8.1]
+  def change
+    create_table :announcements do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.datetime :published_at, null: false
+      t.datetime :expires_at
+      t.boolean :is_active, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260219235250_create_user_announcement_reads.rb
+++ b/db/migrate/20260219235250_create_user_announcement_reads.rb
@@ -1,0 +1,11 @@
+class CreateUserAnnouncementReads < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_announcement_reads do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :announcement, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :user_announcement_reads, [:user_id, :announcement_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_19_232110) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_235250) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "announcements", force: :cascade do |t|
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at"
+    t.boolean "is_active", default: false, null: false
+    t.datetime "published_at", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "broadcast_url"
@@ -131,6 +141,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_232110) do
     t.index ["event_id"], name: "index_rotations_on_event_id"
   end
 
+  create_table "user_announcement_reads", force: :cascade do |t|
+    t.bigint "announcement_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["announcement_id"], name: "index_user_announcement_reads_on_announcement_id"
+    t.index ["user_id", "announcement_id"], name: "index_user_announcement_reads_on_user_id_and_announcement_id", unique: true
+    t.index ["user_id"], name: "index_user_announcement_reads_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "encrypted_password", default: "", null: false
@@ -161,4 +181,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_232110) do
   add_foreign_key "rotation_matches", "users", column: "team2_player2_id"
   add_foreign_key "rotations", "events"
   add_foreign_key "rotations", "rotations", column: "base_rotation_id"
+  add_foreign_key "user_announcement_reads", "announcements"
+  add_foreign_key "user_announcement_reads", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_15_234121) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_232110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_15_234121) do
     t.datetime "created_at", null: false
     t.bigint "event_id", null: false
     t.datetime "played_at", null: false
+    t.integer "reactions_count", default: 0, null: false
     t.bigint "rotation_match_id"
     t.datetime "updated_at", null: false
     t.integer "video_timestamp"


### PR DESCRIPTION
## Summary
release/v1.3.0 を main にマージするリリースPRです。

## 主な変更
- イベント詳細画面でリアクション（スタンプ）を追加・削除できるようになった
- 試合一覧・イベント詳細にリアクション数順ソートを追加
- 対戦履歴の表示件数セレクタをリスト上部にも追加
- アプリ起動時のお知らせモーダル機能を追加（管理者が Markdown で作成・管理）
- イベント詳細の試合表示順が不安定だった問題を修正
- タイムスタンプ自動登録 API と管理画面への解析開始ボタンを追加
- タイムスタンプ登録完了・失敗時に管理者へ Web Push 通知を送信

## 関連Issue・PR
- #70
- #73
- #75
- #77
- #79
- #81