### PR TITLE
chore: リプレイパーサーリポジトリのリネームに伴う設定更新

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -32,7 +32,7 @@ env:
     SOLID_QUEUE_IN_PUMA: true
 
     # GitHub Actions integration (non-secret config)
-    GITHUB_REPO: sp8783/exvs2ib-replay-parser-kgy
+    GITHUB_REPO: sp8783/exvs2ib-replay-parser
     GITHUB_WORKFLOW_ID: analyze.yml
 
     # Database configuration


### PR DESCRIPTION
## Summary
- `config/deploy.yml` の `GITHUB_REPO` を `sp8783/exvs2ib-replay-parser-kgy` → `sp8783/exvs2ib-replay-parser` に更新

## Test plan
- [ ] デプロイ時に GitHub Actions ワークフロー（analyze.yml）が正常にトリガーされることを確認

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)