### PR TITLE
fix: 統計の個人ー総合戦績を開くと500エラーになる問題を修正

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -198,8 +198,8 @@ class StatisticsController < ApplicationController
       match = my_mp.match
 
       # rotation_matchがある場合、round_numberを取得
-      if match.rotation_match
-        round_number = match.rotation_match.round_number
+      if match.rotation_match&.rotation
+        round_number = match.rotation_match.rotation.round_number
 
         round_data[round_number][:total] += 1
         round_data[round_number][:wins] += 1 if match.winning_team == my_mp.team_number


### PR DESCRIPTION
## Summary
- 統計ページの個人タブ「総合戦績」を開くと発生していた500エラーを修正

## 原因
`calculate_rotation_round_stats` メソッド内で `match.rotation_match.round_number` とアクセスしていたが、`round_number` カラムは `rotation_matches` テーブルではなく `rotations` テーブルに存在する。そのため NoMethodError が発生し500エラーとなっていた。

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `app/controllers/statistics_controller.rb` | `match.rotation_match.round_number` | `match.rotation_match.rotation.round_number` |
| nil ガード | `if match.rotation_match` | `if match.rotation_match&.rotation` |

## Test plan
- [ ] 統計ページ（/statistics）を開き、個人タブの「総合戦績」が正常に表示されることを確認する

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)