### PR TITLE
chore: v1.3.1 リリース

### DIFF
--- a/.brakeman.ignore
+++ b/.brakeman.ignore
@@ -1,0 +1,16 @@
+{
+  "ignored_warnings": [
+    {
+      "fingerprint": "0a69f61fc7e2ba08776809a44459895221235e36bc4c1ba19137df9ba61605c0",
+      "note": "Simple https?:// regex in format validation; no ReDoS risk"
+    },
+    {
+      "fingerprint": "1f36024b68c580649e98c6afa19a7aabfb225b7c6649bb61328273a4e2728b71",
+      "note": "broadcast_url is admin-only input validated to start with http(s)://"
+    },
+    {
+      "fingerprint": "b44cb82aa09e5a06caf26cb2d5969066628ab35501ba4807677f0e7241a34e54",
+      "note": "video_url is derived from broadcast_url which is admin-only and validated"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager
+        run: bin/brakeman --no-pager -i .brakeman.ignore
       
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -13,3 +13,12 @@ KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 # PostgreSQL password (set this environment variable before running kamal)
 # Generate a secure password and run: export POSTGRES_PASSWORD=your_secure_password
 POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+
+# Timestamp API token (used to authenticate requests to the timestamp registration endpoint)
+# Generate any secure random string and run: export TIMESTAMP_API_TOKEN=your_token
+TIMESTAMP_API_TOKEN=$TIMESTAMP_API_TOKEN
+
+# GitHub Actions integration (used to trigger the timestamp analysis workflow)
+# Personal access token with 'actions:write' scope on exvs2ib-replay-parser-kgy
+# export GITHUB_TOKEN=your_github_pat
+GITHUB_TOKEN=$GITHUB_TOKEN

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.2)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class AnnouncementsController < BaseController
-    before_action :set_announcement, only: [:edit, :update, :destroy]
+    before_action :set_announcement, only: [ :edit, :update, :destroy ]
 
     def index
       @announcements = Announcement.order(published_at: :desc)

--- a/app/controllers/admin/imports_controller.rb
+++ b/app/controllers/admin/imports_controller.rb
@@ -1,8 +1,7 @@
-require 'csv'
+require "csv"
 
 module Admin
   class ImportsController < BaseController
-
     def new
     end
 
@@ -21,12 +20,12 @@ module Admin
         created_users = Set.new
         row_number = 0
 
-        CSV.foreach(file.path, headers: true, encoding: 'UTF-8') do |row|
+        CSV.foreach(file.path, headers: true, encoding: "UTF-8") do |row|
           begin
             row_number += 1
             # 日付からイベントを取得または作成
             # 試合の順序を保持するため、行番号を秒として加算
-            played_at = parse_date(row['日付']) + row_number.seconds
+            played_at = parse_date(row["日付"]) + row_number.seconds
             event_date = played_at.to_date
 
             event = Event.find_or_create_by(held_on: event_date) do |e|
@@ -40,7 +39,7 @@ module Admin
                 created_users << player_name
               end
             }
-            [row['プレイヤー1'], row['プレイヤー2'], row['プレイヤー3'], row['プレイヤー4']].each(&before_import)
+            [ row["プレイヤー1"], row["プレイヤー2"], row["プレイヤー3"], row["プレイヤー4"] ].each(&before_import)
 
             import_match(row, event)
             imported_count += 1
@@ -55,16 +54,16 @@ module Admin
         message_parts << "#{created_users.size}人のユーザーを作成しました。" if created_users.any?
 
         if errors.any?
-          error_summary = errors.first(5).join(', ')
+          error_summary = errors.first(5).join(", ")
           error_message = "#{errors.size}件のエラーがありました。"
           error_message += " 最初の5件: #{error_summary}" if errors.size > 0
           error_message += " 詳細はログを確認してください。" if errors.size > 5
 
-          flash[:alert] = message_parts.join(' ') + " " + error_message
+          flash[:alert] = message_parts.join(" ") + " " + error_message
           # エラー詳細はログに出力
           Rails.logger.error("CSV Import Errors (#{errors.size} total): #{errors.join(' | ')}")
         else
-          flash[:notice] = message_parts.join(' ')
+          flash[:notice] = message_parts.join(" ")
         end
 
         redirect_to events_path
@@ -90,11 +89,11 @@ module Admin
         errors = []
         position = 0
 
-        CSV.foreach(file.path, headers: true, encoding: 'UTF-8') do |row|
+        CSV.foreach(file.path, headers: true, encoding: "UTF-8") do |row|
           begin
-            mobile_suit_name = row['機体名']
-            cost = row['コスト'].to_i
-            series = row['シリーズ']
+            mobile_suit_name = row["機体名"]
+            cost = row["コスト"].to_i
+            series = row["シリーズ"]
 
             if mobile_suit_name.blank?
               errors << "行#{$.}: 機体名が空です"
@@ -120,7 +119,7 @@ module Admin
         end
 
         if errors.any?
-          error_summary = errors.first(5).join(', ')
+          error_summary = errors.first(5).join(", ")
           error_message = "#{errors.size}件のエラーがありました。"
           error_message += " 最初の5件: #{error_summary}" if errors.size > 0
           error_message += " 詳細はログを確認してください。" if errors.size > 5
@@ -142,18 +141,18 @@ module Admin
 
     def import_match(row, event)
       # CSVの列: 日付, プレイヤー1, 使用機体1, プレイヤー2, 使用機体2, プレイヤー3, 使用機体3, プレイヤー4, 使用機体4, 勝敗1, 勝敗2, 勝敗3, 勝敗4
-      played_at = parse_date(row['日付'])
+      played_at = parse_date(row["日付"])
 
       # プレイヤーと機体の取得
       players_data = [
-        { nickname: row['プレイヤー1'], mobile_suit_name: row['使用機体1'], result: row['勝敗1'], position: 1 },
-        { nickname: row['プレイヤー2'], mobile_suit_name: row['使用機体2'], result: row['勝敗2'], position: 2 },
-        { nickname: row['プレイヤー3'], mobile_suit_name: row['使用機体3'], result: row['勝敗3'], position: 3 },
-        { nickname: row['プレイヤー4'], mobile_suit_name: row['使用機体4'], result: row['勝敗4'], position: 4 }
+        { nickname: row["プレイヤー1"], mobile_suit_name: row["使用機体1"], result: row["勝敗1"], position: 1 },
+        { nickname: row["プレイヤー2"], mobile_suit_name: row["使用機体2"], result: row["勝敗2"], position: 2 },
+        { nickname: row["プレイヤー3"], mobile_suit_name: row["使用機体3"], result: row["勝敗3"], position: 3 },
+        { nickname: row["プレイヤー4"], mobile_suit_name: row["使用機体4"], result: row["勝敗4"], position: 4 }
       ]
 
       # 勝利チームの判定（勝敗1が"1"ならチーム1の勝利、"0"ならチーム2の勝利）
-      winning_team = row['勝敗1'].to_i == 1 ? 1 : 2
+      winning_team = row["勝敗1"].to_i == 1 ? 1 : 2
 
       # チーム分け（1-2 vs 3-4）
       players_data[0][:team_number] = 1
@@ -174,11 +173,11 @@ module Admin
           # 連番でusernameを自動生成（user_1, user_2, ...）
           max_user_number = User.where("username LIKE 'user_%'")
                                  .pluck(:username)
-                                 .map { |name| name.sub('user_', '').to_i }
+                                 .map { |name| name.sub("user_", "").to_i }
                                  .max || 0
           u.username = "user_#{max_user_number + 1}"
-          u.password = 'password'
-          u.password_confirmation = 'password'
+          u.password = "password"
+          u.password_confirmation = "password"
           u.is_admin = false
           u.notification_enabled = false
         end

--- a/app/controllers/admin/master_emojis_controller.rb
+++ b/app/controllers/admin/master_emojis_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class MasterEmojisController < BaseController
-    before_action :set_master_emoji, only: [:edit, :update, :destroy]
+    before_action :set_master_emoji, only: [ :edit, :update, :destroy ]
 
     def index
       @master_emojis = MasterEmoji.ordered.includes(:reactions)

--- a/app/controllers/admin/mobile_suits_controller.rb
+++ b/app/controllers/admin/mobile_suits_controller.rb
@@ -1,9 +1,9 @@
 module Admin
   class MobileSuitsController < BaseController
-    before_action :set_mobile_suit, only: [:edit, :update, :destroy]
+    before_action :set_mobile_suit, only: [ :edit, :update, :destroy ]
 
     def index
-      @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
+      @mobile_suits = MobileSuit.all.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
     end
 
     def new

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class UsersController < BaseController
-    before_action :set_user, only: [:edit, :update, :destroy]
+    before_action :set_user, only: [ :edit, :update, :destroy ]
 
     def index
       @users = User.where(is_guest: false).order(is_admin: :desc, nickname: :asc)
@@ -51,7 +51,7 @@ module Admin
 
     def destroy
       if @user.id == current_user.id
-        redirect_to admin_users_path, alert: '自分自身を削除することはできません。'
+        redirect_to admin_users_path, alert: "自分自身を削除することはできません。"
         return
       end
 

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -37,5 +37,14 @@ module Api
       PushNotificationService.notify_timestamps_registered(event: event, count: matches.size)
       render json: { message: "OK", updated: matches.size }
     end
+
+    def notify_failure
+      event = Event.find_by(id: params[:id])
+      return render json: { error: "Event not found" }, status: :not_found unless event
+
+      error_msg = params[:error].presence || "不明なエラー"
+      PushNotificationService.notify_timestamps_failed(event: event, error: error_msg)
+      render json: { message: "OK" }
+    end
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -22,7 +22,7 @@ class DashboardController < ApplicationController
     @today_event = Event.where(held_on: Time.zone.today).first
     if @today_event
       @active_rotation = @today_event.rotations.includes(
-        rotation_matches: [:team1_player1, :team1_player2, :team2_player1, :team2_player2, :match]
+        rotation_matches: [ :team1_player1, :team1_player2, :team2_player1, :team2_player2, :match ]
       ).find_by(is_active: true)
     end
 
@@ -37,29 +37,29 @@ class DashboardController < ApplicationController
     @recent_events = Event.order(held_on: :desc).limit(5)
 
     # アクティブなローテーション
-    @active_rotations = Rotation.where(is_active: true).includes(:event).joins(:event).order('events.held_on DESC')
+    @active_rotations = Rotation.where(is_active: true).includes(:event).joins(:event).order("events.held_on DESC")
 
     # 最近の試合
-    @recent_matches = Match.order(played_at: :desc).limit(10).includes(:event, :match_players => [:user, :mobile_suit])
+    @recent_matches = Match.order(played_at: :desc).limit(10).includes(:event, match_players: [ :user, :mobile_suit ])
 
     # 今後のイベント
-    @upcoming_events = Event.where('held_on >= ?', Time.zone.today).order(held_on: :asc).limit(5)
+    @upcoming_events = Event.where("held_on >= ?", Time.zone.today).order(held_on: :asc).limit(5)
 
     # 人気機体TOP5
     @popular_mobile_suits = MobileSuit.joins(:match_players)
-                                      .select('mobile_suits.*, COUNT(match_players.id) as usage_count')
-                                      .group('mobile_suits.id')
-                                      .order('usage_count DESC')
+                                      .select("mobile_suits.*, COUNT(match_players.id) as usage_count")
+                                      .group("mobile_suits.id")
+                                      .order("usage_count DESC")
                                       .limit(5)
 
     # イベントごとの試合数
     @event_match_counts = Event.left_joins(:matches)
-                               .select('events.*, COUNT(matches.id) as match_count')
-                               .group('events.id')
+                               .select("events.*, COUNT(matches.id) as match_count")
+                               .group("events.id")
                                .order(held_on: :desc)
                                .limit(10)
 
-    render 'admin_dashboard'
+    render "admin_dashboard"
   end
 
   def render_player_dashboard
@@ -112,9 +112,9 @@ class DashboardController < ApplicationController
 
     # 人気機体TOP5（データベースで集計）
     @popular_mobile_suits = MobileSuit.joins(:match_players)
-                                      .select('mobile_suits.*, COUNT(match_players.id) as usage_count')
-                                      .group('mobile_suits.id')
-                                      .order('usage_count DESC')
+                                      .select("mobile_suits.*, COUNT(match_players.id) as usage_count")
+                                      .group("mobile_suits.id")
+                                      .order("usage_count DESC")
                                       .limit(5)
 
     # ユーザーのお気に入り機体（キャッシュ済みデータから集計）
@@ -124,10 +124,10 @@ class DashboardController < ApplicationController
                                           .take(3)
                                           .map { |suit, count| suit.tap { |s| s.define_singleton_method(:usage_count) { count } } }
 
-    @upcoming_events = Event.where('held_on >= ?', Time.zone.today).order(held_on: :asc).limit(3)
+    @upcoming_events = Event.where("held_on >= ?", Time.zone.today).order(held_on: :asc).limit(3)
     @latest_event = Event.order(held_on: :desc).first
 
-    render 'index'
+    render "index"
   end
 
   # 全ユーザー試合データを一度だけロード（N+1クエリを防ぐ）
@@ -137,11 +137,11 @@ class DashboardController < ApplicationController
                                          :mobile_suit,
                                          match: [
                                            :event,
-                                           match_players: [:user, :mobile_suit]
+                                           match_players: [ :user, :mobile_suit ]
                                          ]
                                        )
                                        .joins(:match)
-                                       .order('matches.played_at DESC, matches.id DESC')
+                                       .order("matches.played_at DESC, matches.id DESC")
                                        .to_a # 配列にキャッシュ
   end
 
@@ -160,7 +160,7 @@ class DashboardController < ApplicationController
 
     # 今日のイベントのアクティブなローテーション表を取得（rotation_matchesを事前ロード）
     @active_rotation = @today_event.rotations.includes(
-      rotation_matches: [:team1_player1, :team1_player2, :team2_player1, :team2_player2]
+      rotation_matches: [ :team1_player1, :team1_player2, :team2_player1, :team2_player2 ]
     ).find_by(is_active: true)
     return unless @active_rotation
 
@@ -196,8 +196,8 @@ class DashboardController < ApplicationController
     # 出番が近い通知
     if @user_next_match && @matches_until_user_turn && @matches_until_user_turn <= 2
       @notifications << {
-        type: 'warning',
-        icon: '⚠️',
+        type: "warning",
+        icon: "⚠️",
         message: "もうすぐあなたの出番です！あと#{@matches_until_user_turn}試合"
       }
     end
@@ -251,9 +251,9 @@ class DashboardController < ApplicationController
 
       if @streak_type.nil?
         # 最新の試合で連勝/連敗のタイプを決定
-        @streak_type = is_win ? 'win' : 'lose'
+        @streak_type = is_win ? "win" : "lose"
         @current_streak = 1
-      elsif (@streak_type == 'win' && is_win) || (@streak_type == 'lose' && !is_win)
+      elsif (@streak_type == "win" && is_win) || (@streak_type == "lose" && !is_win)
         # 連勝/連敗が続いている
         @current_streak += 1
       else
@@ -388,7 +388,7 @@ class DashboardController < ApplicationController
       partner_cost = partner_mp.mobile_suit.cost
 
       # コスト組み合わせのキー（小さい方を先に）
-      costs = [my_cost, partner_cost].sort.reverse
+      costs = [ my_cost, partner_cost ].sort.reverse
       cost_key = "#{costs[0]}+#{costs[1]}"
 
       cost_stats[cost_key][:total] += 1
@@ -408,7 +408,7 @@ class DashboardController < ApplicationController
                           total: stats[:total],
                           losses: stats[:total] - stats[:wins],
                           win_rate: win_rate,
-                          judgment: win_rate >= 60 ? '得意' : (win_rate >= 40 ? '普通' : '苦手')
+                          judgment: win_rate >= 60 ? "得意" : (win_rate >= 40 ? "普通" : "苦手")
                         }
                       end
                       .sort_by { |c| -c[:win_rate] }
@@ -462,7 +462,7 @@ class DashboardController < ApplicationController
                       total: stats[:total],
                       losses: stats[:total] - stats[:wins],
                       win_rate: win_rate,
-                      compatibility: win_rate >= 60 ? '得意' : (win_rate >= 40 ? '普通' : '苦手')
+                      compatibility: win_rate >= 60 ? "得意" : (win_rate >= 40 ? "普通" : "苦手")
                     }
                   end
                   .sort_by { |m| -m[:win_rate] }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,8 +3,8 @@ require "net/http"
 class EventsController < ApplicationController
   include TimestampParseable
   before_action :authenticate_user!
-  before_action :require_admin, only: [:new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis]
-  before_action :set_event, only: [:show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis]
+  before_action :require_admin, only: [ :new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis ]
+  before_action :set_event, only: [ :show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis ]
 
   def index
     @events = Event.includes(:matches).order(held_on: :desc)
@@ -13,17 +13,17 @@ class EventsController < ApplicationController
   def show
     sort = params[:sort].presence_in(%w[oldest reactions]) || "oldest"
     @sort = sort
-    @per_page = [10, 20, 50].include?(params[:per].to_i) ? params[:per].to_i : 20
+    @per_page = [ 10, 20, 50 ].include?(params[:per].to_i) ? params[:per].to_i : 20
 
     base_scope = sort == "reactions" ? @event.matches.by_reactions_oldest : @event.matches.by_oldest
     @matches = base_scope
-                 .includes(:event, :rotation_match, match_players: [:user, :mobile_suit], reactions: :user)
+                 .includes(:event, :rotation_match, match_players: [ :user, :mobile_suit ], reactions: :user)
                  .page(params[:page]).per(@per_page)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
 
     ordered_ids = @event.matches.order(:played_at, :id).pluck(:id)
-    @match_numbers = ordered_ids.each_with_index.to_h { |id, i| [id, i + 1] }
+    @match_numbers = ordered_ids.each_with_index.to_h { |id, i| [ id, i + 1 ] }
   end
 
   def new
@@ -52,13 +52,13 @@ class EventsController < ApplicationController
   end
 
   def edit_timestamps
-    @matches = @event.matches.includes(match_players: [:user, :mobile_suit]).order(:played_at, :id)
+    @matches = @event.matches.includes(match_players: [ :user, :mobile_suit ]).order(:played_at, :id)
     existing = @matches.map { |m| format_timestamp(m.video_timestamp) }
-    @timestamps_text = existing.any?(&:present?) ? existing.join("\n") : ''
+    @timestamps_text = existing.any?(&:present?) ? existing.join("\n") : ""
   end
 
   def update_timestamps
-    @matches = @event.matches.includes(match_players: [:user, :mobile_suit]).order(:played_at, :id)
+    @matches = @event.matches.includes(match_players: [ :user, :mobile_suit ]).order(:played_at, :id)
     raw_text = params[:timestamps].to_s
     lines = raw_text.split("\n").map(&:strip)
 
@@ -162,5 +162,4 @@ class EventsController < ApplicationController
   def event_params
     params.require(:event).permit(:name, :held_on, :description, :broadcast_url)
   end
-
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,6 +21,9 @@ class EventsController < ApplicationController
                  .page(params[:page]).per(@per_page)
     @rotations = @event.rotations.order(created_at: :asc)
     @emojis = MasterEmoji.active.ordered
+
+    ordered_ids = @event.matches.order(:played_at, :id).pluck(:id)
+    @match_numbers = ordered_ids.each_with_index.to_h { |id, i| [id, i + 1] }
   end
 
   def new

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,15 +1,15 @@
 class MatchesController < ApplicationController
   before_action :authenticate_user!
-  before_action :require_admin, except: [:index, :show]
-  before_action :set_event, only: [:new, :create]
-  before_action :set_match, only: [:show, :edit, :update, :destroy]
+  before_action :require_admin, except: [ :index, :show ]
+  before_action :set_event, only: [ :new, :create ]
+  before_action :set_match, only: [ :show, :edit, :update, :destroy ]
 
   def index
     sort = params[:sort].presence_in(%w[latest reactions]) || "latest"
     @sort = sort
 
     base_scope = sort == "reactions" ? Match.by_reactions : Match.by_latest
-    @matches = base_scope.includes(:event, { match_players: [:user, :mobile_suit] }, { reactions: :user })
+    @matches = base_scope.includes(:event, { match_players: [ :user, :mobile_suit ] }, { reactions: :user })
 
     # フィルター: イベント（複数選択対応）
     if params[:events].present?
@@ -31,7 +31,7 @@ class MatchesController < ApplicationController
       ).distinct if streaming_user_ids.any?
     end
 
-    @per_page = [10, 20, 50].include?(params[:per].to_i) ? params[:per].to_i : 20
+    @per_page = [ 10, 20, 50 ].include?(params[:per].to_i) ? params[:per].to_i : 20
     @matches = @matches.page(params[:page]).per(@per_page)
     @emojis = MasterEmoji.active.ordered
     @latest_event = Event.order(held_on: :desc).first
@@ -53,7 +53,7 @@ class MatchesController < ApplicationController
     @match = @event.matches.build(played_at: Time.current)
     4.times { |i| @match.match_players.build(position: i + 1) }
     @users = User.regular_users.order(:nickname)
-    @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
+    @mobile_suits = MobileSuit.all.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
   end
 
   def create
@@ -64,14 +64,14 @@ class MatchesController < ApplicationController
       redirect_to @event, notice: "対戦記録を登録しました。"
     else
       @users = User.regular_users.order(:nickname)
-      @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
+      @mobile_suits = MobileSuit.all.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
       render :new, status: :unprocessable_entity
     end
   end
 
   def edit
     @users = User.regular_users.order(:nickname)
-    @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
+    @mobile_suits = MobileSuit.all.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
   end
 
   def update
@@ -79,7 +79,7 @@ class MatchesController < ApplicationController
       redirect_to @match, notice: "対戦記録を更新しました。"
     else
       @users = User.regular_users.order(:nickname)
-      @mobile_suits = MobileSuit.all.order(Arel.sql('position IS NULL, position ASC, cost DESC, name ASC'))
+      @mobile_suits = MobileSuit.all.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
       render :edit, status: :unprocessable_entity
     end
   end
@@ -159,11 +159,11 @@ class MatchesController < ApplicationController
   end
 
   def set_match
-    @match = Match.includes(:event, :match_players => [:user, :mobile_suit]).find(params[:id])
+    @match = Match.includes(:event, match_players: [ :user, :mobile_suit ]).find(params[:id])
   end
 
   def match_params
-    params.require(:match).permit(:winning_team, :played_at, :video_timestamp_text, match_players_attributes: [:id, :user_id, :mobile_suit_id, :team_number, :position])
+    params.require(:match).permit(:winning_team, :played_at, :video_timestamp_text, match_players_attributes: [ :id, :user_id, :mobile_suit_id, :team_number, :position ])
   end
 
   # Find the next unrecorded match starting from current position
@@ -185,6 +185,6 @@ class MatchesController < ApplicationController
     end
 
     # All matches are recorded, stay at the last match
-    return rotation.rotation_matches.count - 1
+    rotation.rotation_matches.count - 1
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -30,8 +30,8 @@ class ProfilesController < ApplicationController
   private
 
   def reject_guest_user
-    if current_user.username == 'guest'
-      redirect_to root_path, alert: 'ゲストユーザーは設定を変更できません。'
+    if current_user.username == "guest"
+      redirect_to root_path, alert: "ゲストユーザーは設定を変更できません。"
     end
   end
 

--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -1,8 +1,8 @@
 class RotationsController < ApplicationController
   before_action :authenticate_user!
-  before_action :require_admin, except: [:index, :show]
-  before_action :set_rotation, only: [:show, :edit, :update, :destroy, :activate, :deactivate, :next_match, :record_match, :go_to_match, :update_match_record]
-  before_action :set_event, only: [:new, :create]
+  before_action :require_admin, except: [ :index, :show ]
+  before_action :set_rotation, only: [ :show, :edit, :update, :destroy, :activate, :deactivate, :next_match, :record_match, :go_to_match, :update_match_record ]
+  before_action :set_event, only: [ :new, :create ]
 
   def index
     @rotations = Rotation.includes(:event, :rotation_matches).order(created_at: :desc)
@@ -46,7 +46,7 @@ class RotationsController < ApplicationController
     if @rotation.save
       # Generate rotation matches
       generate_rotation_matches(@rotation, player_ids)
-      redirect_to @rotation, notice: 'ローテーションを作成しました。'
+      redirect_to @rotation, notice: "ローテーションを作成しました。"
     else
       render :new, status: :unprocessable_entity
     end
@@ -58,7 +58,7 @@ class RotationsController < ApplicationController
 
   def update
     if @rotation.update(rotation_params)
-      redirect_to @rotation, notice: 'ローテーションを更新しました。'
+      redirect_to @rotation, notice: "ローテーションを更新しました。"
     else
       @players = User.regular_users.order(:nickname)
       render :edit, status: :unprocessable_entity
@@ -67,7 +67,7 @@ class RotationsController < ApplicationController
 
   def destroy
     @rotation.destroy
-    redirect_to rotations_path, notice: 'ローテーションを削除しました。'
+    redirect_to rotations_path, notice: "ローテーションを削除しました。"
   end
 
   # Activate this rotation
@@ -87,13 +87,13 @@ class RotationsController < ApplicationController
     # Send upcoming match notifications (1試合目の出番通知含む)
     notify_upcoming_players(@rotation)
 
-    redirect_to @rotation, notice: 'ローテーションをアクティブにしました。'
+    redirect_to @rotation, notice: "ローテーションをアクティブにしました。"
   end
 
   # Deactivate this rotation
   def deactivate
     @rotation.update(is_active: false)
-    redirect_to @rotation, notice: 'ローテーションを非アクティブにしました。'
+    redirect_to @rotation, notice: "ローテーションを非アクティブにしました。"
   end
 
   # Move to next match
@@ -106,16 +106,16 @@ class RotationsController < ApplicationController
 
       # Broadcast update via Action Cable
       RotationChannel.broadcast_to(@rotation, {
-        type: 'rotation_updated',
+        type: "rotation_updated",
         current_match_index: @rotation.current_match_index
       })
 
       # Send push notifications to upcoming players
       notify_upcoming_players(@rotation)
 
-      redirect_to @rotation, notice: '次の試合に進みました。'
+      redirect_to @rotation, notice: "次の試合に進みました。"
     else
-      redirect_to @rotation, alert: 'これが最後の試合です。'
+      redirect_to @rotation, alert: "これが最後の試合です。"
     end
   end
 
@@ -131,13 +131,13 @@ class RotationsController < ApplicationController
 
       # Broadcast update via Action Cable
       RotationChannel.broadcast_to(@rotation, {
-        type: 'rotation_updated',
+        type: "rotation_updated",
         current_match_index: @rotation.current_match_index
       })
 
       redirect_to @rotation, notice: "第#{match_index + 1}試合に戻りました。"
     else
-      redirect_to @rotation, alert: '無効な試合番号です。'
+      redirect_to @rotation, alert: "無効な試合番号です。"
     end
   end
 
@@ -150,7 +150,7 @@ class RotationsController < ApplicationController
 
     unless rotation_match
       Rails.logger.error "Rotation match not found for index: #{@rotation.current_match_index}"
-      redirect_to @rotation, alert: '試合が見つかりません。' and return
+      redirect_to @rotation, alert: "試合が見つかりません。" and return
     end
 
     # Create match record
@@ -189,7 +189,7 @@ class RotationsController < ApplicationController
 
         # Broadcast update via Action Cable
         RotationChannel.broadcast_to(@rotation, {
-          type: 'rotation_updated',
+          type: "rotation_updated",
           current_match_index: @rotation.current_match_index
         })
 
@@ -205,9 +205,9 @@ class RotationsController < ApplicationController
           # All matches completed - deactivate this rotation and show modal to create next round
           @rotation.update!(is_active: false)
           session[:show_completion_modal] = @rotation.id
-          redirect_to @rotation, notice: '試合を記録しました。'
+          redirect_to @rotation, notice: "試合を記録しました。"
         else
-          redirect_to @rotation, notice: '試合を記録しました。'
+          redirect_to @rotation, notice: "試合を記録しました。"
         end
       else
         Rails.logger.error "Match save failed: #{match.errors.full_messages}"
@@ -240,7 +240,7 @@ class RotationsController < ApplicationController
     rotation_match = @rotation.rotation_matches.find_by(match_index: params[:match_index].to_i)
 
     unless rotation_match && rotation_match.match
-      redirect_to @rotation, alert: '試合が見つかりません。' and return
+      redirect_to @rotation, alert: "試合が見つかりません。" and return
     end
 
     match = rotation_match.match
@@ -265,7 +265,7 @@ class RotationsController < ApplicationController
     end
 
     if match.save
-      redirect_to @rotation, notice: '試合記録を更新しました。'
+      redirect_to @rotation, notice: "試合記録を更新しました。"
     else
       redirect_to @rotation, alert: "試合記録の更新に失敗しました: #{match.errors.full_messages.join(', ')}"
     end
@@ -342,7 +342,7 @@ class RotationsController < ApplicationController
     end
 
     # All matches are recorded, stay at the last match
-    return rotation.rotation_matches.count - 1
+    rotation.rotation_matches.count - 1
   end
 
   def notify_upcoming_players(rotation)

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -4,31 +4,31 @@ class StatisticsController < ApplicationController
   before_action :apply_filters
 
   def index
-    @active_tab = params[:tab] || 'overall'
+    @active_tab = params[:tab] || "overall"
 
     # ゲストユーザー（または管理者がゲスト視点切り替え中）は個人統計タブにアクセス不可
     personal_tabs = %w[overview events event_progression mobile_suits opponent_suits partners opponents]
     if viewing_as_user.is_guest && personal_tabs.include?(@active_tab)
-      redirect_to statistics_path(tab: 'overall'), alert: '個人統計を見るには管理者にアカウント発行を依頼してください'
+      redirect_to statistics_path(tab: "overall"), alert: "個人統計を見るには管理者にアカウント発行を依頼してください"
       return
     end
 
     case @active_tab
-    when 'overview'
+    when "overview"
       calculate_overview_stats
-    when 'overall'
+    when "overall"
       calculate_overall_stats
-    when 'partners'
+    when "partners"
       calculate_partner_stats
-    when 'mobile_suits'
+    when "mobile_suits"
       calculate_mobile_suit_stats
-    when 'opponent_suits'
+    when "opponent_suits"
       calculate_mobile_suit_stats
-    when 'events'
+    when "events"
       calculate_event_stats
-    when 'event_progression'
+    when "event_progression"
       calculate_event_progression_stats
-    when 'opponents'
+    when "opponents"
       calculate_opponent_stats
     end
 
@@ -112,7 +112,7 @@ class StatisticsController < ApplicationController
 
   def calculate_max_streak
     # 全試合を時系列順に取得
-    all_matches = @filtered_matches.order('matches.played_at ASC').to_a
+    all_matches = @filtered_matches.order("matches.played_at ASC").to_a
 
     max_streak = 0
     current_streak = 0
@@ -120,7 +120,7 @@ class StatisticsController < ApplicationController
     all_matches.each do |mp|
       if mp.match.winning_team == mp.team_number
         current_streak += 1
-        max_streak = [max_streak, current_streak].max
+        max_streak = [ max_streak, current_streak ].max
       else
         current_streak = 0
       end
@@ -171,7 +171,7 @@ class StatisticsController < ApplicationController
       next unless partner_mp
 
       partner_cost = partner_mp.mobile_suit.cost
-      costs = [my_cost, partner_cost].sort.reverse
+      costs = [ my_cost, partner_cost ].sort.reverse
       cost_key = "#{costs[0]}+#{costs[1]}"
 
       cost_data[cost_key][:total] += 1
@@ -187,7 +187,7 @@ class StatisticsController < ApplicationController
         win_rate: data[:total] > 0 ? (data[:wins].to_f / data[:total] * 100).round(1) : 0,
         total: data[:total]
       }
-    end.sort_by { |d| [-d[:cost1], -d[:cost2]] }
+    end.sort_by { |d| [ -d[:cost1], -d[:cost2] ] }
   end
 
   def calculate_rotation_round_stats

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Users::SessionsController < Devise::SessionsController
-  before_action :configure_sign_in_params, only: [:create]
+  before_action :configure_sign_in_params, only: [ :create ]
 
   # Set user_id in encrypted cookies for Action Cable authentication
   def create
@@ -16,8 +16,8 @@ class Users::SessionsController < Devise::SessionsController
 
   # Guest login
   def guest
-    guest_user = User.find_or_create_by!(username: 'guest') do |user|
-      user.nickname = 'ゲスト'
+    guest_user = User.find_or_create_by!(username: "guest") do |user|
+      user.nickname = "ゲスト"
       user.password = SecureRandom.hex(16)
       user.is_admin = false
       user.is_guest = true
@@ -25,13 +25,13 @@ class Users::SessionsController < Devise::SessionsController
 
     sign_in(guest_user)
     cookies.encrypted[:user_id] = guest_user.id
-    redirect_to root_path, notice: 'ゲストとしてログインしました。'
+    redirect_to root_path, notice: "ゲストとしてログインしました。"
   end
 
   protected
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_in_params
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:username])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [ :username ])
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,7 @@ class Event < ApplicationRecord
   # Validations
   validates :name, presence: true
   validates :held_on, presence: true
+  validates :broadcast_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
 
   # Associations
   has_many :matches, dependent: :destroy

--- a/app/models/master_emoji.rb
+++ b/app/models/master_emoji.rb
@@ -8,7 +8,7 @@ class MasterEmoji < ApplicationRecord
 
   # Scopes
   scope :active, -> { where(is_active: true) }
-  scope :ordered, -> { order(Arel.sql('position IS NULL, position ASC, created_at ASC')) }
+  scope :ordered, -> { order(Arel.sql("position IS NULL, position ASC, created_at ASC")) }
 
   # Helper method to check if image_key is an asset file
   def asset_image?

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -15,12 +15,12 @@ class Match < ApplicationRecord
 
   # Validations
   validates :played_at, presence: true
-  validates :winning_team, presence: true, inclusion: { in: [1, 2] }
+  validates :winning_team, presence: true, inclusion: { in: [ 1, 2 ] }
   validates :match_players, length: { is: 4 }
 
   # イベント内での試合番号を取得（古い順に1から採番）
   def match_number
-    event.matches.where('played_at < ?', played_at).count + 1
+    event.matches.where("played_at < ?", played_at).count + 1
   end
 
   # 特定のユーザーが特定の絵文字でリアクションしているかどうか
@@ -44,7 +44,7 @@ class Match < ApplicationRecord
 
   # H:MM:SS形式でのタイムスタンプ入出力用
   def video_timestamp_text
-    return '' if video_timestamp.nil?
+    return "" if video_timestamp.nil?
     h, remainder = video_timestamp.divmod(3600)
     m, s = remainder.divmod(60)
     "#{h}:#{format('%02d', m)}:#{format('%02d', s)}"
@@ -55,7 +55,7 @@ class Match < ApplicationRecord
       self.video_timestamp = nil
       return
     end
-    parts = text.strip.split(':').map(&:to_i)
+    parts = text.strip.split(":").map(&:to_i)
     self.video_timestamp = case parts.size
     when 3 then parts[0] * 3600 + parts[1] * 60 + parts[2]
     when 2 then parts[0] * 60 + parts[1]
@@ -67,7 +67,7 @@ class Match < ApplicationRecord
     return nil unless video_timestamp.present? && event.broadcast_url.present?
 
     base_url = event.broadcast_url
-    separator = base_url.include?('?') ? '&' : '?'
+    separator = base_url.include?("?") ? "&" : "?"
     "#{base_url}#{separator}t=#{video_timestamp}s"
   end
 

--- a/app/models/match_player.rb
+++ b/app/models/match_player.rb
@@ -5,7 +5,7 @@ class MatchPlayer < ApplicationRecord
   belongs_to :mobile_suit
 
   # Validations
-  validates :team_number, presence: true, inclusion: { in: [1, 2] }
-  validates :position, presence: true, inclusion: { in: [1, 2, 3, 4] }
+  validates :team_number, presence: true, inclusion: { in: [ 1, 2 ] }
+  validates :position, presence: true, inclusion: { in: [ 1, 2, 3, 4 ] }
   validates :position, uniqueness: { scope: :match_id }
 end

--- a/app/models/mobile_suit.rb
+++ b/app/models/mobile_suit.rb
@@ -2,7 +2,7 @@ class MobileSuit < ApplicationRecord
   # Validations
   validates :name, presence: true
   validates :series, presence: true
-  validates :cost, presence: true, inclusion: { in: [1000, 1500, 2000, 2500, 3000] }
+  validates :cost, presence: true, inclusion: { in: [ 1000, 1500, 2000, 2500, 3000 ] }
 
   # Associations
   has_many :match_players, dependent: :restrict_with_error

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -5,5 +5,5 @@ class Reaction < ApplicationRecord
   belongs_to :master_emoji
 
   # Validations
-  validates :user_id, uniqueness: { scope: [:match_id, :master_emoji_id], message: "は同じ試合に同じスタンプで複数回リアクションできません" }
+  validates :user_id, uniqueness: { scope: [ :match_id, :master_emoji_id ], message: "は同じ試合に同じスタンプで複数回リアクションできません" }
 end

--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -1,8 +1,8 @@
 class Rotation < ApplicationRecord
   # Associations
   belongs_to :event
-  belongs_to :base_rotation, class_name: 'Rotation', optional: true
-  has_many :derived_rotations, class_name: 'Rotation', foreign_key: 'base_rotation_id', dependent: :nullify
+  belongs_to :base_rotation, class_name: "Rotation", optional: true
+  has_many :derived_rotations, class_name: "Rotation", foreign_key: "base_rotation_id", dependent: :nullify
   has_many :rotation_matches, dependent: :destroy
 
   # Validations
@@ -16,7 +16,7 @@ class Rotation < ApplicationRecord
   # Get all unique players in this rotation
   def players
     player_ids = rotation_matches.flat_map do |rm|
-      [rm.team1_player1_id, rm.team1_player2_id, rm.team2_player1_id, rm.team2_player2_id]
+      [ rm.team1_player1_id, rm.team1_player2_id, rm.team2_player1_id, rm.team2_player2_id ]
     end.uniq
 
     User.where(id: player_ids)
@@ -34,7 +34,7 @@ class Rotation < ApplicationRecord
     end
 
     rotation_matches.each do |rm|
-      all_players = [rm.team1_player1, rm.team1_player2, rm.team2_player1, rm.team2_player2]
+      all_players = [ rm.team1_player1, rm.team1_player2, rm.team2_player1, rm.team2_player2 ]
 
       # Update match counts
       all_players.each do |player|
@@ -43,14 +43,14 @@ class Rotation < ApplicationRecord
       end
 
       # Update pair counts
-      [[rm.team1_player1, rm.team1_player2], [rm.team2_player1, rm.team2_player2]].each do |pair|
+      [ [ rm.team1_player1, rm.team1_player2 ], [ rm.team2_player1, rm.team2_player2 ] ].each do |pair|
         stats[pair[0].id][:pair_counts][pair[1].id] += 1
         stats[pair[1].id][:pair_counts][pair[0].id] += 1
       end
 
       # Update opponent counts
-      [rm.team1_player1, rm.team1_player2].each do |team1_player|
-        [rm.team2_player1, rm.team2_player2].each do |team2_player|
+      [ rm.team1_player1, rm.team1_player2 ].each do |team1_player|
+        [ rm.team2_player1, rm.team2_player2 ].each do |team2_player|
           stats[team1_player.id][:opponent_counts][team2_player.id] += 1
           stats[team2_player.id][:opponent_counts][team1_player.id] += 1
         end
@@ -63,9 +63,9 @@ class Rotation < ApplicationRecord
   # Find next match for a specific player
   def next_match_for_player(player_id)
     rotation_matches
-      .where('match_index >= ?', current_match_index)
+      .where("match_index >= ?", current_match_index)
       .where(
-        'team1_player1_id = ? OR team1_player2_id = ? OR team2_player1_id = ? OR team2_player2_id = ?',
+        "team1_player1_id = ? OR team1_player2_id = ? OR team2_player1_id = ? OR team2_player2_id = ?",
         player_id, player_id, player_id, player_id
       )
       .order(:match_index)
@@ -75,13 +75,13 @@ class Rotation < ApplicationRecord
   # Get player's partner and opponents for a specific match
   def match_info_for_player(rotation_match, player_id)
     if rotation_match.team1_player1_id == player_id
-      { partner: rotation_match.team1_player2, opponents: [rotation_match.team2_player1, rotation_match.team2_player2] }
+      { partner: rotation_match.team1_player2, opponents: [ rotation_match.team2_player1, rotation_match.team2_player2 ] }
     elsif rotation_match.team1_player2_id == player_id
-      { partner: rotation_match.team1_player1, opponents: [rotation_match.team2_player1, rotation_match.team2_player2] }
+      { partner: rotation_match.team1_player1, opponents: [ rotation_match.team2_player1, rotation_match.team2_player2 ] }
     elsif rotation_match.team2_player1_id == player_id
-      { partner: rotation_match.team2_player2, opponents: [rotation_match.team1_player1, rotation_match.team1_player2] }
+      { partner: rotation_match.team2_player2, opponents: [ rotation_match.team1_player1, rotation_match.team1_player2 ] }
     elsif rotation_match.team2_player2_id == player_id
-      { partner: rotation_match.team2_player1, opponents: [rotation_match.team1_player1, rotation_match.team1_player2] }
+      { partner: rotation_match.team2_player1, opponents: [ rotation_match.team1_player1, rotation_match.team1_player2 ] }
     else
       nil
     end

--- a/app/models/rotation_match.rb
+++ b/app/models/rotation_match.rb
@@ -1,12 +1,12 @@
 class RotationMatch < ApplicationRecord
   # Associations
   belongs_to :rotation
-  belongs_to :team1_player1, class_name: 'User'
-  belongs_to :team1_player2, class_name: 'User'
-  belongs_to :team2_player1, class_name: 'User'
-  belongs_to :team2_player2, class_name: 'User'
+  belongs_to :team1_player1, class_name: "User"
+  belongs_to :team1_player2, class_name: "User"
+  belongs_to :team2_player1, class_name: "User"
+  belongs_to :team2_player2, class_name: "User"
   belongs_to :match, optional: true
-  has_one :match_result, class_name: 'Match', foreign_key: 'rotation_match_id', dependent: :nullify
+  has_one :match_result, class_name: "Match", foreign_key: "rotation_match_id", dependent: :nullify
 
   # Validations
   validates :match_index, presence: true, numericality: { greater_than_or_equal_to: 0 }
@@ -14,6 +14,6 @@ class RotationMatch < ApplicationRecord
 
   # Get all players in this match
   def players
-    [team1_player1, team1_player2, team2_player1, team2_player2]
+    [ team1_player1, team1_player2, team2_player1, team2_player2 ]
   end
 end

--- a/app/services/rotation_generator.rb
+++ b/app/services/rotation_generator.rb
@@ -40,23 +40,23 @@ class RotationGenerator
     # Format: [[team1_p1_idx, team1_p2_idx], [team2_p1_idx, team2_p2_idx]]
     # First player in team1 is always the streaming player
     template = [
-      [[0, 1], [2, 3]],  # A B vs C D
-      [[1, 0], [2, 3]],  # B A vs C D
-      [[2, 3], [0, 1]],  # C D vs A B
-      [[3, 2], [0, 1]],  # D C vs A B
-      [[0, 2], [1, 3]],  # A C vs B D
-      [[2, 0], [1, 3]],  # C A vs B D
-      [[1, 3], [0, 2]],  # B D vs A C
-      [[3, 1], [0, 2]],  # D B vs A C
-      [[0, 3], [1, 2]],  # A D vs B C
-      [[3, 0], [1, 2]],  # D A vs B C
-      [[1, 2], [0, 3]],  # B C vs A D
-      [[2, 1], [0, 3]]   # C B vs A D
+      [ [ 0, 1 ], [ 2, 3 ] ],  # A B vs C D
+      [ [ 1, 0 ], [ 2, 3 ] ],  # B A vs C D
+      [ [ 2, 3 ], [ 0, 1 ] ],  # C D vs A B
+      [ [ 3, 2 ], [ 0, 1 ] ],  # D C vs A B
+      [ [ 0, 2 ], [ 1, 3 ] ],  # A C vs B D
+      [ [ 2, 0 ], [ 1, 3 ] ],  # C A vs B D
+      [ [ 1, 3 ], [ 0, 2 ] ],  # B D vs A C
+      [ [ 3, 1 ], [ 0, 2 ] ],  # D B vs A C
+      [ [ 0, 3 ], [ 1, 2 ] ],  # A D vs B C
+      [ [ 3, 0 ], [ 1, 2 ] ],  # D A vs B C
+      [ [ 1, 2 ], [ 0, 3 ] ],  # B C vs A D
+      [ [ 2, 1 ], [ 0, 3 ] ]   # C B vs A D
     ]
 
     template.each_with_index do |match, idx|
-      team1 = [@players[match[0][0]], @players[match[0][1]]]
-      team2 = [@players[match[1][0]], @players[match[1][1]]]
+      team1 = [ @players[match[0][0]], @players[match[0][1]] ]
+      team2 = [ @players[match[1][0]], @players[match[1][1]] ]
       add_match(idx, team1, team2)
     end
   end
@@ -69,26 +69,26 @@ class RotationGenerator
     # Format: [[team1_p1_idx, team1_p2_idx], [team2_p1_idx, team2_p2_idx]]
     # First player in team1 is always the streaming player
     template = [
-      [[0, 1], [2, 3]],  # A B vs C D
-      [[2, 0], [1, 3]],  # C A vs B D
-      [[3, 0], [1, 2]],  # D A vs B C
-      [[0, 2], [1, 4]],  # A C vs B E
-      [[4, 0], [1, 2]],  # E A vs B C
-      [[1, 0], [4, 2]],  # B A vs E C
-      [[3, 0], [1, 4]],  # D A vs B E
-      [[4, 0], [1, 3]],  # E A vs B D
-      [[1, 0], [4, 3]],  # B A vs E D
-      [[0, 4], [2, 3]],  # A E vs C D
-      [[2, 0], [4, 3]],  # C A vs E D
-      [[3, 0], [4, 2]],  # D A vs E C
-      [[2, 1], [3, 4]],  # C B vs D E
-      [[1, 3], [2, 4]],  # B D vs C E
-      [[4, 1], [2, 3]]   # E B vs C D
+      [ [ 0, 1 ], [ 2, 3 ] ],  # A B vs C D
+      [ [ 2, 0 ], [ 1, 3 ] ],  # C A vs B D
+      [ [ 3, 0 ], [ 1, 2 ] ],  # D A vs B C
+      [ [ 0, 2 ], [ 1, 4 ] ],  # A C vs B E
+      [ [ 4, 0 ], [ 1, 2 ] ],  # E A vs B C
+      [ [ 1, 0 ], [ 4, 2 ] ],  # B A vs E C
+      [ [ 3, 0 ], [ 1, 4 ] ],  # D A vs B E
+      [ [ 4, 0 ], [ 1, 3 ] ],  # E A vs B D
+      [ [ 1, 0 ], [ 4, 3 ] ],  # B A vs E D
+      [ [ 0, 4 ], [ 2, 3 ] ],  # A E vs C D
+      [ [ 2, 0 ], [ 4, 3 ] ],  # C A vs E D
+      [ [ 3, 0 ], [ 4, 2 ] ],  # D A vs E C
+      [ [ 2, 1 ], [ 3, 4 ] ],  # C B vs D E
+      [ [ 1, 3 ], [ 2, 4 ] ],  # B D vs C E
+      [ [ 4, 1 ], [ 2, 3 ] ]   # E B vs C D
     ]
 
     template.each_with_index do |match, idx|
-      team1 = [@players[match[0][0]], @players[match[0][1]]]
-      team2 = [@players[match[1][0]], @players[match[1][1]]]
+      team1 = [ @players[match[0][0]], @players[match[0][1]] ]
+      team2 = [ @players[match[1][0]], @players[match[1][1]] ]
       add_match(idx, team1, team2)
     end
   end
@@ -100,56 +100,56 @@ class RotationGenerator
     # Format: [[team1_p1_idx, team1_p2_idx], [team2_p1_idx, team2_p2_idx]]
     # First player in team1 is always the streaming player
     template = [
-      [[0, 1], [2, 3]],  # A B vs C D
-      [[1, 0], [4, 5]],  # B A vs E F
-      [[3, 2], [4, 5]],  # D C vs E F
-      [[4, 1], [0, 2]],  # E B vs A C
-      [[3, 5], [0, 2]],  # D F vs A C
-      [[5, 3], [1, 4]],  # F D vs B E
-      [[0, 3], [1, 5]],  # A D vs B F
-      [[3, 0], [2, 4]],  # D A vs C E
-      [[1, 5], [2, 4]],  # B F vs C E
-      [[1, 3], [0, 4]],  # B D vs A E
-      [[2, 5], [0, 4]],  # C F vs A E
-      [[5, 2], [1, 3]],  # F C vs B D
-      [[2, 1], [0, 5]],  # C B vs A F
-      [[3, 4], [0, 5]],  # D E vs A F
-      [[4, 3], [1, 2]],  # E D vs B C
-      [[0, 1], [2, 4]],  # A B vs C E
-      [[1, 0], [3, 5]],  # B A vs D F
-      [[4, 2], [3, 5]],  # E C vs D F
-      [[0, 2], [3, 4]],  # A C vs D E
-      [[2, 0], [1, 5]],  # C A vs B F
-      [[3, 4], [1, 5]],  # D E vs B F
-      [[5, 4], [0, 3]],  # F E vs A D
-      [[1, 2], [0, 3]],  # B C vs A D
-      [[2, 1], [4, 5]],  # C B vs E F
-      [[0, 4], [2, 3]],  # A E vs C D
-      [[4, 0], [1, 5]],  # E A vs B F
-      [[3, 2], [1, 5]],  # D C vs B F
-      [[0, 5], [2, 4]],  # A F vs C E
-      [[5, 0], [1, 3]],  # F A vs B D
-      [[2, 4], [1, 3]],  # C E vs B D
-      [[4, 3], [0, 1]],  # E D vs A B
-      [[2, 5], [0, 1]],  # C F vs A B
-      [[5, 2], [3, 4]],  # F C vs D E
-      [[1, 3], [0, 2]],  # B D vs A C
-      [[4, 5], [0, 2]],  # E F vs A C
-      [[5, 4], [1, 3]],  # F E vs B D
-      [[0, 3], [1, 4]],  # A D vs B E
-      [[3, 0], [2, 5]],  # D A vs C F
-      [[4, 1], [2, 5]],  # E B vs C F
-      [[2, 1], [0, 4]],  # C B vs A E
-      [[3, 5], [0, 4]],  # D F vs A E
-      [[5, 3], [1, 2]],  # F D vs B C
-      [[0, 5], [1, 4]],  # A F vs B E
-      [[5, 0], [2, 3]],  # F A vs C D
-      [[1, 4], [2, 3]]   # B E vs C D
+      [ [ 0, 1 ], [ 2, 3 ] ],  # A B vs C D
+      [ [ 1, 0 ], [ 4, 5 ] ],  # B A vs E F
+      [ [ 3, 2 ], [ 4, 5 ] ],  # D C vs E F
+      [ [ 4, 1 ], [ 0, 2 ] ],  # E B vs A C
+      [ [ 3, 5 ], [ 0, 2 ] ],  # D F vs A C
+      [ [ 5, 3 ], [ 1, 4 ] ],  # F D vs B E
+      [ [ 0, 3 ], [ 1, 5 ] ],  # A D vs B F
+      [ [ 3, 0 ], [ 2, 4 ] ],  # D A vs C E
+      [ [ 1, 5 ], [ 2, 4 ] ],  # B F vs C E
+      [ [ 1, 3 ], [ 0, 4 ] ],  # B D vs A E
+      [ [ 2, 5 ], [ 0, 4 ] ],  # C F vs A E
+      [ [ 5, 2 ], [ 1, 3 ] ],  # F C vs B D
+      [ [ 2, 1 ], [ 0, 5 ] ],  # C B vs A F
+      [ [ 3, 4 ], [ 0, 5 ] ],  # D E vs A F
+      [ [ 4, 3 ], [ 1, 2 ] ],  # E D vs B C
+      [ [ 0, 1 ], [ 2, 4 ] ],  # A B vs C E
+      [ [ 1, 0 ], [ 3, 5 ] ],  # B A vs D F
+      [ [ 4, 2 ], [ 3, 5 ] ],  # E C vs D F
+      [ [ 0, 2 ], [ 3, 4 ] ],  # A C vs D E
+      [ [ 2, 0 ], [ 1, 5 ] ],  # C A vs B F
+      [ [ 3, 4 ], [ 1, 5 ] ],  # D E vs B F
+      [ [ 5, 4 ], [ 0, 3 ] ],  # F E vs A D
+      [ [ 1, 2 ], [ 0, 3 ] ],  # B C vs A D
+      [ [ 2, 1 ], [ 4, 5 ] ],  # C B vs E F
+      [ [ 0, 4 ], [ 2, 3 ] ],  # A E vs C D
+      [ [ 4, 0 ], [ 1, 5 ] ],  # E A vs B F
+      [ [ 3, 2 ], [ 1, 5 ] ],  # D C vs B F
+      [ [ 0, 5 ], [ 2, 4 ] ],  # A F vs C E
+      [ [ 5, 0 ], [ 1, 3 ] ],  # F A vs B D
+      [ [ 2, 4 ], [ 1, 3 ] ],  # C E vs B D
+      [ [ 4, 3 ], [ 0, 1 ] ],  # E D vs A B
+      [ [ 2, 5 ], [ 0, 1 ] ],  # C F vs A B
+      [ [ 5, 2 ], [ 3, 4 ] ],  # F C vs D E
+      [ [ 1, 3 ], [ 0, 2 ] ],  # B D vs A C
+      [ [ 4, 5 ], [ 0, 2 ] ],  # E F vs A C
+      [ [ 5, 4 ], [ 1, 3 ] ],  # F E vs B D
+      [ [ 0, 3 ], [ 1, 4 ] ],  # A D vs B E
+      [ [ 3, 0 ], [ 2, 5 ] ],  # D A vs C F
+      [ [ 4, 1 ], [ 2, 5 ] ],  # E B vs C F
+      [ [ 2, 1 ], [ 0, 4 ] ],  # C B vs A E
+      [ [ 3, 5 ], [ 0, 4 ] ],  # D F vs A E
+      [ [ 5, 3 ], [ 1, 2 ] ],  # F D vs B C
+      [ [ 0, 5 ], [ 1, 4 ] ],  # A F vs B E
+      [ [ 5, 0 ], [ 2, 3 ] ],  # F A vs C D
+      [ [ 1, 4 ], [ 2, 3 ] ]   # B E vs C D
     ]
 
     template.each_with_index do |match, idx|
-      team1 = [@players[match[0][0]], @players[match[0][1]]]
-      team2 = [@players[match[1][0]], @players[match[1][1]]]
+      team1 = [ @players[match[0][0]], @players[match[0][1]] ]
+      team2 = [ @players[match[1][0]], @players[match[1][1]] ]
       add_match(idx, team1, team2)
     end
   end
@@ -162,32 +162,32 @@ class RotationGenerator
     # Format: [[team1_p1_idx, team1_p2_idx], [team2_p1_idx, team2_p2_idx]]
     # First player in team1 is always the streaming player
     template = [
-      [[2, 3], [0, 1]],  # C D vs A B
-      [[4, 5], [0, 1]],  # E F vs A B
-      [[5, 4], [2, 3]],  # F E vs C D
-      [[0, 2], [3, 4]],  # A C vs D E
-      [[2, 0], [6, 1]],  # C A vs G B
-      [[3, 4], [6, 1]],  # D E vs G B
-      [[0, 3], [5, 6]],  # A D vs F G
-      [[3, 0], [1, 2]],  # D A vs B C
-      [[6, 5], [1, 2]],  # G F vs B C
-      [[0, 4], [5, 1]],  # A E vs F B
-      [[4, 0], [6, 2]],  # E A vs G C
-      [[1, 5], [6, 2]],  # B F vs G C
-      [[6, 3], [0, 5]],  # G D vs A F
-      [[1, 4], [0, 5]],  # B E vs A F
-      [[4, 1], [6, 3]],  # E B vs G D
-      [[2, 4], [0, 6]],  # C E vs A G
-      [[5, 3], [0, 6]],  # F D vs A G
-      [[3, 5], [2, 4]],  # D F vs C E
-      [[1, 3], [2, 5]],  # B D vs C F
-      [[6, 4], [1, 3]],  # G E vs B D
-      [[5, 2], [6, 4]]   # F C vs G E
+      [ [ 2, 3 ], [ 0, 1 ] ],  # C D vs A B
+      [ [ 4, 5 ], [ 0, 1 ] ],  # E F vs A B
+      [ [ 5, 4 ], [ 2, 3 ] ],  # F E vs C D
+      [ [ 0, 2 ], [ 3, 4 ] ],  # A C vs D E
+      [ [ 2, 0 ], [ 6, 1 ] ],  # C A vs G B
+      [ [ 3, 4 ], [ 6, 1 ] ],  # D E vs G B
+      [ [ 0, 3 ], [ 5, 6 ] ],  # A D vs F G
+      [ [ 3, 0 ], [ 1, 2 ] ],  # D A vs B C
+      [ [ 6, 5 ], [ 1, 2 ] ],  # G F vs B C
+      [ [ 0, 4 ], [ 5, 1 ] ],  # A E vs F B
+      [ [ 4, 0 ], [ 6, 2 ] ],  # E A vs G C
+      [ [ 1, 5 ], [ 6, 2 ] ],  # B F vs G C
+      [ [ 6, 3 ], [ 0, 5 ] ],  # G D vs A F
+      [ [ 1, 4 ], [ 0, 5 ] ],  # B E vs A F
+      [ [ 4, 1 ], [ 6, 3 ] ],  # E B vs G D
+      [ [ 2, 4 ], [ 0, 6 ] ],  # C E vs A G
+      [ [ 5, 3 ], [ 0, 6 ] ],  # F D vs A G
+      [ [ 3, 5 ], [ 2, 4 ] ],  # D F vs C E
+      [ [ 1, 3 ], [ 2, 5 ] ],  # B D vs C F
+      [ [ 6, 4 ], [ 1, 3 ] ],  # G E vs B D
+      [ [ 5, 2 ], [ 6, 4 ] ]   # F C vs G E
     ]
 
     template.each_with_index do |match, idx|
-      team1 = [@players[match[0][0]], @players[match[0][1]]]
-      team2 = [@players[match[1][0]], @players[match[1][1]]]
+      team1 = [ @players[match[0][0]], @players[match[0][1]] ]
+      team2 = [ @players[match[1][0]], @players[match[1][1]] ]
       add_match(idx, team1, team2)
     end
   end
@@ -200,53 +200,53 @@ class RotationGenerator
     # First player in team1 is always the streaming player
     # A=0, B=1, C=2, D=3, E=4, F=5, G=6, H=7
     template = [
-      [[0, 1], [2, 3]],  # A B vs C D
-      [[1, 0], [4, 5]],  # B A vs E F
-      [[6, 7], [0, 1]],  # G H vs A B
-      [[7, 6], [2, 3]],  # H G vs C D
-      [[4, 5], [2, 3]],  # E F vs C D
-      [[5, 4], [6, 7]],  # F E vs G H
-      [[3, 1], [0, 2]],  # D B vs A C
-      [[2, 0], [4, 6]],  # C A vs E G
-      [[0, 2], [5, 7]],  # A C vs F H
-      [[1, 3], [5, 7]],  # B D vs F H
-      [[6, 4], [1, 3]],  # G E vs B D
-      [[7, 5], [4, 6]],  # H F vs E G
-      [[2, 1], [0, 3]],  # C B vs A D
-      [[4, 7], [0, 3]],  # E H vs A D
-      [[3, 0], [6, 5]],  # D A vs G F
-      [[5, 6], [1, 2]],  # F G vs B C
-      [[1, 2], [4, 7]],  # B C vs E H
-      [[6, 5], [4, 7]],  # G F vs E H
-      [[0, 4], [1, 5]],  # A E vs B F
-      [[4, 0], [2, 6]],  # E A vs C G
-      [[7, 3], [0, 4]],  # H D vs A E
-      [[5, 1], [3, 7]],  # F B vs D H
-      [[2, 6], [1, 5]],  # C G vs B F
-      [[3, 7], [2, 6]],  # D H vs C G
-      [[1, 4], [0, 5]],  # B E vs A F
-      [[0, 5], [2, 7]],  # A F vs C H
-      [[5, 0], [3, 6]],  # F A vs D G
-      [[6, 3], [1, 4]],  # G D vs B E
-      [[4, 1], [2, 7]],  # E B vs C H
-      [[3, 6], [2, 7]],  # D G vs C H
-      [[7, 1], [0, 6]],  # H B vs A G
-      [[2, 4], [0, 6]],  # C E vs A G
-      [[0, 6], [3, 5]],  # A G vs D F
-      [[1, 7], [3, 5]],  # B H vs D F
-      [[7, 1], [2, 4]],  # H B vs C E
-      [[2, 4], [3, 5]],  # C E vs D F
-      [[6, 1], [0, 7]],  # G B vs A H
-      [[5, 2], [0, 7]],  # F C vs A H
-      [[4, 3], [0, 7]],  # E D vs A H
-      [[3, 4], [1, 6]],  # D E vs B G
-      [[6, 1], [2, 5]],  # G B vs C F
-      [[5, 2], [3, 4]]   # F C vs D E
+      [ [ 0, 1 ], [ 2, 3 ] ],  # A B vs C D
+      [ [ 1, 0 ], [ 4, 5 ] ],  # B A vs E F
+      [ [ 6, 7 ], [ 0, 1 ] ],  # G H vs A B
+      [ [ 7, 6 ], [ 2, 3 ] ],  # H G vs C D
+      [ [ 4, 5 ], [ 2, 3 ] ],  # E F vs C D
+      [ [ 5, 4 ], [ 6, 7 ] ],  # F E vs G H
+      [ [ 3, 1 ], [ 0, 2 ] ],  # D B vs A C
+      [ [ 2, 0 ], [ 4, 6 ] ],  # C A vs E G
+      [ [ 0, 2 ], [ 5, 7 ] ],  # A C vs F H
+      [ [ 1, 3 ], [ 5, 7 ] ],  # B D vs F H
+      [ [ 6, 4 ], [ 1, 3 ] ],  # G E vs B D
+      [ [ 7, 5 ], [ 4, 6 ] ],  # H F vs E G
+      [ [ 2, 1 ], [ 0, 3 ] ],  # C B vs A D
+      [ [ 4, 7 ], [ 0, 3 ] ],  # E H vs A D
+      [ [ 3, 0 ], [ 6, 5 ] ],  # D A vs G F
+      [ [ 5, 6 ], [ 1, 2 ] ],  # F G vs B C
+      [ [ 1, 2 ], [ 4, 7 ] ],  # B C vs E H
+      [ [ 6, 5 ], [ 4, 7 ] ],  # G F vs E H
+      [ [ 0, 4 ], [ 1, 5 ] ],  # A E vs B F
+      [ [ 4, 0 ], [ 2, 6 ] ],  # E A vs C G
+      [ [ 7, 3 ], [ 0, 4 ] ],  # H D vs A E
+      [ [ 5, 1 ], [ 3, 7 ] ],  # F B vs D H
+      [ [ 2, 6 ], [ 1, 5 ] ],  # C G vs B F
+      [ [ 3, 7 ], [ 2, 6 ] ],  # D H vs C G
+      [ [ 1, 4 ], [ 0, 5 ] ],  # B E vs A F
+      [ [ 0, 5 ], [ 2, 7 ] ],  # A F vs C H
+      [ [ 5, 0 ], [ 3, 6 ] ],  # F A vs D G
+      [ [ 6, 3 ], [ 1, 4 ] ],  # G D vs B E
+      [ [ 4, 1 ], [ 2, 7 ] ],  # E B vs C H
+      [ [ 3, 6 ], [ 2, 7 ] ],  # D G vs C H
+      [ [ 7, 1 ], [ 0, 6 ] ],  # H B vs A G
+      [ [ 2, 4 ], [ 0, 6 ] ],  # C E vs A G
+      [ [ 0, 6 ], [ 3, 5 ] ],  # A G vs D F
+      [ [ 1, 7 ], [ 3, 5 ] ],  # B H vs D F
+      [ [ 7, 1 ], [ 2, 4 ] ],  # H B vs C E
+      [ [ 2, 4 ], [ 3, 5 ] ],  # C E vs D F
+      [ [ 6, 1 ], [ 0, 7 ] ],  # G B vs A H
+      [ [ 5, 2 ], [ 0, 7 ] ],  # F C vs A H
+      [ [ 4, 3 ], [ 0, 7 ] ],  # E D vs A H
+      [ [ 3, 4 ], [ 1, 6 ] ],  # D E vs B G
+      [ [ 6, 1 ], [ 2, 5 ] ],  # G B vs C F
+      [ [ 5, 2 ], [ 3, 4 ] ]   # F C vs D E
     ]
 
     template.each_with_index do |match, idx|
-      team1 = [@players[match[0][0]], @players[match[0][1]]]
-      team2 = [@players[match[1][0]], @players[match[1][1]]]
+      team1 = [ @players[match[0][0]], @players[match[0][1]] ]
+      team2 = [ @players[match[1][0]], @players[match[1][1]] ]
       add_match(idx, team1, team2)
     end
   end
@@ -311,7 +311,7 @@ class RotationGenerator
     team1 = shuffled[0..1]
     team2 = shuffled[2..3]
 
-    [team1, team2]
+    [ team1, team2 ]
   end
 
   def add_match(index, team1, team2)
@@ -346,7 +346,7 @@ class RotationGenerator
   end
 
   def player_pair_key(player1, player2)
-    [player1.id, player2.id].sort
+    [ player1.id, player2.id ].sort
   end
 
   # Get statistics for analysis

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -113,13 +113,12 @@
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
           <ul class="divide-y divide-gray-200">
-            <% match_offset = (@matches.current_page - 1) * @matches.limit_value %>
-            <% @matches.each_with_index do |match, index| %>
+            <% @matches.each do |match| %>
               <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
               <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
                 <li class="px-4 py-3">
                   <div class="flex items-center gap-2 mb-2">
-                    <span class="text-sm font-semibold text-gray-900">第<%= match_offset + index + 1 %>試合</span>
+                    <span class="text-sm font-semibold text-gray-900">第<%= @match_numbers[match.id] %>試合</span>
                     <% if match.rotation_match&.started_at %>
                       <span class="text-xs text-gray-500"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
                     <% elsif match.played_at %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,10 +38,10 @@ module VsmobileKgy
 
     # Locale settings
     config.i18n.default_locale = :ja
-    config.i18n.available_locales = [:ja, :en]
+    config.i18n.available_locales = [ :ja, :en ]
 
     # Time zone settings
-    config.time_zone = 'Tokyo'
+    config.time_zone = "Tokyo"
     config.active_record.default_timezone = :local
 
     # Don't generate system test files.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -36,7 +36,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [:username]
+  config.authentication_keys = [ :username ]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -58,12 +58,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:username]
+  config.case_insensitive_keys = [ :username ]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:username]
+  config.strip_whitespace_keys = [ :username ]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  config.skip_session_storage = [ :http_auth ]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
     resources :events, only: [] do
       member do
         post :timestamps
+        post :notify_failure
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    sessions: 'users/sessions'
+    sessions: "users/sessions"
   }
 
   # Guest login
   devise_scope :user do
-    post 'users/guest', to: 'users/sessions#guest', as: :guest_login
+    post "users/guest", to: "users/sessions#guest", as: :guest_login
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
   get "dashboard", to: "dashboard#index", as: :dashboard
 
   # Profile (User settings)
-  resource :profile, only: [:edit, :update]
+  resource :profile, only: [ :edit, :update ]
 
   # Statistics
   get "statistics", to: "statistics#index", as: :statistics
@@ -53,12 +53,12 @@ Rails.application.routes.draw do
       patch :update_timestamps
       post :trigger_analysis
     end
-    resources :matches, only: [:new, :create]
-    resources :rotations, only: [:new, :create]
+    resources :matches, only: [ :new, :create ]
+    resources :rotations, only: [ :new, :create ]
   end
 
   # Matches
-  resources :matches, only: [:index, :show, :edit, :update, :destroy] do
+  resources :matches, only: [ :index, :show, :edit, :update, :destroy ] do
     collection do
       delete :bulk_destroy
     end
@@ -92,8 +92,8 @@ Rails.application.routes.draw do
 
   # Admin
   namespace :admin do
-    resources :announcements, except: [:show]
-    resources :users, except: [:show] do
+    resources :announcements, except: [ :show ]
+    resources :users, except: [ :show ] do
       member do
         post :switch_view
       end
@@ -101,12 +101,12 @@ Rails.application.routes.draw do
         post :clear_view
       end
     end
-    resources :mobile_suits, except: [:show]
-    resources :master_emojis, except: [:show]
-    resources :imports, only: [:new, :create] do
+    resources :mobile_suits, except: [ :show ]
+    resources :master_emojis, except: [ :show ]
+    resources :imports, only: [ :new, :create ] do
       collection do
-        get 'mobile_suits/new', to: 'imports#new_mobile_suits', as: 'new_mobile_suits'
-        post 'mobile_suits', to: 'imports#import_mobile_suits', as: 'import_mobile_suits'
+        get "mobile_suits/new", to: "imports#new_mobile_suits", as: "new_mobile_suits"
+        post "mobile_suits", to: "imports#import_mobile_suits", as: "import_mobile_suits"
       end
     end
   end

--- a/db/migrate/20251229015201_create_rotations.rb
+++ b/db/migrate/20251229015201_create_rotations.rb
@@ -12,7 +12,7 @@ class CreateRotations < ActiveRecord::Migration[8.1]
     end
 
     add_index :rotations, :base_rotation_id
-    add_index :rotations, [:event_id, :is_active]
+    add_index :rotations, [ :event_id, :is_active ]
     add_foreign_key :rotations, :rotations, column: :base_rotation_id
   end
 end

--- a/db/migrate/20251229015319_create_match_players.rb
+++ b/db/migrate/20251229015319_create_match_players.rb
@@ -10,6 +10,6 @@ class CreateMatchPlayers < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :match_players, [:match_id, :position], unique: true
+    add_index :match_players, [ :match_id, :position ], unique: true
   end
 end

--- a/db/migrate/20251229015358_create_rotation_matches.rb
+++ b/db/migrate/20251229015358_create_rotation_matches.rb
@@ -12,7 +12,7 @@ class CreateRotationMatches < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :rotation_matches, [:rotation_id, :match_index], unique: true
+    add_index :rotation_matches, [ :rotation_id, :match_index ], unique: true
     add_index :rotation_matches, :match_id
     add_foreign_key :rotation_matches, :users, column: :team1_player1_id
     add_foreign_key :rotation_matches, :users, column: :team1_player2_id

--- a/db/migrate/20251230220603_add_indexes_to_match_players.rb
+++ b/db/migrate/20251230220603_add_indexes_to_match_players.rb
@@ -4,10 +4,10 @@ class AddIndexesToMatchPlayers < ActiveRecord::Migration[8.1]
     add_index :match_players, :team_number
 
     # Composite indexes for common query patterns
-    add_index :match_players, [:user_id, :mobile_suit_id]
-    add_index :match_players, [:match_id, :team_number]
+    add_index :match_players, [ :user_id, :mobile_suit_id ]
+    add_index :match_players, [ :match_id, :team_number ]
 
     # Event-based queries for dashboard statistics
-    add_index :matches, [:event_id, :played_at]
+    add_index :matches, [ :event_id, :played_at ]
   end
 end

--- a/db/migrate/20260205122912_create_reactions.rb
+++ b/db/migrate/20260205122912_create_reactions.rb
@@ -8,6 +8,6 @@ class CreateReactions < ActiveRecord::Migration[8.1]
       t.timestamps
     end
 
-    add_index :reactions, [:user_id, :match_id, :master_emoji_id], unique: true, name: 'index_reactions_unique'
+    add_index :reactions, [ :user_id, :match_id, :master_emoji_id ], unique: true, name: 'index_reactions_unique'
   end
 end

--- a/db/migrate/20260219235250_create_user_announcement_reads.rb
+++ b/db/migrate/20260219235250_create_user_announcement_reads.rb
@@ -6,6 +6,6 @@ class CreateUserAnnouncementReads < ActiveRecord::Migration[8.1]
 
       t.timestamps
     end
-    add_index :user_announcement_reads, [:user_id, :announcement_id], unique: true
+    add_index :user_announcement_reads, [ :user_id, :announcement_id ], unique: true
   end
 end


### PR DESCRIPTION
## Summary
release/v1.3.1 を main にマージするリリースPRです。

## 主な変更
- リアクション順ソート時の「第○試合」番号が実施順で表示されるよう修正 (#86)
- タイムスタンプ解析ワークフロー失敗時の管理者通知エンドポイントを追加 (#84)
- CI の RuboCop lint エラーと Brakeman 警告を解消（Brakeman 8.0.2 へ更新） (#78)

## 関連Issue・PR
- #87
- #85
- #88