### PR TITLE
chore: TIMESTAMP_API_TOKEN を VSMOBILE_API_TOKEN にリネーム

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -14,9 +14,9 @@ KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 # Generate a secure password and run: export POSTGRES_PASSWORD=your_secure_password
 POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 
-# Timestamp API token (used to authenticate requests to the timestamp registration endpoint)
-# Generate any secure random string and run: export TIMESTAMP_API_TOKEN=your_token
-TIMESTAMP_API_TOKEN=$TIMESTAMP_API_TOKEN
+# vsmobile API token (used to authenticate requests from external workflows)
+# Generate any secure random string and run: export VSMOBILE_API_TOKEN=your_token
+VSMOBILE_API_TOKEN=$VSMOBILE_API_TOKEN
 
 # GitHub Actions integration (used to trigger the timestamp analysis workflow)
 # Personal access token with 'actions:write' scope on exvs2ib-replay-parser

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,7 +6,7 @@ module Api
 
     def authenticate_api_token!
       token = request.headers["Authorization"]&.sub(/\ABearer /, "")
-      api_token = ENV["TIMESTAMP_API_TOKEN"].presence
+      api_token = ENV["VSMOBILE_API_TOKEN"].presence
 
       if api_token.blank? || token != api_token
         render json: { error: "Unauthorized" }, status: :unauthorized

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -25,7 +25,7 @@ env:
   secret:
     - RAILS_MASTER_KEY
     - POSTGRES_PASSWORD
-    - TIMESTAMP_API_TOKEN
+    - VSMOBILE_API_TOKEN
     - GITHUB_TOKEN
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.


### PR DESCRIPTION
## Summary
- `TIMESTAMP_API_TOKEN` 環境変数名を `VSMOBILE_API_TOKEN` に変更
- 対象: `Api::BaseController`、`.kamal/secrets`、`config/deploy.yml`

## デプロイ時の注意
本番サーバーで `VSMOBILE_API_TOKEN` を設定してから `kamal deploy` すること（旧 `TIMESTAMP_API_TOKEN` と同じ値）。

## Test plan
- [ ] ローカルで `VSMOBILE_API_TOKEN` をセットしてサーバー起動 → API が認証できること
- [ ] `VSMOBILE_API_TOKEN` 未設定時に 401 が返ること

## 関連Issue・PR
#105