### PR TITLE
feat: タイムスタンプ解析失敗時の通知エンドポイントを追加

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -37,5 +37,14 @@ module Api
       PushNotificationService.notify_timestamps_registered(event: event, count: matches.size)
       render json: { message: "OK", updated: matches.size }
     end
+
+    def notify_failure
+      event = Event.find_by(id: params[:id])
+      return render json: { error: "Event not found" }, status: :not_found unless event
+
+      error_msg = params[:error].presence || "不明なエラー"
+      PushNotificationService.notify_timestamps_failed(event: event, error: error_msg)
+      render json: { message: "OK" }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
     resources :events, only: [] do
       member do
         post :timestamps
+        post :notify_failure
       end
     end
   end


### PR DESCRIPTION
## Summary
- `POST /api/events/:id/notify_failure` エンドポイントを新設
- GitHub Actions ワークフロー自体が失敗した場合に呼び出し、管理者へ Web Push 通知を送る
- 認証は既存の `TIMESTAMP_API_TOKEN` を使用

## Test plan
- [ ] `exvs2ib-replay-parser-kgy` の `analyze.yml` に `if: failure()` ステップを追加し、失敗時に通知が届くことを確認
- [ ] 認証トークンが不正な場合に 401 が返ることを確認

Closes #84