### PR TITLE
fix: GitHub Actions トリガー設定の修正

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -27,11 +27,13 @@ env:
     - POSTGRES_PASSWORD
     - TIMESTAMP_API_TOKEN
     - GITHUB_TOKEN
-    - GITHUB_REPO
-    - GITHUB_WORKFLOW_ID
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     SOLID_QUEUE_IN_PUMA: true
+
+    # GitHub Actions integration (non-secret config)
+    GITHUB_REPO: sp8783/exvs2ib-replay-parser-kgy
+    GITHUB_WORKFLOW_ID: analyze.yml
 
     # Database configuration
     DB_HOST: vsmobile-kgy-db


### PR DESCRIPTION
## Summary
- `GITHUB_REPO` と `GITHUB_WORKFLOW_ID` を secret から clear（平文）に移動し、値を直接 deploy.yml に設定

## 原因
`deploy.yml` の `env.secret` に `GITHUB_REPO`・`GITHUB_WORKFLOW_ID` が含まれていたため、デプロイ時に shell の環境変数として設定する必要があった。これらは秘密情報ではなく単なる設定値なので、`env.clear` に移動して値を直接記述するのが適切。

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `GITHUB_REPO` | `env.secret`（shell 環境変数から注入が必要） | `env.clear: sp8783/exvs2ib-replay-parser-kgy` |
| `GITHUB_WORKFLOW_ID` | `env.secret`（shell 環境変数から注入が必要） | `env.clear: analyze.yml` |

## Test plan
- [ ] `kamal deploy` が環境変数なしで成功する
- [ ] 「解析開始」ボタンで GitHub Actions がトリガーされる