### PR TITLE
feat: 統計データ自動投入用 API エンドポイントを追加

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -53,7 +53,7 @@ module Api
       event = Event.find_by(id: params[:id])
       return render json: { error: "Event not found" }, status: :not_found unless event
 
-      matches_data = request.request_parameters
+      matches_data = JSON.parse(request.body.read)
       unless matches_data.is_a?(Array)
         return render json: { error: "リクエストボディは JSON 配列である必要があります" }, status: :unprocessable_entity
       end
@@ -75,6 +75,8 @@ module Api
       end
 
       render json: { message: "OK", updated: db_matches.size }
+    rescue JSON::ParserError
+      render json: { error: "リクエストボディが不正な JSON 形式です" }, status: :unprocessable_entity
     rescue ActiveRecord::RecordInvalid => e
       render json: { error: e.message }, status: :unprocessable_entity
     end

--- a/app/controllers/concerns/match_stats_importable.rb
+++ b/app/controllers/concerns/match_stats_importable.rb
@@ -1,0 +1,162 @@
+module MatchStatsImportable
+  extend ActiveSupport::Concern
+
+  private
+
+  # フルワークフロー JSON または ベア timeline_raw を受け取り、タイムラインを保存・統計を再計算する
+  # @param parsed [Hash] パース済み JSON（team_a/team_b/timeline_raw を含むフル形式 or ベア形式）
+  def apply_timeline_data(parsed)
+    if parsed["timeline_raw"]
+      import_from_workflow_json(parsed)
+
+      tl = parsed["timeline_raw"].merge(
+        "_player_order" => {
+          "team1" => parsed.dig("team_a", "players")&.map { |p| p["name"] }&.compact,
+          "team2" => parsed.dig("team_b", "players")&.map { |p| p["name"] }&.compact
+        }.compact
+      )
+    else
+      tl = parsed
+    end
+
+    game_end_cs  = tl["game_end_cs"]
+    game_end_str = tl["game_end_str"]
+
+    if @match.match_timeline
+      @match.match_timeline.update!(
+        timeline_raw: tl,
+        game_end_cs: game_end_cs,
+        game_end_str: game_end_str
+      )
+    else
+      @match.create_match_timeline!(
+        timeline_raw: tl,
+        game_end_cs: game_end_cs,
+        game_end_str: game_end_str
+      )
+    end
+
+    recalculate_timeline_derived_stats
+  end
+
+  # スコア降順で1〜4位を自動計算して match_rank に保存
+  def recalculate_match_ranks
+    players = @match.match_players.reload
+    with_score    = players.select { |mp| mp.score.present? }.sort_by { |mp| -mp.score }
+    without_score = players.reject { |mp| mp.score.present? }
+
+    MatchPlayer.where(id: without_score.map(&:id)).update_all(match_rank: nil) if without_score.any?
+    with_score.each_with_index do |mp, i|
+      MatchPlayer.where(id: mp.id).update_all(match_rank: i + 1)
+    end
+  end
+
+  # フルワークフロー JSON からスコア等（タイムラインに存在しない値）とチームフラグを投入する
+  def import_from_workflow_json(data)
+    name_to_mp = @match.match_players.each_with_object({}) { |mp, h| h[mp.user.nickname] = mp }
+    tl_events  = data.dig("timeline_raw", "events") || []
+
+    # 名前 → グループキーのマッピング（team_a.players[i] → "team1-{i+1}"）
+    name_to_group = {}
+    (data.dig("team_a", "players") || []).each_with_index { |p, i| name_to_group[p["name"]] = "team1-#{i + 1}" }
+    (data.dig("team_b", "players") || []).each_with_index { |p, i| name_to_group[p["name"]] = "team2-#{i + 1}" }
+
+    team_flag_updates = {}
+
+    [ data["team_a"], data["team_b"] ].each do |team_data|
+      next unless team_data
+
+      players = team_data["players"] || []
+
+      # DB team_number を1人目のプレイヤーの名前突合で特定
+      db_team_num = name_to_mp[players.first&.dig("name")]&.team_number
+
+      if db_team_num
+        # チームフラグ: 全員に exbst-ov イベントがない → OL未発動 → true
+        group_keys  = players.map { |p| name_to_group[p["name"]] }.compact
+        team_has_ol = group_keys.any? { |gk| tl_events.any? { |e| e["group"] == gk && e["class_name"] == "exbst-ov" } }
+        team_flag_updates[:"team#{db_team_num}_ex_overlimit_before_end"] = !team_has_ol
+      end
+
+      # スコア・ダメージ等（タイムラインに存在しない値のみ）
+      players.each do |pj|
+        mp = name_to_mp[pj["name"]]
+        next unless mp
+
+        mp.update!(
+          score:           pj["score"],
+          kills:           pj["kills"],
+          deaths:          pj["deaths"],
+          damage_dealt:    pj["damage_dealt"],
+          damage_received: pj["damage_received"],
+          exburst_damage:  pj["exburst_damage"]
+        )
+      end
+    end
+
+    @match.update!(team_flag_updates) if team_flag_updates.any?
+  end
+
+  # 保存済みタイムラインから導出可能な統計を再計算する
+  def recalculate_timeline_derived_stats
+    tl = @match.match_timeline
+    return unless tl
+
+    tl_data      = tl.timeline_raw || {}
+    tl_events    = tl_data["events"] || []
+    game_end_cs  = tl_data["game_end_cs"] || Float::INFINITY
+    player_order = tl_data["_player_order"] || {}
+
+    # _player_order から name → group key マッピングを構築
+    name_to_group = {}
+    (player_order["team1"] || []).each_with_index { |name, i| name_to_group[name] = "team1-#{i + 1}" }
+    (player_order["team2"] || []).each_with_index { |name, i| name_to_group[name] = "team2-#{i + 1}" }
+    return if name_to_group.empty?
+
+    name_to_mp       = @match.match_players.each_with_object({}) { |mp, h| h[mp.user.nickname] = mp }
+    last_death_group = tl_events.select { |e| e["is_point"] }.max_by { |e| e["start_cs"] || 0 }&.dig("group")
+
+    name_to_mp.each do |name, mp|
+      group_key = name_to_group[name]
+      next unless group_key
+
+      player_events = tl_events.select { |e| e["group"] == group_key }
+      burst_events  = player_events.select { |e| %w[exbst-f exbst-s exbst-e].include?(e["class_name"]) }
+      ex_zones      = player_events.select { |e| e["class_name"] == "ex" }
+
+      # exburst_count: バースト発動イベントの数
+      exburst_count = burst_events.size
+
+      # exburst_deaths: 被撃墜時刻がバースト区間内に含まれる数
+      exburst_deaths = player_events.select { |e| e["is_point"] }.count do |death|
+        cs = death["start_cs"]
+        burst_events.any? { |b| b["start_cs"] && b["end_cs"] && b["start_cs"] <= cs && cs < b["end_cs"] }
+      end
+
+      # EXゾーン判定ヘルパー
+      ex_available_at = lambda do |cs|
+        in_ex    = ex_zones.any?     { |e| e["start_cs"] && e["end_cs"] && e["start_cs"] <= cs && cs <= e["end_cs"] }
+        in_burst = burst_events.any? { |b| b["start_cs"] && b["end_cs"] && b["start_cs"] <= cs && cs <= b["end_cs"] }
+        in_ex && !in_burst
+      end
+
+      # 属性1: 試合を決めた被撃墜時にEX可能域かつ未発動
+      last_death_ex_available = if group_key == last_death_group
+        last_death = player_events.select { |e| e["is_point"] }.max_by { |e| e["start_cs"] || 0 }
+        ex_available_at.call([ last_death["start_cs"], game_end_cs ].min) if last_death
+      end
+
+      # 属性2: 試合終了時に被撃墜されていないプレイヤー — 試合終了時点でEX可能域かつ未発動
+      survive_loss_ex_available = if group_key != last_death_group && game_end_cs != Float::INFINITY
+        ex_available_at.call(game_end_cs)
+      end
+
+      mp.update!(
+        exburst_count:             exburst_count,
+        exburst_deaths:            exburst_deaths,
+        last_death_ex_available:   last_death_ex_available,
+        survive_loss_ex_available: survive_loss_ex_available
+      )
+    end
+  end
+end

--- a/app/controllers/match_stats_controller.rb
+++ b/app/controllers/match_stats_controller.rb
@@ -1,4 +1,6 @@
 class MatchStatsController < ApplicationController
+  include MatchStatsImportable
+
   before_action :authenticate_user!
   before_action :require_admin
   before_action :set_match
@@ -54,174 +56,14 @@ class MatchStatsController < ApplicationController
     @match = Match.includes(:event, :match_timeline, match_players: [ :user, :mobile_suit ]).find(params[:match_id])
   end
 
-  # スコア降順で1〜4位を自動計算して match_rank に保存
-  def recalculate_match_ranks
-    players = @match.match_players.reload
-    with_score    = players.select { |mp| mp.score.present? }.sort_by { |mp| -mp.score }
-    without_score = players.reject { |mp| mp.score.present? }
-
-    MatchPlayer.where(id: without_score.map(&:id)).update_all(match_rank: nil) if without_score.any?
-    with_score.each_with_index do |mp, i|
-      MatchPlayer.where(id: mp.id).update_all(match_rank: i + 1)
-    end
-  end
-
   def handle_timeline_update
     raw_json = params.dig(:match_timeline, :timeline_raw_text).presence
+    return @match.match_timeline&.destroy! if raw_json.nil?
 
-    if raw_json.nil?
-      @match.match_timeline&.destroy!
-      return
-    end
-
-    parsed = JSON.parse(raw_json)
-
-    # フルワークフロー JSON（team_a / team_b を含む）とベア timeline_raw 形式の両方をサポート
-    if parsed["timeline_raw"]
-      # スコア等ワークフローJSONにしか存在しない統計・チームフラグを投入
-      import_from_workflow_json(parsed)
-
-      tl = parsed["timeline_raw"].merge(
-        "_player_order" => {
-          "team1" => parsed.dig("team_a", "players")&.map { |p| p["name"] }&.compact,
-          "team2" => parsed.dig("team_b", "players")&.map { |p| p["name"] }&.compact
-        }.compact
-      )
-    else
-      tl = parsed
-    end
-
-    game_end_cs  = tl["game_end_cs"]
-    game_end_str = tl["game_end_str"]
-
-    if @match.match_timeline
-      @match.match_timeline.update!(
-        timeline_raw: tl,
-        game_end_cs: game_end_cs,
-        game_end_str: game_end_str
-      )
-    else
-      @match.create_match_timeline!(
-        timeline_raw: tl,
-        game_end_cs: game_end_cs,
-        game_end_str: game_end_str
-      )
-    end
-
-    # タイムライン保存後に常にタイムライン由来の統計を再計算
-    # ベアJSONの再保存でも exburst_count/deaths・EXバースト残し系フラグが更新される
-    recalculate_timeline_derived_stats
+    apply_timeline_data(JSON.parse(raw_json))
   rescue JSON::ParserError
-    raise ActiveRecord::RecordInvalid.new(MatchTimeline.new.tap { |t| t.errors.add(:timeline_raw, "が不正な JSON 形式です") })
-  end
-
-  # フルワークフロー JSON からスコア等（タイムラインに存在しない値）とチームフラグを投入する
-  def import_from_workflow_json(data)
-    name_to_mp = @match.match_players.each_with_object({}) { |mp, h| h[mp.user.nickname] = mp }
-    tl_events  = data.dig("timeline_raw", "events") || []
-
-    # 名前 → グループキーのマッピング（team_a.players[i] → "team1-{i+1}"）
-    name_to_group = {}
-    (data.dig("team_a", "players") || []).each_with_index { |p, i| name_to_group[p["name"]] = "team1-#{i + 1}" }
-    (data.dig("team_b", "players") || []).each_with_index { |p, i| name_to_group[p["name"]] = "team2-#{i + 1}" }
-
-    team_flag_updates = {}
-
-    [ data["team_a"], data["team_b"] ].each do |team_data|
-      next unless team_data
-
-      players = team_data["players"] || []
-
-      # DB team_number を1人目のプレイヤーの名前突合で特定
-      db_team_num = name_to_mp[players.first&.dig("name")]&.team_number
-
-      if db_team_num
-        # チームフラグ: 全員に exbst-ov イベントがない → OL未発動 → true
-        group_keys  = players.map { |p| name_to_group[p["name"]] }.compact
-        team_has_ol = group_keys.any? { |gk| tl_events.any? { |e| e["group"] == gk && e["class_name"] == "exbst-ov" } }
-        team_flag_updates[:"team#{db_team_num}_ex_overlimit_before_end"] = !team_has_ol
-      end
-
-      # スコア・ダメージ等（タイムラインに存在しない値のみ）
-      players.each do |pj|
-        mp = name_to_mp[pj["name"]]
-        next unless mp
-
-        mp.update!(
-          score:           pj["score"],
-          kills:           pj["kills"],
-          deaths:          pj["deaths"],
-          damage_dealt:    pj["damage_dealt"],
-          damage_received: pj["damage_received"],
-          exburst_damage:  pj["exburst_damage"]
-        )
-      end
-    end
-
-    @match.update!(team_flag_updates) if team_flag_updates.any?
-  end
-
-  # 保存済みタイムラインから導出可能な統計を再計算する
-  # ベアJSONの再保存でも正しく動作するよう handle_timeline_update から常に呼ばれる
-  def recalculate_timeline_derived_stats
-    tl = @match.match_timeline
-    return unless tl
-
-    tl_data      = tl.timeline_raw || {}
-    tl_events    = tl_data["events"] || []
-    game_end_cs  = tl_data["game_end_cs"] || Float::INFINITY
-    player_order = tl_data["_player_order"] || {}
-
-    # _player_order から name → group key マッピングを構築
-    name_to_group = {}
-    (player_order["team1"] || []).each_with_index { |name, i| name_to_group[name] = "team1-#{i + 1}" }
-    (player_order["team2"] || []).each_with_index { |name, i| name_to_group[name] = "team2-#{i + 1}" }
-    return if name_to_group.empty?
-
-    name_to_mp       = @match.match_players.each_with_object({}) { |mp, h| h[mp.user.nickname] = mp }
-    last_death_group = tl_events.select { |e| e["is_point"] }.max_by { |e| e["start_cs"] || 0 }&.dig("group")
-
-    name_to_mp.each do |name, mp|
-      group_key = name_to_group[name]
-      next unless group_key
-
-      player_events = tl_events.select { |e| e["group"] == group_key }
-      burst_events  = player_events.select { |e| %w[exbst-f exbst-s exbst-e].include?(e["class_name"]) }
-      ex_zones      = player_events.select { |e| e["class_name"] == "ex" }
-
-      # exburst_count: バースト発動イベントの数
-      exburst_count = burst_events.size
-
-      # exburst_deaths: 被撃墜時刻がバースト区間内に含まれる数
-      exburst_deaths = player_events.select { |e| e["is_point"] }.count do |death|
-        cs = death["start_cs"]
-        burst_events.any? { |b| b["start_cs"] && b["end_cs"] && b["start_cs"] <= cs && cs < b["end_cs"] }
-      end
-
-      # EXゾーン判定ヘルパー
-      ex_available_at = lambda do |cs|
-        in_ex    = ex_zones.any?     { |e| e["start_cs"] && e["end_cs"] && e["start_cs"] <= cs && cs <= e["end_cs"] }
-        in_burst = burst_events.any? { |b| b["start_cs"] && b["end_cs"] && b["start_cs"] <= cs && cs <= b["end_cs"] }
-        in_ex && !in_burst
-      end
-
-      # 属性1: 試合を決めた被撃墜時にEX可能域かつ未発動
-      last_death_ex_available = if group_key == last_death_group
-        last_death = player_events.select { |e| e["is_point"] }.max_by { |e| e["start_cs"] || 0 }
-        ex_available_at.call([ last_death["start_cs"], game_end_cs ].min) if last_death
-      end
-
-      # 属性2: 試合終了時に被撃墜されていないプレイヤー — 試合終了時点でEX可能域かつ未発動
-      survive_loss_ex_available = if group_key != last_death_group && game_end_cs != Float::INFINITY
-        ex_available_at.call(game_end_cs)
-      end
-
-      mp.update!(
-        exburst_count:             exburst_count,
-        exburst_deaths:            exburst_deaths,
-        last_death_ex_available:   last_death_ex_available,
-        survive_loss_ex_available: survive_loss_ex_available
-      )
-    end
+    raise ActiveRecord::RecordInvalid.new(
+      MatchTimeline.new.tap { |t| t.errors.add(:timeline_raw, "が不正な JSON 形式です") }
+    )
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -25,6 +25,7 @@
             <%= link_to "タイムスタンプ一括設定", edit_timestamps_event_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
             <%= button_to "解析開始", trigger_analysis_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で動画解析を開始しますか？完了後にタイムスタンプが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <% end %>
+          <%= button_to "統計スクレイピング開始", trigger_scraping_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で統計スクレイピングを開始しますか？完了後に統計データが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= link_to "編集", edit_event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= button_to "削除", event_path(@event), method: :delete, data: { turbo_confirm: "イベント「#{@event.name}」を削除してもよろしいですか？関連する試合やローテーションもすべて削除されます。" }, class: "bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
         </div>

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -35,6 +35,10 @@ env:
     GITHUB_REPO: sp8783/exvs2ib-replay-parser
     GITHUB_WORKFLOW_ID: analyze.yml
 
+    # Scraper integration (non-secret config)
+    SCRAPER_GITHUB_REPO: sp8783/exvs2ib-vsmobile-scraper
+    SCRAPER_GITHUB_WORKFLOW_ID: scrape.yml
+
     # Database configuration
     DB_HOST: vsmobile-kgy-db
     POSTGRES_USER: vsmobile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       get :edit_timestamps
       patch :update_timestamps
       post :trigger_analysis
+      post :trigger_scraping
     end
     resources :matches, only: [ :new, :create ]
     resources :rotations, only: [ :new, :create ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       member do
         post :timestamps
         post :notify_failure
+        post :stats
       end
     end
   end


### PR DESCRIPTION
## Summary
- `MatchStatsImportable` concern を新規作成し、タイムライン保存・統計再計算ロジックを `MatchStatsController` から抽出して共有化
- `POST /api/events/:id/stats` エンドポイントを追加（既存の `TIMESTAMP_API_TOKEN` で認証）
- スクレイパー出力 JSON 配列をそのまま受け取り、イベント内試合と順番ベースで対応付けて一括投入
- イベント詳細ページに「統計スクレイピング開始」ボタンを追加（GitHub Actions `workflow_dispatch` をトリガー）
- `deploy.yml` に `SCRAPER_GITHUB_REPO` / `SCRAPER_GITHUB_WORKFLOW_ID` を追加

## Test plan
- [x] 401: Authorization ヘッダなし → `{"error":"Unauthorized"}`
- [x] 404: 存在しない event_id → `{"error":"Event not found"}`
- [x] 422: 配列でない JSON → `{"error":"リクエストボディは JSON 配列である必要があります"}`
- [x] 422: 件数不一致 → `{"error":"データ件数（N）とイベント内試合数（M）が一致しません"}`
- [x] 200: 正常系 → スコア・タイムライン・match_rank が DB に保存されることを確認
- [ ] 「統計スクレイピング開始」ボタン → GitHub Actions ワークフローが起動することを確認（本番環境 or PAT設定後）
- [ ] 既存の手動フォーム（`/matches/:id/stats/edit`）で統計が引き続き保存できること

## 関連Issue・PR
#101