### PR TITLE
feat: 試合詳細への対戦統計・タイムライン機能を追加

### DIFF
--- a/.brakeman.ignore
+++ b/.brakeman.ignore
@@ -9,7 +9,7 @@
       "note": "broadcast_url is admin-only input validated to start with http(s)://"
     },
     {
-      "fingerprint": "b44cb82aa09e5a06caf26cb2d5969066628ab35501ba4807677f0e7241a34e54",
+      "fingerprint": "652adbfbfa39ac5b41a8897180055a57808e46418bdf665debbf998d9faefe66",
       "note": "video_url is derived from broadcast_url which is admin-only and validated"
     }
   ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (8.0.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)

--- a/app/controllers/match_stats_controller.rb
+++ b/app/controllers/match_stats_controller.rb
@@ -1,0 +1,106 @@
+class MatchStatsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin
+  before_action :set_match
+
+  def edit
+    @players = @match.match_players.includes(:user, :mobile_suit).order(:position)
+    @match_timeline = @match.match_timeline || @match.build_match_timeline
+  end
+
+  def update
+    ActiveRecord::Base.transaction do
+      # チームフラグを更新
+      @match.assign_attributes(match_team_flags_params)
+      @match.save!
+
+      # プレイヤー統計を更新
+      player_stats_params.each do |id, attrs|
+        mp = @match.match_players.find(id)
+        mp.update!(attrs)
+      end
+
+      # タイムラインを更新
+      handle_timeline_update
+    end
+
+    redirect_to @match, notice: "統計データを保存しました。"
+  rescue ActiveRecord::RecordInvalid => e
+    @players = @match.match_players.includes(:user, :mobile_suit).order(:position)
+    @match_timeline = @match.match_timeline || @match.build_match_timeline
+    flash.now[:alert] = "保存に失敗しました: #{e.message}"
+    render :edit, status: :unprocessable_entity
+  end
+
+  def destroy
+    ActiveRecord::Base.transaction do
+      # プレイヤー統計をリセット
+      stat_columns = %i[match_rank score kills deaths damage_dealt damage_received
+                        exburst_damage exburst_count exburst_deaths ex_overlimit_activated]
+      @match.match_players.update_all(stat_columns.index_with(nil))
+
+      # チームフラグをリセット
+      @match.update!(
+        team1_ex_overlimit_before_end: nil,
+        team2_ex_overlimit_before_end: nil
+      )
+
+      # タイムラインを削除
+      @match.match_timeline&.destroy!
+    end
+
+    redirect_to @match, notice: "統計データを削除しました。"
+  rescue => e
+    redirect_to edit_match_stats_path(@match), alert: "削除に失敗しました: #{e.message}"
+  end
+
+  private
+
+  def set_match
+    @match = Match.includes(:event, :match_timeline, match_players: [ :user, :mobile_suit ]).find(params[:match_id])
+  end
+
+  def match_team_flags_params
+    params.require(:match).permit(:team1_ex_overlimit_before_end, :team2_ex_overlimit_before_end)
+  end
+
+  def player_stats_params
+    return {} unless params[:match_players].present?
+
+    stat_fields = %i[match_rank score kills deaths damage_dealt damage_received
+                     exburst_damage exburst_count exburst_deaths ex_overlimit_activated]
+    @match.match_players.each_with_object({}) do |mp, result|
+      next unless params[:match_players][mp.id.to_s]
+      result[mp.id] = params[:match_players][mp.id.to_s].permit(*stat_fields).to_h
+    end
+  end
+
+  def handle_timeline_update
+    raw_json = params.dig(:match_timeline, :timeline_raw_text).presence
+
+    if raw_json.nil?
+      @match.match_timeline&.destroy!
+      return
+    end
+
+    parsed = JSON.parse(raw_json)
+    game_end_cs = parsed["game_end_cs"]
+    game_end_str = parsed["game_end_str"]
+
+    if @match.match_timeline
+      @match.match_timeline.update!(
+        timeline_raw: parsed,
+        game_end_cs: game_end_cs,
+        game_end_str: game_end_str
+      )
+    else
+      @match.create_match_timeline!(
+        timeline_raw: parsed,
+        game_end_cs: game_end_cs,
+        game_end_str: game_end_str
+      )
+    end
+  rescue JSON::ParserError
+    raise ActiveRecord::RecordInvalid.new(MatchTimeline.new.tap { |t| t.errors.add(:timeline_raw, "が不正な JSON 形式です") })
+  end
+end

--- a/app/controllers/match_stats_controller.rb
+++ b/app/controllers/match_stats_controller.rb
@@ -208,7 +208,7 @@ class MatchStatsController < ApplicationController
       # 属性1: 試合を決めた被撃墜時にEX可能域かつ未発動
       last_death_ex_available = if group_key == last_death_group
         last_death = player_events.select { |e| e["is_point"] }.max_by { |e| e["start_cs"] || 0 }
-        ex_available_at.call([last_death["start_cs"], game_end_cs].min) if last_death
+        ex_available_at.call([ last_death["start_cs"], game_end_cs ].min) if last_death
       end
 
       # 属性2: 試合終了時に被撃墜されていないプレイヤー — 試合終了時点でEX可能域かつ未発動

--- a/app/controllers/match_stats_controller.rb
+++ b/app/controllers/match_stats_controller.rb
@@ -10,21 +10,11 @@ class MatchStatsController < ApplicationController
 
   def update
     ActiveRecord::Base.transaction do
-      # チームフラグを更新
-      @match.assign_attributes(match_team_flags_params)
-      @match.save!
-
-      # プレイヤー統計を更新
-      player_stats_params.each do |id, attrs|
-        mp = @match.match_players.find(id)
-        mp.update!(attrs)
-      end
-
-      # スコアの降順で順位を自動計算して保存
-      recalculate_match_ranks
-
-      # タイムラインを更新
+      # タイムラインを更新（フルJSON の場合は統計・チームフラグも自動投入）
       handle_timeline_update
+
+      # スコアの降順で順位を自動計算して保存（統計投入後に実行）
+      recalculate_match_ranks
     end
 
     redirect_to @match, notice: "統計データを保存しました。"
@@ -39,7 +29,8 @@ class MatchStatsController < ApplicationController
     ActiveRecord::Base.transaction do
       # プレイヤー統計をリセット
       stat_columns = %i[match_rank score kills deaths damage_dealt damage_received
-                        exburst_damage exburst_count exburst_deaths ex_overlimit_activated]
+                        exburst_damage exburst_count exburst_deaths
+                        last_death_ex_available survive_loss_ex_available ex_overlimit_activated]
       @match.match_players.update_all(stat_columns.index_with(nil))
 
       # チームフラグをリセット
@@ -63,21 +54,6 @@ class MatchStatsController < ApplicationController
     @match = Match.includes(:event, :match_timeline, match_players: [ :user, :mobile_suit ]).find(params[:match_id])
   end
 
-  def match_team_flags_params
-    params.require(:match).permit(:team1_ex_overlimit_before_end, :team2_ex_overlimit_before_end)
-  end
-
-  def player_stats_params
-    return {} unless params[:match_players].present?
-
-    stat_fields = %i[score kills deaths damage_dealt damage_received
-                     exburst_damage exburst_count exburst_deaths]
-    @match.match_players.each_with_object({}) do |mp, result|
-      next unless params[:match_players][mp.id.to_s]
-      result[mp.id] = params[:match_players][mp.id.to_s].permit(*stat_fields).to_h
-    end
-  end
-
   # スコア降順で1〜4位を自動計算して match_rank に保存
   def recalculate_match_ranks
     players = @match.match_players.reload
@@ -99,23 +75,153 @@ class MatchStatsController < ApplicationController
     end
 
     parsed = JSON.parse(raw_json)
-    game_end_cs = parsed["game_end_cs"]
-    game_end_str = parsed["game_end_str"]
+
+    # フルワークフロー JSON（team_a / team_b を含む）とベア timeline_raw 形式の両方をサポート
+    if parsed["timeline_raw"]
+      # スコア等ワークフローJSONにしか存在しない統計・チームフラグを投入
+      import_from_workflow_json(parsed)
+
+      tl = parsed["timeline_raw"].merge(
+        "_player_order" => {
+          "team1" => parsed.dig("team_a", "players")&.map { |p| p["name"] }&.compact,
+          "team2" => parsed.dig("team_b", "players")&.map { |p| p["name"] }&.compact
+        }.compact
+      )
+    else
+      tl = parsed
+    end
+
+    game_end_cs  = tl["game_end_cs"]
+    game_end_str = tl["game_end_str"]
 
     if @match.match_timeline
       @match.match_timeline.update!(
-        timeline_raw: parsed,
+        timeline_raw: tl,
         game_end_cs: game_end_cs,
         game_end_str: game_end_str
       )
     else
       @match.create_match_timeline!(
-        timeline_raw: parsed,
+        timeline_raw: tl,
         game_end_cs: game_end_cs,
         game_end_str: game_end_str
       )
     end
+
+    # タイムライン保存後に常にタイムライン由来の統計を再計算
+    # ベアJSONの再保存でも exburst_count/deaths・EXバースト残し系フラグが更新される
+    recalculate_timeline_derived_stats
   rescue JSON::ParserError
     raise ActiveRecord::RecordInvalid.new(MatchTimeline.new.tap { |t| t.errors.add(:timeline_raw, "が不正な JSON 形式です") })
+  end
+
+  # フルワークフロー JSON からスコア等（タイムラインに存在しない値）とチームフラグを投入する
+  def import_from_workflow_json(data)
+    name_to_mp = @match.match_players.each_with_object({}) { |mp, h| h[mp.user.nickname] = mp }
+    tl_events  = data.dig("timeline_raw", "events") || []
+
+    # 名前 → グループキーのマッピング（team_a.players[i] → "team1-{i+1}"）
+    name_to_group = {}
+    (data.dig("team_a", "players") || []).each_with_index { |p, i| name_to_group[p["name"]] = "team1-#{i + 1}" }
+    (data.dig("team_b", "players") || []).each_with_index { |p, i| name_to_group[p["name"]] = "team2-#{i + 1}" }
+
+    team_flag_updates = {}
+
+    [ data["team_a"], data["team_b"] ].each do |team_data|
+      next unless team_data
+
+      players = team_data["players"] || []
+
+      # DB team_number を1人目のプレイヤーの名前突合で特定
+      db_team_num = name_to_mp[players.first&.dig("name")]&.team_number
+
+      if db_team_num
+        # チームフラグ: 全員に exbst-ov イベントがない → OL未発動 → true
+        group_keys  = players.map { |p| name_to_group[p["name"]] }.compact
+        team_has_ol = group_keys.any? { |gk| tl_events.any? { |e| e["group"] == gk && e["class_name"] == "exbst-ov" } }
+        team_flag_updates[:"team#{db_team_num}_ex_overlimit_before_end"] = !team_has_ol
+      end
+
+      # スコア・ダメージ等（タイムラインに存在しない値のみ）
+      players.each do |pj|
+        mp = name_to_mp[pj["name"]]
+        next unless mp
+
+        mp.update!(
+          score:           pj["score"],
+          kills:           pj["kills"],
+          deaths:          pj["deaths"],
+          damage_dealt:    pj["damage_dealt"],
+          damage_received: pj["damage_received"],
+          exburst_damage:  pj["exburst_damage"]
+        )
+      end
+    end
+
+    @match.update!(team_flag_updates) if team_flag_updates.any?
+  end
+
+  # 保存済みタイムラインから導出可能な統計を再計算する
+  # ベアJSONの再保存でも正しく動作するよう handle_timeline_update から常に呼ばれる
+  def recalculate_timeline_derived_stats
+    tl = @match.match_timeline
+    return unless tl
+
+    tl_data      = tl.timeline_raw || {}
+    tl_events    = tl_data["events"] || []
+    game_end_cs  = tl_data["game_end_cs"] || Float::INFINITY
+    player_order = tl_data["_player_order"] || {}
+
+    # _player_order から name → group key マッピングを構築
+    name_to_group = {}
+    (player_order["team1"] || []).each_with_index { |name, i| name_to_group[name] = "team1-#{i + 1}" }
+    (player_order["team2"] || []).each_with_index { |name, i| name_to_group[name] = "team2-#{i + 1}" }
+    return if name_to_group.empty?
+
+    name_to_mp       = @match.match_players.each_with_object({}) { |mp, h| h[mp.user.nickname] = mp }
+    last_death_group = tl_events.select { |e| e["is_point"] }.max_by { |e| e["start_cs"] || 0 }&.dig("group")
+
+    name_to_mp.each do |name, mp|
+      group_key = name_to_group[name]
+      next unless group_key
+
+      player_events = tl_events.select { |e| e["group"] == group_key }
+      burst_events  = player_events.select { |e| %w[exbst-f exbst-s exbst-e].include?(e["class_name"]) }
+      ex_zones      = player_events.select { |e| e["class_name"] == "ex" }
+
+      # exburst_count: バースト発動イベントの数
+      exburst_count = burst_events.size
+
+      # exburst_deaths: 被撃墜時刻がバースト区間内に含まれる数
+      exburst_deaths = player_events.select { |e| e["is_point"] }.count do |death|
+        cs = death["start_cs"]
+        burst_events.any? { |b| b["start_cs"] && b["end_cs"] && b["start_cs"] <= cs && cs < b["end_cs"] }
+      end
+
+      # EXゾーン判定ヘルパー
+      ex_available_at = lambda do |cs|
+        in_ex    = ex_zones.any?     { |e| e["start_cs"] && e["end_cs"] && e["start_cs"] <= cs && cs <= e["end_cs"] }
+        in_burst = burst_events.any? { |b| b["start_cs"] && b["end_cs"] && b["start_cs"] <= cs && cs <= b["end_cs"] }
+        in_ex && !in_burst
+      end
+
+      # 属性1: 試合を決めた被撃墜時にEX可能域かつ未発動
+      last_death_ex_available = if group_key == last_death_group
+        last_death = player_events.select { |e| e["is_point"] }.max_by { |e| e["start_cs"] || 0 }
+        ex_available_at.call([last_death["start_cs"], game_end_cs].min) if last_death
+      end
+
+      # 属性2: 試合終了時に被撃墜されていないプレイヤー — 試合終了時点でEX可能域かつ未発動
+      survive_loss_ex_available = if group_key != last_death_group && game_end_cs != Float::INFINITY
+        ex_available_at.call(game_end_cs)
+      end
+
+      mp.update!(
+        exburst_count:             exburst_count,
+        exburst_deaths:            exburst_deaths,
+        last_death_ex_available:   last_death_ex_available,
+        survive_loss_ex_available: survive_loss_ex_available
+      )
+    end
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -159,7 +159,7 @@ class MatchesController < ApplicationController
   end
 
   def set_match
-    @match = Match.includes(:event, match_players: [ :user, :mobile_suit ]).find(params[:id])
+    @match = Match.includes(:event, :match_timeline, match_players: [ :user, :mobile_suit ]).find(params[:id])
   end
 
   def match_params

--- a/app/javascript/controllers/match_timeline_controller.js
+++ b/app/javascript/controllers/match_timeline_controller.js
@@ -1,0 +1,221 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Rendering constants
+const ICON_W    = 55   // left column (mobile suit icon)
+const ROW_H     = 38   // height per player row
+const HEADER_H  = 35   // height of time axis header
+const TEAM_GAP  = 6    // gap between team 1 and team 2
+const BAR_H     = 20   // event bar height
+const BAR_Y_OFF = (ROW_H - BAR_H) / 2  // vertical centering offset for bars
+const END_PAD   = 32   // right padding (END label area)
+
+// class_name → rendering style
+const CLASS_STYLES = {
+  "ex":       { fill: "#9CA3AF", stroke: null },        // EXバースト発動可能域
+  "exbst-f":  { fill: "#F97316", stroke: null },        // ファイティングバースト
+  "exbst-s":  { fill: "#3B82F6", stroke: null },        // シューティングバースト
+  "exbst-e":  { fill: "#22C55E", stroke: null },        // エクステンドバースト
+  "ov":       { fill: "none",    stroke: "#D1FAE5" },   // EXオーバーリミット発動可能域 (outline)
+  "exbst-ov": { fill: "#F1F5F9", stroke: null },        // EXオーバーリミット発動中
+  "xb":       { fill: "#374151", stroke: null },        // EXバーストクロス
+  "com":      { fill: "url(#hatch)", stroke: "#6B7280" }, // データ無し
+}
+
+// Convert centiseconds to "M:SS" display string
+function fmtCs(cs) {
+  const totalSec = Math.floor(cs / 100)
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}:${String(s).padStart(2, "0")}`
+}
+
+function svgEl(tag, attrs = {}, ns = "http://www.w3.org/2000/svg") {
+  const el = document.createElementNS(ns, tag)
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v)
+  return el
+}
+
+export default class extends Controller {
+  static values = { json: String }
+
+  connect() { this.render() }
+  jsonValueChanged() { this.render() }
+
+  render() {
+    const raw = this.jsonValue
+    if (!raw) return
+
+    let data
+    try { data = JSON.parse(raw) } catch {
+      this.element.innerHTML = '<p class="text-red-400 text-xs p-2">タイムラインデータの解析に失敗しました</p>'
+      return
+    }
+
+    const groups   = data.groups   || {}
+    const events   = data.events   || []
+    const gameEndCs = data.game_end_cs || 36000
+
+    // Sort group keys: team1-1, team1-2, team2-1, team2-2
+    const groupKeys = Object.keys(groups).sort((a, b) => {
+      const parse = s => s.replace("team", "").split("-").map(Number)
+      const [at, ai] = parse(a)
+      const [bt, bi] = parse(b)
+      return at !== bt ? at - bt : ai - bi
+    })
+    if (groupKeys.length === 0) return
+
+    const containerW = Math.max(this.element.clientWidth || 700, 550)
+    const chartW     = Math.max(containerW - ICON_W - END_PAD, 400)
+    const scale      = chartW / gameEndCs
+
+    // Y position for each group row
+    const groupY = {}
+    groupKeys.forEach((key, i) => {
+      const gapOffset = key.startsWith("team2") ? TEAM_GAP : 0
+      groupY[key] = HEADER_H + i * ROW_H + gapOffset
+    })
+    const totalH = HEADER_H + groupKeys.length * ROW_H + TEAM_GAP + 12
+    const totalW = ICON_W + chartW + END_PAD
+
+    const NS = "http://www.w3.org/2000/svg"
+    const svg = svgEl("svg", {
+      xmlns: NS,
+      width: "100%",
+      viewBox: `0 0 ${totalW} ${totalH}`,
+      style: `min-width: 550px; display: block; font-family: sans-serif;`,
+    })
+
+    // Defs: hatch pattern
+    const defs = svgEl("defs")
+    defs.innerHTML = `
+      <pattern id="hatch" patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
+        <line x1="0" y1="0" x2="0" y2="6" stroke="#888" stroke-width="2"/>
+      </pattern>`
+    svg.appendChild(defs)
+
+    // Background
+    svg.appendChild(svgEl("rect", { x: 0, y: 0, width: totalW, height: totalH, fill: "#111827" }))
+
+    // Major/minor tick interval
+    const majorInterval = gameEndCs <= 18000 ? 3000 : 6000  // 30s or 60s
+    const minorInterval = 1000                               // 10s
+
+    // Vertical grid lines at major ticks
+    for (let cs = 0; cs <= gameEndCs; cs += majorInterval) {
+      svg.appendChild(svgEl("line", {
+        x1: ICON_W + cs * scale, x2: ICON_W + cs * scale,
+        y1: HEADER_H, y2: totalH - 8,
+        stroke: "#1F2937", "stroke-width": 1,
+      }))
+    }
+
+    // Time axis ticks and labels
+    for (let cs = 0; cs <= gameEndCs; cs += minorInterval) {
+      const x      = ICON_W + cs * scale
+      const isMajor = cs % majorInterval === 0
+      const tickH  = isMajor ? 8 : 4
+      svg.appendChild(svgEl("line", {
+        x1: x, x2: x, y1: HEADER_H - tickH, y2: HEADER_H,
+        stroke: isMajor ? "#9CA3AF" : "#4B5563", "stroke-width": 1,
+      }))
+      if (isMajor) {
+        const t = svgEl("text", {
+          x, y: HEADER_H - 10, "text-anchor": "middle",
+          fill: "#9CA3AF", "font-size": 9,
+        })
+        t.textContent = fmtCs(cs)
+        svg.appendChild(t)
+      }
+    }
+
+    // Player rows: background + icon
+    groupKeys.forEach(key => {
+      const y       = groupY[key]
+      const iconUrl = groups[key]
+      const rowFill = key.startsWith("team1") ? "#1A2332" : "#1A2A22"
+
+      svg.appendChild(svgEl("rect", { x: 0, y, width: totalW, height: ROW_H, fill: rowFill }))
+
+      if (iconUrl) {
+        svg.appendChild(svgEl("image", {
+          href: iconUrl, x: 4, y: y + 3,
+          width: ICON_W - 8, height: ROW_H - 6,
+          preserveAspectRatio: "xMidYMid meet",
+        }))
+      }
+    })
+
+    // Team separator
+    const firstT2 = groupKeys.find(k => k.startsWith("team2"))
+    if (firstT2) {
+      const sepY = groupY[firstT2] - TEAM_GAP / 2
+      svg.appendChild(svgEl("line", {
+        x1: 0, x2: totalW, y1: sepY, y2: sepY,
+        stroke: "#374151", "stroke-width": 1,
+      }))
+    }
+
+    // Events
+    events.forEach(evt => {
+      const y = groupY[evt.group]
+      if (y === undefined) return
+
+      if (evt.is_point) {
+        // Death: red X mark
+        const x  = ICON_W + evt.start_cs * scale
+        const cy = y + ROW_H / 2
+        const s  = 5
+        for (const [dx1, dy1, dx2, dy2] of [[-s,-s,s,s],[s,-s,-s,s]]) {
+          svg.appendChild(svgEl("line", {
+            x1: x + dx1, y1: cy + dy1, x2: x + dx2, y2: cy + dy2,
+            stroke: "#EF4444", "stroke-width": 2.5, "stroke-linecap": "round",
+          }))
+        }
+        return
+      }
+
+      // Bar
+      const style = CLASS_STYLES[evt.class_name] || { fill: "#6B7280", stroke: null }
+      const x = ICON_W + evt.start_cs * scale
+      const w = Math.max((evt.end_cs - evt.start_cs) * scale, 2)
+
+      const bar = svgEl("rect", {
+        x, y: y + BAR_Y_OFF, width: w, height: BAR_H, rx: 3,
+        fill: style.fill,
+      })
+      if (style.stroke) {
+        bar.setAttribute("stroke", style.stroke)
+        bar.setAttribute("stroke-width", 1.5)
+      }
+      svg.appendChild(bar)
+
+      // Diamond marker for exbst-ov (OL active)
+      if (evt.class_name === "exbst-ov" && w >= 10) {
+        const cx = x + w / 2
+        const cy = y + ROW_H / 2
+        const s  = 5
+        const diamond = svgEl("polygon", {
+          points: `${cx},${cy - s} ${cx + s},${cy} ${cx},${cy + s} ${cx - s},${cy}`,
+          fill: "#111827",
+        })
+        svg.appendChild(diamond)
+      }
+    })
+
+    // END marker
+    const endX = ICON_W + gameEndCs * scale
+    svg.appendChild(svgEl("line", {
+      x1: endX, x2: endX, y1: HEADER_H, y2: totalH - 4,
+      stroke: "#D1D5DB", "stroke-width": 1.5, "stroke-dasharray": "4,3",
+    }))
+    const endLabel = svgEl("text", {
+      x: endX + 3, y: HEADER_H + 12,
+      fill: "#D1D5DB", "font-size": 9,
+    })
+    endLabel.textContent = "END"
+    svg.appendChild(endLabel)
+
+    this.element.innerHTML = ""
+    this.element.appendChild(svg)
+  }
+}

--- a/app/javascript/controllers/match_timeline_editor_controller.js
+++ b/app/javascript/controllers/match_timeline_editor_controller.js
@@ -20,13 +20,22 @@ export default class extends Controller {
     }
 
     try {
-      JSON.parse(raw)  // validation only
+      const parsed = JSON.parse(raw)
       this.errorTarget.classList.add("hidden")
       this.errorTarget.textContent = ""
 
+      // フルワークフロー JSON の場合は timeline_raw を抽出し、winner_keys を付加してプレビューに渡す
+      const timelineRaw = parsed.timeline_raw || parsed
+      let winnerKeys = []
+      if (parsed.team_a && parsed.team_b) {
+        const winnerPrefix = parsed.team_a.result === "win" ? "team1-" : "team2-"
+        winnerKeys = Object.keys(timelineRaw.groups || {}).filter(k => k.startsWith(winnerPrefix))
+      }
+      const previewData = { ...timelineRaw, winner_keys: winnerKeys }
+
       // Push new JSON value to the nested match-timeline controller.
       // Stimulus's Value API automatically calls jsonValueChanged() which re-renders.
-      this.chartTarget.dataset.matchTimelineJsonValue = raw
+      this.chartTarget.dataset.matchTimelineJsonValue = JSON.stringify(previewData)
 
       this.previewTarget.classList.remove("hidden")
     } catch (e) {

--- a/app/javascript/controllers/match_timeline_editor_controller.js
+++ b/app/javascript/controllers/match_timeline_editor_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "preview", "chart", "error"]
+
+  connect() {
+    // Show preview for existing timeline data
+    if (this.inputTarget.value.trim()) {
+      this.preview()
+    }
+  }
+
+  preview() {
+    const raw = this.inputTarget.value.trim()
+
+    if (!raw) {
+      this.previewTarget.classList.add("hidden")
+      this.errorTarget.classList.add("hidden")
+      return
+    }
+
+    try {
+      JSON.parse(raw)  // validation only
+      this.errorTarget.classList.add("hidden")
+      this.errorTarget.textContent = ""
+
+      // Push new JSON value to the nested match-timeline controller.
+      // Stimulus's Value API automatically calls jsonValueChanged() which re-renders.
+      this.chartTarget.dataset.matchTimelineJsonValue = raw
+
+      this.previewTarget.classList.remove("hidden")
+    } catch (e) {
+      this.errorTarget.textContent = `JSON 解析エラー: ${e.message}`
+      this.errorTarget.classList.remove("hidden")
+      this.previewTarget.classList.add("hidden")
+    }
+  }
+}

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -4,6 +4,7 @@ class Match < ApplicationRecord
   belongs_to :rotation_match, optional: true
   has_many :match_players, dependent: :destroy
   has_many :reactions, dependent: :destroy
+  has_one :match_timeline, dependent: :destroy
 
   accepts_nested_attributes_for :match_players
 

--- a/app/models/match_player.rb
+++ b/app/models/match_player.rb
@@ -8,4 +8,10 @@ class MatchPlayer < ApplicationRecord
   validates :team_number, presence: true, inclusion: { in: [ 1, 2 ] }
   validates :position, presence: true, inclusion: { in: [ 1, 2, 3, 4 ] }
   validates :position, uniqueness: { scope: :match_id }
+  validates :match_rank, inclusion: { in: [ 1, 2, 3, 4 ] }, allow_nil: true
+
+  def has_stats?
+    score.present? || kills.present? || deaths.present? ||
+      damage_dealt.present? || damage_received.present? || exburst_damage.present?
+  end
 end

--- a/app/models/match_timeline.rb
+++ b/app/models/match_timeline.rb
@@ -1,0 +1,13 @@
+class MatchTimeline < ApplicationRecord
+  belongs_to :match
+
+  validates :timeline_raw, presence: true
+  validate :timeline_raw_must_be_hash
+
+  private
+
+  def timeline_raw_must_be_hash
+    return if timeline_raw.is_a?(Hash)
+    errors.add(:timeline_raw, "は有効なJSON形式ではありません")
+  end
+end

--- a/app/views/match_stats/_player_stats_fields.html.erb
+++ b/app/views/match_stats/_player_stats_fields.html.erb
@@ -1,0 +1,64 @@
+<%# locals: (player:, label:) %>
+<% pfx = "match_players[#{player.id}]" %>
+
+<div class="border border-gray-200 rounded-lg p-4">
+  <h3 class="text-sm font-semibold text-gray-800 mb-3"><%= label %> — <%= player.user.nickname %> (<%= player.mobile_suit.name %>)</h3>
+
+  <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">順位</label>
+      <%= select_tag "#{pfx}[match_rank]",
+          options_for_select([["未設定", ""], ["1位", 1], ["2位", 2], ["3位", 3], ["4位", 4]], player.match_rank),
+          class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">スコア</label>
+      <%= number_field_tag "#{pfx}[score]", player.score, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 12000" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">撃墜</label>
+      <%= number_field_tag "#{pfx}[kills]", player.kills, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">被撃墜</label>
+      <%= number_field_tag "#{pfx}[deaths]", player.deaths, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">与ダメージ</label>
+      <%= number_field_tag "#{pfx}[damage_dealt]", player.damage_dealt, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">被ダメージ</label>
+      <%= number_field_tag "#{pfx}[damage_received]", player.damage_received, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">EXバーストダメージ</label>
+      <%= number_field_tag "#{pfx}[exburst_damage]", player.exburst_damage, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">EXバースト使用回数 ※</label>
+      <%= number_field_tag "#{pfx}[exburst_count]", player.exburst_count, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">バースト中被撃墜 ※</label>
+      <%= number_field_tag "#{pfx}[exburst_deaths]", player.exburst_deaths, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">EX覚醒発動 ※</label>
+      <%= select_tag "#{pfx}[ex_overlimit_activated]",
+          options_for_select([["未設定", ""], ["発動", "true"], ["未発動", "false"]], player.ex_overlimit_activated.nil? ? "" : player.ex_overlimit_activated.to_s),
+          class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+  </div>
+
+  <p class="mt-2 text-xs text-gray-400">※ タイムラインから導出される値</p>
+</div>

--- a/app/views/match_stats/_player_stats_fields.html.erb
+++ b/app/views/match_stats/_player_stats_fields.html.erb
@@ -6,13 +6,6 @@
 
   <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
     <div>
-      <label class="block text-xs font-medium text-gray-600 mb-1">順位</label>
-      <%= select_tag "#{pfx}[match_rank]",
-          options_for_select([["未設定", ""], ["1位", 1], ["2位", 2], ["3位", 3], ["4位", 4]], player.match_rank),
-          class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
-    </div>
-
-    <div>
       <label class="block text-xs font-medium text-gray-600 mb-1">スコア</label>
       <%= number_field_tag "#{pfx}[score]", player.score, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 12000" %>
     </div>
@@ -50,13 +43,6 @@
     <div>
       <label class="block text-xs font-medium text-gray-600 mb-1">バースト中被撃墜 ※</label>
       <%= number_field_tag "#{pfx}[exburst_deaths]", player.exburst_deaths, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
-    </div>
-
-    <div>
-      <label class="block text-xs font-medium text-gray-600 mb-1">EX覚醒発動 ※</label>
-      <%= select_tag "#{pfx}[ex_overlimit_activated]",
-          options_for_select([["未設定", ""], ["発動", "true"], ["未発動", "false"]], player.ex_overlimit_activated.nil? ? "" : player.ex_overlimit_activated.to_s),
-          class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
     </div>
   </div>
 

--- a/app/views/match_stats/edit.html.erb
+++ b/app/views/match_stats/edit.html.erb
@@ -15,74 +15,17 @@
       </div>
     <% end %>
 
-    <%# ---- チーム1 ---- %>
-    <div class="bg-white shadow sm:rounded-lg p-6">
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-semibold text-gray-900">チーム1
-          <% if @match.winning_team == 1 %>
-            <span class="ml-2 px-2 py-0.5 bg-blue-600 text-white rounded-full text-xs font-semibold">WIN</span>
-          <% else %>
-            <span class="ml-2 px-2 py-0.5 bg-red-600 text-white rounded-full text-xs font-semibold">LOSE</span>
-          <% end %>
-        </h2>
-      </div>
-
-      <div class="space-y-6">
-        <% @players.select { |p| p.team_number == 1 }.each_with_index do |player, idx| %>
-          <%= render "match_stats/player_stats_fields", player: player, label: "プレイヤー#{idx + 1}#{idx == 0 ? ' (配信台)' : ''}" %>
-        <% end %>
-      </div>
-
-      <div class="mt-6 pt-4 border-t border-gray-200">
-        <label class="flex items-center gap-3 cursor-pointer">
-          <%= select_tag "match[team1_ex_overlimit_before_end]",
-              options_for_select([["未設定", ""], ["はい（OL前に決着）", "true"], ["いいえ（OL後/未到達）", "false"]], @match.team1_ex_overlimit_before_end.nil? ? "" : @match.team1_ex_overlimit_before_end.to_s),
-              class: "px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
-          <span class="text-sm font-medium text-gray-700">EXオーバーリミット発動可能前に決着がついた</span>
-        </label>
-      </div>
-    </div>
-
-    <%# ---- チーム2 ---- %>
-    <div class="bg-white shadow sm:rounded-lg p-6">
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-semibold text-gray-900">チーム2
-          <% if @match.winning_team == 2 %>
-            <span class="ml-2 px-2 py-0.5 bg-blue-600 text-white rounded-full text-xs font-semibold">WIN</span>
-          <% else %>
-            <span class="ml-2 px-2 py-0.5 bg-red-600 text-white rounded-full text-xs font-semibold">LOSE</span>
-          <% end %>
-        </h2>
-      </div>
-
-      <div class="space-y-6">
-        <% @players.select { |p| p.team_number == 2 }.each_with_index do |player, idx| %>
-          <%= render "match_stats/player_stats_fields", player: player, label: "プレイヤー#{idx + 3}" %>
-        <% end %>
-      </div>
-
-      <div class="mt-6 pt-4 border-t border-gray-200">
-        <label class="flex items-center gap-3 cursor-pointer">
-          <%= select_tag "match[team2_ex_overlimit_before_end]",
-              options_for_select([["未設定", ""], ["はい（OL前に決着）", "true"], ["いいえ（OL後/未到達）", "false"]], @match.team2_ex_overlimit_before_end.nil? ? "" : @match.team2_ex_overlimit_before_end.to_s),
-              class: "px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
-          <span class="text-sm font-medium text-gray-700">EXオーバーリミット発動可能前に決着がついた</span>
-        </label>
-      </div>
-    </div>
-
-    <%# ---- タイムライン ---- %>
     <div class="bg-white shadow sm:rounded-lg p-6"
          data-controller="match-timeline-editor">
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">タイムライン</h2>
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">ワークフロー JSON</h2>
       <p class="text-sm text-gray-500 mb-4">
-        <code class="bg-gray-100 px-1 rounded">timeline_raw</code> の JSON をそのまま貼り付けてください。空にすると削除されます。
+        ワークフロー JSON をそのまま貼り付けて保存してください。プレイヤー統計・チームフラグ・タイムラインが自動投入されます。空にすると全データが削除されます。
       </p>
 
       <%= text_area_tag "match_timeline[timeline_raw_text]",
           (@match_timeline.persisted? ? JSON.pretty_generate(@match_timeline.timeline_raw) : ""),
-          rows: 12,
-          placeholder: '{"groups": {...}, "events": [...], "game_end_cs": 36000, "game_end_str": "6:00.00"}',
+          rows: 16,
+          placeholder: '{"team_a": {...}, "team_b": {...}, "timeline_raw": {...}, ...}',
           class: "w-full px-3 py-2 font-mono text-xs border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500",
           data: { "match-timeline-editor-target": "input", action: "input->match-timeline-editor#preview" } %>
 

--- a/app/views/match_stats/edit.html.erb
+++ b/app/views/match_stats/edit.html.erb
@@ -1,0 +1,116 @@
+<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="mb-6">
+    <%= link_to "← 対戦詳細に戻る", match_path(@match), class: "text-blue-600 hover:text-blue-500" %>
+  </div>
+
+  <h1 class="text-3xl font-bold text-gray-900 mb-2">対戦統計 編集</h1>
+  <p class="text-sm text-gray-600 mb-6">
+    <%= @match.event.name %> ・ <%= @match.played_at.strftime('%Y年%m月%d日') %>
+  </p>
+
+  <%= form_with url: match_stats_path(@match), method: :patch, class: "space-y-6" do |form| %>
+    <% if flash[:alert] %>
+      <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+        <%= flash[:alert] %>
+      </div>
+    <% end %>
+
+    <%# ---- チーム1 ---- %>
+    <div class="bg-white shadow sm:rounded-lg p-6">
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold text-gray-900">チーム1
+          <% if @match.winning_team == 1 %>
+            <span class="ml-2 px-2 py-0.5 bg-blue-600 text-white rounded-full text-xs font-semibold">WIN</span>
+          <% else %>
+            <span class="ml-2 px-2 py-0.5 bg-red-600 text-white rounded-full text-xs font-semibold">LOSE</span>
+          <% end %>
+        </h2>
+      </div>
+
+      <div class="space-y-6">
+        <% @players.select { |p| p.team_number == 1 }.each_with_index do |player, idx| %>
+          <%= render "match_stats/player_stats_fields", player: player, label: "プレイヤー#{idx + 1}#{idx == 0 ? ' (配信台)' : ''}" %>
+        <% end %>
+      </div>
+
+      <div class="mt-6 pt-4 border-t border-gray-200">
+        <label class="flex items-center gap-3 cursor-pointer">
+          <%= select_tag "match[team1_ex_overlimit_before_end]",
+              options_for_select([["未設定", ""], ["はい（OL前に決着）", "true"], ["いいえ（OL後/未到達）", "false"]], @match.team1_ex_overlimit_before_end.nil? ? "" : @match.team1_ex_overlimit_before_end.to_s),
+              class: "px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+          <span class="text-sm font-medium text-gray-700">EXオーバーリミット発動可能前に決着がついた</span>
+        </label>
+      </div>
+    </div>
+
+    <%# ---- チーム2 ---- %>
+    <div class="bg-white shadow sm:rounded-lg p-6">
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold text-gray-900">チーム2
+          <% if @match.winning_team == 2 %>
+            <span class="ml-2 px-2 py-0.5 bg-blue-600 text-white rounded-full text-xs font-semibold">WIN</span>
+          <% else %>
+            <span class="ml-2 px-2 py-0.5 bg-red-600 text-white rounded-full text-xs font-semibold">LOSE</span>
+          <% end %>
+        </h2>
+      </div>
+
+      <div class="space-y-6">
+        <% @players.select { |p| p.team_number == 2 }.each_with_index do |player, idx| %>
+          <%= render "match_stats/player_stats_fields", player: player, label: "プレイヤー#{idx + 3}" %>
+        <% end %>
+      </div>
+
+      <div class="mt-6 pt-4 border-t border-gray-200">
+        <label class="flex items-center gap-3 cursor-pointer">
+          <%= select_tag "match[team2_ex_overlimit_before_end]",
+              options_for_select([["未設定", ""], ["はい（OL前に決着）", "true"], ["いいえ（OL後/未到達）", "false"]], @match.team2_ex_overlimit_before_end.nil? ? "" : @match.team2_ex_overlimit_before_end.to_s),
+              class: "px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+          <span class="text-sm font-medium text-gray-700">EXオーバーリミット発動可能前に決着がついた</span>
+        </label>
+      </div>
+    </div>
+
+    <%# ---- タイムライン ---- %>
+    <div class="bg-white shadow sm:rounded-lg p-6"
+         data-controller="match-timeline-editor">
+      <h2 class="text-lg font-semibold text-gray-900 mb-1">タイムライン</h2>
+      <p class="text-sm text-gray-500 mb-4">
+        <code class="bg-gray-100 px-1 rounded">timeline_raw</code> の JSON をそのまま貼り付けてください。空にすると削除されます。
+      </p>
+
+      <%= text_area_tag "match_timeline[timeline_raw_text]",
+          (@match_timeline.persisted? ? JSON.pretty_generate(@match_timeline.timeline_raw) : ""),
+          rows: 12,
+          placeholder: '{"groups": {...}, "events": [...], "game_end_cs": 36000, "game_end_str": "6:00.00"}',
+          class: "w-full px-3 py-2 font-mono text-xs border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500",
+          data: { "match-timeline-editor-target": "input", action: "input->match-timeline-editor#preview" } %>
+
+      <div class="mt-3 text-xs text-red-600 hidden" data-match-timeline-editor-target="error"></div>
+
+      <%# プレビュー %>
+      <div class="mt-4 hidden" data-match-timeline-editor-target="preview">
+        <p class="text-xs font-medium text-gray-500 mb-2">プレビュー</p>
+        <div data-controller="match-timeline"
+             data-match-timeline-json-value=""
+             data-match-timeline-editor-target="chart"
+             class="overflow-x-auto rounded border border-gray-200 bg-gray-900">
+        </div>
+      </div>
+    </div>
+
+    <%# ---- ボタン ---- %>
+    <div class="flex justify-between items-center">
+      <%= button_to "統計データを全削除",
+          match_stats_path(@match),
+          method: :delete,
+          data: { turbo_confirm: "この試合の統計データをすべて削除してもよろしいですか？" },
+          class: "px-4 py-2 bg-red-600 text-white font-semibold rounded-md hover:bg-red-700" %>
+
+      <div class="flex space-x-3">
+        <%= link_to "キャンセル", match_path(@match), class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
+        <%= submit_tag "保存", class: "px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700 cursor-pointer" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/matches/_rank_badge.html.erb
+++ b/app/views/matches/_rank_badge.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (rank: nil) %>
+<% if rank %>
+  <% badge_class = case rank
+    when 1 then "bg-yellow-400 text-yellow-900"
+    when 2 then "bg-gray-300 text-gray-700"
+    when 3 then "bg-orange-400 text-orange-900"
+    else        "bg-gray-100 text-gray-500"
+    end %>
+  <span class="inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold <%= badge_class %>">
+    <%= rank %>
+  </span>
+<% end %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -146,7 +146,6 @@
                       <th class="px-3 py-2 text-right">EXバーストダメ</th>
                       <th class="px-3 py-2 text-right">バースト回数</th>
                       <th class="px-3 py-2 text-right">バースト中被撃墜</th>
-                      <th class="px-3 py-2 text-center">EX覚醒</th>
                     </tr>
                   </thead>
                   <tbody class="divide-y divide-gray-100">
@@ -166,15 +165,6 @@
                         <td class="px-3 py-2 text-right text-gray-700"><%= number_with_delimiter(player.exburst_damage) if player.exburst_damage %></td>
                         <td class="px-3 py-2 text-right text-gray-700"><%= player.exburst_count %></td>
                         <td class="px-3 py-2 text-right text-gray-700"><%= player.exburst_deaths %></td>
-                        <td class="px-3 py-2 text-center">
-                          <% unless player.ex_overlimit_activated.nil? %>
-                            <% if player.ex_overlimit_activated %>
-                              <span class="text-green-600 font-semibold">発動</span>
-                            <% else %>
-                              <span class="text-gray-400">未発動</span>
-                            <% end %>
-                          <% end %>
-                        </td>
                       </tr>
                     <% end %>
                   </tbody>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -23,8 +23,9 @@
           </div>
         </div>
         <% if current_user.is_admin? %>
-          <div class="flex space-x-3">
+          <div class="flex flex-wrap gap-2">
             <%= link_to "編集", edit_match_path(@match), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded" %>
+            <%= link_to "統計を編集", edit_match_stats_path(@match), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
             <%= button_to "削除", match_path(@match), method: :delete, data: { turbo_confirm: "この対戦記録を削除してもよろしいですか？" }, class: "bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded" %>
           </div>
         <% end %>
@@ -38,8 +39,8 @@
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <% team1_players = @match.match_players.where(team_number: 1).order(:position) %>
-        <% team2_players = @match.match_players.where(team_number: 2).order(:position) %>
+        <% team1_players = @match.match_players.select { |p| p.team_number == 1 }.sort_by(&:position) %>
+        <% team2_players = @match.match_players.select { |p| p.team_number == 2 }.sort_by(&:position) %>
 
         <!-- Team 1 -->
         <div class="<%= @match.winning_team == 1 ? 'bg-blue-50 border-2 border-blue-400 rounded-lg p-6' : 'bg-red-50 border-2 border-red-400 rounded-lg p-6' %>">
@@ -57,12 +58,15 @@
               <div class="bg-white rounded-lg p-4 shadow-sm">
                 <div class="flex items-start justify-between">
                   <div class="flex-1">
-                    <p class="text-lg font-semibold <%= index == 0 ? 'text-red-600' : 'text-gray-900' %>">
-                      <%= player.user.nickname %>
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <%= render "matches/rank_badge", rank: player.match_rank %>
+                      <p class="text-lg font-semibold <%= index == 0 ? 'text-red-600' : 'text-gray-900' %>">
+                        <%= player.user.nickname %>
+                      </p>
                       <% if index == 0 %>
-                        <span class="ml-2 px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
+                        <span class="px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
                       <% end %>
-                    </p>
+                    </div>
                     <div class="mt-2">
                       <p class="text-sm text-gray-500">使用機体</p>
                       <p class="text-sm font-medium text-gray-900 flex items-center gap-2">
@@ -93,7 +97,10 @@
               <div class="bg-white rounded-lg p-4 shadow-sm">
                 <div class="flex items-start justify-between">
                   <div class="flex-1">
-                    <p class="text-lg font-semibold text-gray-900"><%= player.user.nickname %></p>
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <%= render "matches/rank_badge", rank: player.match_rank %>
+                      <p class="text-lg font-semibold text-gray-900"><%= player.user.nickname %></p>
+                    </div>
                     <div class="mt-2">
                       <p class="text-sm text-gray-500">使用機体</p>
                       <p class="text-sm font-medium text-gray-900 flex items-center gap-2">
@@ -108,6 +115,108 @@
           </div>
         </div>
       </div>
+
+      <!-- 対戦統計セクション -->
+      <% all_players = team1_players + team2_players %>
+      <% has_stats = all_players.any?(&:has_stats?) || !@match.team1_ex_overlimit_before_end.nil? || !@match.team2_ex_overlimit_before_end.nil? %>
+      <% if has_stats %>
+        <div class="mt-8">
+          <h2 class="text-lg font-bold text-gray-900 mb-4">対戦統計</h2>
+
+          <% [[team1_players, 1], [team2_players, 2]].each do |players, team_num| %>
+            <div class="mb-6">
+              <h3 class="text-sm font-semibold text-gray-600 mb-2">
+                チーム<%= team_num %>
+                <% if @match.winning_team == team_num %>
+                  <span class="ml-1 text-blue-600">WIN</span>
+                <% else %>
+                  <span class="ml-1 text-red-600">LOSE</span>
+                <% end %>
+              </h3>
+              <div class="overflow-x-auto">
+                <table class="min-w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
+                  <thead class="bg-gray-50 text-xs text-gray-500 uppercase">
+                    <tr>
+                      <th class="px-3 py-2 text-left">プレイヤー</th>
+                      <th class="px-3 py-2 text-right">スコア</th>
+                      <th class="px-3 py-2 text-right">撃墜</th>
+                      <th class="px-3 py-2 text-right">被撃墜</th>
+                      <th class="px-3 py-2 text-right">与ダメ</th>
+                      <th class="px-3 py-2 text-right">被ダメ</th>
+                      <th class="px-3 py-2 text-right">EXバーストダメ</th>
+                      <th class="px-3 py-2 text-right">バースト回数</th>
+                      <th class="px-3 py-2 text-right">バースト中被撃墜</th>
+                      <th class="px-3 py-2 text-center">EX覚醒</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-gray-100">
+                    <% players.each do |player| %>
+                      <tr class="bg-white hover:bg-gray-50">
+                        <td class="px-3 py-2 font-medium text-gray-900 whitespace-nowrap">
+                          <div class="flex items-center gap-2">
+                            <%= render "matches/rank_badge", rank: player.match_rank %>
+                            <%= player.user.nickname %>
+                          </div>
+                        </td>
+                        <td class="px-3 py-2 text-right text-gray-700"><%= number_with_delimiter(player.score) if player.score %></td>
+                        <td class="px-3 py-2 text-right text-gray-700"><%= player.kills %></td>
+                        <td class="px-3 py-2 text-right text-gray-700"><%= player.deaths %></td>
+                        <td class="px-3 py-2 text-right text-gray-700"><%= number_with_delimiter(player.damage_dealt) if player.damage_dealt %></td>
+                        <td class="px-3 py-2 text-right text-gray-700"><%= number_with_delimiter(player.damage_received) if player.damage_received %></td>
+                        <td class="px-3 py-2 text-right text-gray-700"><%= number_with_delimiter(player.exburst_damage) if player.exburst_damage %></td>
+                        <td class="px-3 py-2 text-right text-gray-700"><%= player.exburst_count %></td>
+                        <td class="px-3 py-2 text-right text-gray-700"><%= player.exburst_deaths %></td>
+                        <td class="px-3 py-2 text-center">
+                          <% unless player.ex_overlimit_activated.nil? %>
+                            <% if player.ex_overlimit_activated %>
+                              <span class="text-green-600 font-semibold">発動</span>
+                            <% else %>
+                              <span class="text-gray-400">未発動</span>
+                            <% end %>
+                          <% end %>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+
+              <% ol_flag = team_num == 1 ? @match.team1_ex_overlimit_before_end : @match.team2_ex_overlimit_before_end %>
+              <% unless ol_flag.nil? %>
+                <p class="mt-2 text-xs text-gray-500">
+                  EXオーバーリミット発動可能前決着:
+                  <% if ol_flag %>
+                    <span class="text-amber-600 font-semibold">はい（OL前に決着）</span>
+                  <% else %>
+                    <span class="text-gray-600">いいえ</span>
+                  <% end %>
+                </p>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <!-- タイムラインセクション -->
+      <% if @match.match_timeline %>
+        <div class="mt-8">
+          <h2 class="text-lg font-bold text-gray-900 mb-4">タイムライン</h2>
+          <div class="overflow-x-auto rounded-lg border border-gray-200 bg-gray-900 p-4"
+               data-controller="match-timeline"
+               data-match-timeline-json-value="<%= @match.match_timeline.timeline_raw.to_json.html_safe %>">
+          </div>
+          <div class="mt-2 flex flex-wrap gap-4 text-xs text-gray-500">
+            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-gray-400 rounded"></span>EXバースト発動可能域</span>
+            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-orange-500 rounded"></span>ファイティングバースト</span>
+            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-blue-500 rounded"></span>シューティングバースト</span>
+            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-green-500 rounded"></span>エクステンドバースト</span>
+            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 border border-white rounded" style="background:transparent"></span>EXオーバーリミット発動可能域</span>
+            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-white rounded"></span>EXオーバーリミット発動中</span>
+            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-gray-700 rounded"></span>EXバーストクロス</span>
+            <span class="flex items-center gap-1 text-red-500 font-bold">✕</span><span>被撃墜</span>
+          </div>
+        </div>
+      <% end %>
 
       <!-- リアクションバー -->
       <%= render "reactions/reaction_bar", match: @match %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -203,7 +203,7 @@
           <h2 class="text-lg font-bold text-gray-900 mb-4">タイムライン</h2>
           <div class="overflow-x-auto rounded-lg border border-gray-200 bg-gray-900 p-4"
                data-controller="match-timeline"
-               data-match-timeline-json-value="<%= @match.match_timeline.timeline_raw.to_json.html_safe %>">
+               data-match-timeline-json-value="<%= @match.match_timeline.timeline_raw.to_json %>">
           </div>
           <div class="mt-2 flex flex-wrap gap-4 text-xs text-gray-500">
             <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-gray-400 rounded"></span>EXバースト発動可能域</span>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_from "match_#{@match.id}_reactions" %>
 
-<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
   <div class="mb-6">
     <%= link_to "← 対戦履歴に戻る", matches_path, class: "text-blue-600 hover:text-blue-500" %>
   </div>
@@ -124,10 +124,11 @@
           <h2 class="text-lg font-bold text-gray-900 mb-4">対戦統計</h2>
 
           <% [[team1_players, 1], [team2_players, 2]].each do |players, team_num| %>
+            <% is_winner = @match.winning_team == team_num %>
             <div class="mb-6">
               <h3 class="text-sm font-semibold text-gray-600 mb-2">
                 チーム<%= team_num %>
-                <% if @match.winning_team == team_num %>
+                <% if is_winner %>
                   <span class="ml-1 text-blue-600">WIN</span>
                 <% else %>
                   <span class="ml-1 text-red-600">LOSE</span>
@@ -141,11 +142,12 @@
                       <th class="px-3 py-2 text-right">スコア</th>
                       <th class="px-3 py-2 text-right">撃墜</th>
                       <th class="px-3 py-2 text-right">被撃墜</th>
-                      <th class="px-3 py-2 text-right">与ダメ</th>
-                      <th class="px-3 py-2 text-right">被ダメ</th>
-                      <th class="px-3 py-2 text-right">EXバーストダメ</th>
-                      <th class="px-3 py-2 text-right">バースト回数</th>
-                      <th class="px-3 py-2 text-right">バースト中被撃墜</th>
+                      <th class="px-3 py-2 text-right">与ダメージ</th>
+                      <th class="px-3 py-2 text-right">被ダメージ</th>
+                      <th class="px-3 py-2 text-right">EXバーストダメージ</th>
+                      <th class="px-3 py-2 text-right">EXバースト回数</th>
+                      <th class="px-3 py-2 text-right">EXバースト中被撃墜</th>
+                      <th class="px-3 py-2 text-right <%= is_winner ? 'text-gray-300' : '' %>">EXバースト残し</th>
                     </tr>
                   </thead>
                   <tbody class="divide-y divide-gray-100">
@@ -165,22 +167,42 @@
                         <td class="px-3 py-2 text-right text-gray-700"><%= number_with_delimiter(player.exburst_damage) if player.exburst_damage %></td>
                         <td class="px-3 py-2 text-right text-gray-700"><%= player.exburst_count %></td>
                         <td class="px-3 py-2 text-right text-gray-700"><%= player.exburst_deaths %></td>
+                        <td class="px-3 py-2 text-right">
+                          <% if is_winner %>
+                            <span class="text-gray-300">―</span>
+                          <% elsif player.last_death_ex_available || player.survive_loss_ex_available %>
+                            <span class="px-1.5 py-0.5 rounded bg-red-100 text-red-700 text-xs font-semibold">あり</span>
+                          <% elsif player.last_death_ex_available == false || player.survive_loss_ex_available == false %>
+                            <span class="text-gray-500">なし</span>
+                          <% else %>
+                            <span class="text-gray-300">―</span>
+                          <% end %>
+                        </td>
                       </tr>
                     <% end %>
                   </tbody>
                 </table>
               </div>
 
+              <% unless is_winner %>
+                <p class="mt-1 text-xs text-gray-400">※ EXバースト残し: 敗北チームのみ・EXバーストを持ったまま敗戦</p>
+              <% end %>
               <% ol_flag = team_num == 1 ? @match.team1_ex_overlimit_before_end : @match.team2_ex_overlimit_before_end %>
               <% unless ol_flag.nil? %>
-                <p class="mt-2 text-xs text-gray-500">
-                  EXオーバーリミット発動可能前決着:
+                <div class="mt-2 flex items-center gap-2 text-xs">
+                  <span class="text-gray-400">EXオーバーリミット:</span>
                   <% if ol_flag %>
-                    <span class="text-amber-600 font-semibold">はい（OL前に決着）</span>
+                    <%# ol_flag=true = OL未発動（exbst-ovイベントなし） %>
+                    <% if is_winner %>
+                      <span class="px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 font-semibold">OL未発動で勝利</span>
+                    <% else %>
+                      <span class="px-2 py-0.5 rounded-full bg-red-100 text-red-700 font-semibold">OL未発動で敗北</span>
+                    <% end %>
                   <% else %>
-                    <span class="text-gray-600">いいえ</span>
+                    <%# ol_flag=false = OL発動あり %>
+                    <span class="px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 font-semibold">OL発動あり</span>
                   <% end %>
-                </p>
+                </div>
               <% end %>
             </div>
           <% end %>
@@ -189,21 +211,70 @@
 
       <!-- タイムラインセクション -->
       <% if @match.match_timeline %>
+        <%
+          _raw          = @match.match_timeline.timeline_raw
+          _player_order = _raw["_player_order"]
+          # _player_order: { "team1" => ["ぱぴこ", "りーん"], "team2" => ["ラソ", "まき神"] }
+          # ワークフロー JSON から保存時に生成。グループキーの配列インデックスと対応。
+
+          if _player_order
+            # ニックネームで DB の match_player と突合し、正しい team_number・position を取得
+            _name_to_mp = @match.match_players.each_with_object({}) { |mp, h| h[mp.user.nickname] = mp }
+
+            # グループキー → match_player のマッピング
+            _key_to_mp = {}
+            (_player_order["team1"] || []).each_with_index { |name, i| mp = _name_to_mp[name]; _key_to_mp["team1-#{i + 1}"] = mp if mp }
+            (_player_order["team2"] || []).each_with_index { |name, i| mp = _name_to_mp[name]; _key_to_mp["team2-#{i + 1}"] = mp if mp }
+
+            # group_order: DB team_number → DB position 昇順（統計表・チームカードと同じ並び）
+            _group_order = _key_to_mp.keys.sort_by { |k| mp = _key_to_mp[k]; mp ? [mp.team_number, mp.position] : [99, 99] }
+
+            # team_info: グループキー → DB team_number（JS のチームカラー・セパレーター判定用）
+            _team_info = _key_to_mp.transform_values(&:team_number)
+
+            _winner_keys = _group_order.select { |k| _team_info[k] == @match.winning_team }
+            _timeline_data = _raw.merge("group_order" => _group_order, "team_info" => _team_info, "winner_keys" => _winner_keys)
+          else
+            # 規約フォールバック: team1-1 = team1 の position が小さい方（配信台）
+            _group_order = (
+              team1_players.each_with_index.map { |_, i| "team1-#{i + 1}" } +
+              team2_players.each_with_index.map { |_, i| "team2-#{i + 1}" }
+            )
+            _winner_prefix = "team#{@match.winning_team}-"
+            _winner_keys = _group_order.select { |k| k.start_with?(_winner_prefix) }
+            _timeline_data = _raw.merge("group_order" => _group_order, "winner_keys" => _winner_keys)
+          end
+        %>
         <div class="mt-8">
           <h2 class="text-lg font-bold text-gray-900 mb-4">タイムライン</h2>
-          <div class="overflow-x-auto rounded-lg border border-gray-200 bg-gray-900 p-4"
+          <div class="overflow-x-auto rounded-xl shadow-md bg-indigo-50 p-4"
                data-controller="match-timeline"
-               data-match-timeline-json-value="<%= @match.match_timeline.timeline_raw.to_json %>">
+               data-match-timeline-json-value="<%= _timeline_data.to_json %>">
           </div>
-          <div class="mt-2 flex flex-wrap gap-4 text-xs text-gray-500">
-            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-gray-400 rounded"></span>EXバースト発動可能域</span>
-            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-orange-500 rounded"></span>ファイティングバースト</span>
-            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-blue-500 rounded"></span>シューティングバースト</span>
-            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-green-500 rounded"></span>エクステンドバースト</span>
-            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 border border-white rounded" style="background:transparent"></span>EXオーバーリミット発動可能域</span>
-            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-white rounded"></span>EXオーバーリミット発動中</span>
-            <span class="flex items-center gap-1"><span class="inline-block w-4 h-2 bg-gray-700 rounded"></span>EXバーストクロス</span>
-            <span class="flex items-center gap-1 text-red-500 font-bold">✕</span><span>被撃墜</span>
+          <div class="mt-2 text-xs text-gray-500 space-y-2">
+            <div>
+              <span class="font-semibold text-gray-400">上段 — EXバースト系</span>
+              <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+                <span class="flex items-center gap-1"><span class="inline-block w-4 rounded" style="height:8px;background:#C7D2FE"></span>EXバースト発動可能域</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-4 rounded" style="height:8px;background:#F97316"></span>ファイティングバースト</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-4 rounded" style="height:8px;background:#3B82F6"></span>シューティングバースト</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-4 rounded" style="height:8px;background:#22C55E"></span>エクステンドバースト</span>
+                <span class="flex items-center gap-1"><span class="inline-block rounded" style="width:20px;height:14px;background:#EDE9FE"></span>EXバーストクロス</span>
+              </div>
+            </div>
+            <div>
+              <span class="font-semibold text-purple-600">下段 — EXオーバーリミット系</span>
+              <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+                <span class="flex items-center gap-1"><span class="inline-block w-4 rounded" style="height:6px;background:#DDD6FE"></span>EXオーバーリミット発動可能域</span>
+                <span class="flex items-center gap-1"><span class="inline-block w-4 rounded" style="height:6px;background:#8B5CF6"></span>EXオーバーリミット発動中</span>
+              </div>
+            </div>
+            <div>
+              <span class="font-semibold text-red-500">マーカー</span>
+              <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+                <span class="flex items-center gap-1"><span class="font-black text-red-500" style="font-size:14px;line-height:1">✕</span>被撃墜</span>
+              </div>
+            </div>
           </div>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
         post :toggle
       end
     end
+    resource :stats, controller: "match_stats", only: [ :edit, :update, :destroy ]
   end
 
   # Rotations

--- a/db/migrate/20260225124639_add_stats_to_match_players.rb
+++ b/db/migrate/20260225124639_add_stats_to_match_players.rb
@@ -1,0 +1,14 @@
+class AddStatsToMatchPlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :match_players, :match_rank, :integer
+    add_column :match_players, :score, :integer
+    add_column :match_players, :kills, :integer
+    add_column :match_players, :deaths, :integer
+    add_column :match_players, :damage_dealt, :integer
+    add_column :match_players, :damage_received, :integer
+    add_column :match_players, :exburst_damage, :integer
+    add_column :match_players, :exburst_count, :integer
+    add_column :match_players, :exburst_deaths, :integer
+    add_column :match_players, :ex_overlimit_activated, :boolean
+  end
+end

--- a/db/migrate/20260225124643_add_team_flags_to_matches.rb
+++ b/db/migrate/20260225124643_add_team_flags_to_matches.rb
@@ -1,0 +1,6 @@
+class AddTeamFlagsToMatches < ActiveRecord::Migration[8.1]
+  def change
+    add_column :matches, :team1_ex_overlimit_before_end, :boolean
+    add_column :matches, :team2_ex_overlimit_before_end, :boolean
+  end
+end

--- a/db/migrate/20260225124646_create_match_timelines.rb
+++ b/db/migrate/20260225124646_create_match_timelines.rb
@@ -1,0 +1,12 @@
+class CreateMatchTimelines < ActiveRecord::Migration[8.1]
+  def change
+    create_table :match_timelines do |t|
+      t.references :match, null: false, foreign_key: true, index: { unique: true }
+      t.jsonb    :timeline_raw, null: false
+      t.integer  :game_end_cs
+      t.string   :game_end_str
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260227001008_add_ex_available_deaths_to_match_players.rb
+++ b/db/migrate/20260227001008_add_ex_available_deaths_to_match_players.rb
@@ -1,0 +1,5 @@
+class AddExAvailableDeathsToMatchPlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :match_players, :last_death_ex_available, :boolean
+  end
+end

--- a/db/migrate/20260227124645_add_survive_loss_ex_available_to_match_players.rb
+++ b/db/migrate/20260227124645_add_survive_loss_ex_available_to_match_players.rb
@@ -1,0 +1,5 @@
+class AddSurviveLossExAvailableToMatchPlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :match_players, :survive_loss_ex_available, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_25_124646) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_27_124645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -53,11 +53,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_25_124646) do
     t.integer "exburst_damage"
     t.integer "exburst_deaths"
     t.integer "kills"
+    t.boolean "last_death_ex_available"
     t.bigint "match_id", null: false
     t.integer "match_rank"
     t.bigint "mobile_suit_id", null: false
     t.integer "position", null: false
     t.integer "score"
+    t.boolean "survive_loss_ex_available"
     t.integer "team_number", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_19_235250) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_25_124646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -45,9 +45,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_235250) do
 
   create_table "match_players", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "damage_dealt"
+    t.integer "damage_received"
+    t.integer "deaths"
+    t.boolean "ex_overlimit_activated"
+    t.integer "exburst_count"
+    t.integer "exburst_damage"
+    t.integer "exburst_deaths"
+    t.integer "kills"
     t.bigint "match_id", null: false
+    t.integer "match_rank"
     t.bigint "mobile_suit_id", null: false
     t.integer "position", null: false
+    t.integer "score"
     t.integer "team_number", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
@@ -60,12 +70,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_235250) do
     t.index ["user_id"], name: "index_match_players_on_user_id"
   end
 
+  create_table "match_timelines", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "game_end_cs"
+    t.string "game_end_str"
+    t.bigint "match_id", null: false
+    t.jsonb "timeline_raw", null: false
+    t.datetime "updated_at", null: false
+    t.index ["match_id"], name: "index_match_timelines_on_match_id", unique: true
+  end
+
   create_table "matches", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "event_id", null: false
     t.datetime "played_at", null: false
     t.integer "reactions_count", default: 0, null: false
     t.bigint "rotation_match_id"
+    t.boolean "team1_ex_overlimit_before_end"
+    t.boolean "team2_ex_overlimit_before_end"
     t.datetime "updated_at", null: false
     t.integer "video_timestamp"
     t.integer "winning_team", null: false
@@ -167,6 +189,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_235250) do
   add_foreign_key "match_players", "matches"
   add_foreign_key "match_players", "mobile_suits"
   add_foreign_key "match_players", "users"
+  add_foreign_key "match_timelines", "matches"
   add_foreign_key "matches", "events"
   add_foreign_key "matches", "rotation_matches"
   add_foreign_key "push_subscriptions", "users"


### PR DESCRIPTION
## Summary

### DB・モデル
- `match_players` に統計カラムを追加（score, kills, deaths, damage_dealt, damage_received, exburst_damage, exburst_count, exburst_deaths, last_death_ex_available, survive_loss_ex_available）
- `matches` にチーム単位 OL フラグを追加（team1/2_ex_overlimit_before_end）
- `match_timelines` テーブルを新規作成（timeline_raw:jsonb + game_end_cs/str）

### 統計編集（MatchStatsController）
- 手動入力フォームをワークフロー JSON 一括入力に刷新（管理者のみ）
- フルワークフロー JSON（team_a / team_b 含む）とベア timeline_raw の両形式に対応
- タイムライン保存後に常に `recalculate_timeline_derived_stats` を呼び、exburst_count / exburst_deaths / EXバースト残しフラグを再計算
- 統計データ全削除ボタンで全カラムをリセット

### EXバースト残しフラグ（ADR-003）
- `last_death_ex_available`: 試合を決めた被撃墜プレイヤーの死亡時に EX 可能域だったか
- `survive_loss_ex_available`: 試合終了時に生存していた敗北プレイヤーが EX 可能域だったか
- DB は2カラムで別管理し、表示は「あり/なし」で統一

### タイムライン可視化（Stimulus）
- ライトテーマ・インディゴブランドカラーに刷新
- 上段レーン（EXバースト系）・下段レーン（OLリミット系）の2レーン構成
- 3パス描画: XB背景 → レーンバー → 被撃墜縦線
- `winner_keys` をサーバー側で計算して渡し、チームカラーを確実に判定

### 試合詳細画面（show）
- 統計テーブルのカラム名を正式表記に統一（EXバースト回数・与ダメージ 等）
- OL フラグを色付きバッジ表示（青=OL未発動で勝利、赤=OL未発動で敗北、灰=OL発動あり）
- 敗北チームに「EXバースト残し」列を追加（あり/なし/―）

## Test plan
- [ ] ワークフロー JSON を貼り付けて保存 → 統計・タイムラインが正しく表示される
- [ ] ベア timeline_raw を再保存 → exburst_count / exburst_deaths / EXバースト残しが再計算される
- [ ] 統計データ全削除 → 全カラムがリセットされテーブル・タイムラインが非表示になる
- [ ] 勝利チームの OL バッジが青、敗北チームが赤または灰で表示される
- [ ] 敗北チームの EXバースト残し列が「あり」「なし」「―」で正しく表示される
- [ ] タイムライン SVG の勝利チームが青、敗北チームが赤で表示される
- [ ] bin/rails db:migrate が正常完了する

Closes #98