### PR TITLE
fix: リアクション順ソート時の「第○試合」採番を実施順に修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,9 @@ class EventsController < ApplicationController
                  .page(params[:page]).per(@per_page)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
+
+    ordered_ids = @event.matches.order(:played_at, :id).pluck(:id)
+    @match_numbers = ordered_ids.each_with_index.to_h { |id, i| [id, i + 1] }
   end
 
   def new

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -113,13 +113,12 @@
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
           <ul class="divide-y divide-gray-200">
-            <% match_offset = (@matches.current_page - 1) * @matches.limit_value %>
-            <% @matches.each_with_index do |match, index| %>
+            <% @matches.each do |match| %>
               <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
                   <div class="flex items-center gap-2 mb-2">
-                    <span class="text-sm font-semibold text-gray-900">第<%= match_offset + index + 1 %>試合</span>
+                    <span class="text-sm font-semibold text-gray-900">第<%= @match_numbers[match.id] %>試合</span>
                     <% if match.rotation_match&.started_at %>
                       <span class="text-xs text-gray-500"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
                     <% elsif match.played_at %>


### PR DESCRIPTION
## Summary
- ソート順に関わらず「第○試合」を実施順（played_at / id 昇順）に基づく番号で表示するよう修正

## 原因
`match_offset + index + 1` はページネーション内の連番のため、リアクション順ソート時に実際の試合番号とズレていた

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `events_controller.rb` | `@match_numbers`（match_id => 実施順番号のマップ）を事前計算 |
| `events/show.html.erb` | `match_offset + index + 1` を `@match_numbers[match.id]` に置き換え |

## Test plan
- [ ] 試合順ソート時に「第○試合」が正しく表示される
- [ ] リアクション順ソート時に「第○試合」が実施順の番号で表示される
- [ ] ページネーションをまたいでも番号が正しい

Closes #86