### PR TITLE
feat: 統計ページにパフォーマンスタブを追加

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -7,7 +7,7 @@ class StatisticsController < ApplicationController
     @active_tab = params[:tab] || "overall"
 
     # ゲストユーザー（または管理者がゲスト視点切り替え中）は個人統計タブにアクセス不可
-    personal_tabs = %w[overview events event_progression mobile_suits opponent_suits partners opponents performance]
+    personal_tabs = %w[overview performance events event_progression mobile_suits opponent_suits partners opponents]
     if viewing_as_user.is_guest && personal_tabs.include?(@active_tab)
       redirect_to statistics_path(tab: "overall"), alert: "個人統計を見るには管理者にアカウント発行を依頼してください"
       return

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -568,6 +568,141 @@ class StatisticsController < ApplicationController
       opp_ol == true  # true = 相手チームOL未発動
     end
     @total_wins_all = all_wins.size
+
+    @has_ol_data = (all_losses + all_wins).any? { |mp|
+      flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
+      !flag.nil?
+    }
+
+    # EXバースト活用分析のコミュニティ分布（ユーザー別率 → avg/min/max）
+    ex_loss_mps = MatchPlayer.joins(:match, :user).includes(:match)
+      .where(users: { is_guest: false })
+      .where("matches.winning_team IS NOT NULL AND matches.winning_team != match_players.team_number")
+      .where("last_death_ex_available IS NOT NULL OR survive_loss_ex_available IS NOT NULL")
+      .to_a
+    if ex_loss_mps.any?
+      last_death_rates = []
+      survive_rates    = []
+      ex_rates = ex_loss_mps.group_by(&:user_id).map do |_uid, mps|
+        n = mps.size
+        remaining = mps.count { |mp| mp.last_death_ex_available || mp.survive_loss_ex_available }
+        last_death_rates << (mps.count { |mp| mp.last_death_ex_available  } * 100.0 / n).round(1)
+        survive_rates    << (mps.count { |mp| mp.survive_loss_ex_available } * 100.0 / n).round(1)
+        (remaining * 100.0 / n).round(1)
+      end
+      @community_ex_remaining_rate  = (ex_rates.sum        / ex_rates.size).round(1)
+      @community_ex_remaining_min   = ex_rates.min
+      @community_ex_remaining_max   = ex_rates.max
+      @community_last_death_ex_rate = (last_death_rates.sum / last_death_rates.size).round(1)
+      @community_last_death_ex_min  = last_death_rates.min
+      @community_last_death_ex_max  = last_death_rates.max
+      @community_survive_ex_rate    = (survive_rates.sum    / survive_rates.size).round(1)
+      @community_survive_ex_min     = survive_rates.min
+      @community_survive_ex_max     = survive_rates.max
+    end
+
+    # OL分析のコミュニティ分布（ユーザー別率 → avg/min/max）
+    ol_mps_all = MatchPlayer.joins(:match, :user).includes(:match)
+      .where(users: { is_guest: false })
+      .where("matches.winning_team IS NOT NULL")
+      .to_a
+    if ol_mps_all.any?
+      no_ol_loss_rates    = []
+      opp_no_ol_win_rates = []
+      ol_mps_all.group_by(&:user_id).each do |_uid, mps|
+        loss_mps = mps.select { |mp| mp.match.winning_team != mp.team_number }
+        if loss_mps.any?
+          no_ol = loss_mps.count { |mp|
+            flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
+            flag == true
+          }
+          no_ol_loss_rates << (no_ol * 100.0 / loss_mps.size).round(1)
+        end
+        win_mps = mps.select { |mp| mp.match.winning_team == mp.team_number }
+        if win_mps.any?
+          opp_no_ol = win_mps.count { |mp|
+            flag = mp.team_number == 1 ? mp.match.team2_ex_overlimit_before_end : mp.match.team1_ex_overlimit_before_end
+            flag == true
+          }
+          opp_no_ol_win_rates << (opp_no_ol * 100.0 / win_mps.size).round(1)
+        end
+      end
+      if no_ol_loss_rates.any?
+        @community_no_ol_loss_rate = (no_ol_loss_rates.sum / no_ol_loss_rates.size).round(1)
+        @community_no_ol_loss_min  = no_ol_loss_rates.min
+        @community_no_ol_loss_max  = no_ol_loss_rates.max
+      end
+      if opp_no_ol_win_rates.any?
+        @community_opp_no_ol_win_rate = (opp_no_ol_win_rates.sum / opp_no_ol_win_rates.size).round(1)
+        @community_opp_no_ol_win_min  = opp_no_ol_win_rates.min
+        @community_opp_no_ol_win_max  = opp_no_ol_win_rates.max
+      end
+    end
+
+    # コミュニティ平均を算出（基本パフォーマンス統計テーブル用）
+    has_stats_sql = "score IS NOT NULL AND kills IS NOT NULL AND deaths IS NOT NULL AND " \
+                    "damage_dealt IS NOT NULL AND damage_received IS NOT NULL AND exburst_damage IS NOT NULL"
+    all_stats_mps = MatchPlayer.joins(:match, :user).includes(:match)
+      .where(has_stats_sql).where(users: { is_guest: false }).to_a
+    if all_stats_mps.any?
+      by_user = all_stats_mps.group_by(&:user_id)
+      user_perf_list = by_user.map do |_uid, mps|
+        n  = mps.size
+        sf = ->(f) { mps.sum { |mp| mp.send(f).to_f } }
+        total_ex   = mps.sum { |mp| mp.exburst_count.to_i }
+        total_ex_d = mps.sum { |mp| mp.exburst_deaths.to_i }
+        ol_count   = mps.count { |mp|
+          flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
+          flag == false
+        }
+        loss_mps   = mps.select { |mp| mp.match.winning_team && mp.match.winning_team != mp.team_number }
+        ol_loss_count = loss_mps.count { |mp|
+          flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
+          flag == false
+        }
+        {
+          score:              (sf.call(:score)          / n).round(1),
+          kills:              (sf.call(:kills)           / n).round(2),
+          deaths:             (sf.call(:deaths)          / n).round(2),
+          damage_dealt:       (sf.call(:damage_dealt)    / n).round(0),
+          damage_received:    (sf.call(:damage_received) / n).round(0),
+          exburst_damage:     (sf.call(:exburst_damage)  / n).round(0),
+          exburst_count:      (sf.call(:exburst_count)   / n).round(2),
+          exburst_deaths:     (sf.call(:exburst_deaths)  / n).round(2),
+          exburst_death_rate: total_ex > 0 ? (total_ex_d * 100.0 / total_ex).round(1) : nil,
+          ol_rate:            (ol_count * 100.0 / n).round(1),
+          ol_rate_losses:     loss_mps.any? ? (ol_loss_count * 100.0 / loss_mps.size).round(1) : nil
+        }
+      end
+      nu = user_perf_list.size
+      valid_dr = user_perf_list.map { |u| u[:exburst_death_rate] }.compact
+      @community_avg = {
+        score:              (user_perf_list.sum { |u| u[:score] }          / nu).round(1),
+        kills:              (user_perf_list.sum { |u| u[:kills] }           / nu).round(2),
+        deaths:             (user_perf_list.sum { |u| u[:deaths] }          / nu).round(2),
+        damage_dealt:       (user_perf_list.sum { |u| u[:damage_dealt] }    / nu).round(0),
+        damage_received:    (user_perf_list.sum { |u| u[:damage_received] } / nu).round(0),
+        exburst_damage:     (user_perf_list.sum { |u| u[:exburst_damage] }  / nu).round(0),
+        exburst_count:      (user_perf_list.sum { |u| u[:exburst_count] }   / nu).round(2),
+        exburst_deaths:     (user_perf_list.sum { |u| u[:exburst_deaths] }  / nu).round(2),
+        exburst_death_rate: valid_dr.any? ? (valid_dr.sum / valid_dr.size).round(1) : nil,
+        ol_rate:            (user_perf_list.sum { |u| u[:ol_rate] }         / nu).round(1)
+      }
+      stat_keys = %i[score kills deaths damage_dealt damage_received exburst_damage exburst_count exburst_deaths ol_rate]
+      @community_min = stat_keys.to_h { |k| [k, user_perf_list.map { |u| u[k] }.compact.min] }
+      @community_max = stat_keys.to_h { |k| [k, user_perf_list.map { |u| u[k] }.compact.max] }
+      if valid_dr.any?
+        @community_min[:exburst_death_rate] = valid_dr.min
+        @community_max[:exburst_death_rate] = valid_dr.max
+      end
+      valid_ol_losses = user_perf_list.map { |u| u[:ol_rate_losses] }.compact
+      if valid_ol_losses.any?
+        @community_avg[:ol_rate_losses]  = (valid_ol_losses.sum / valid_ol_losses.size).round(1)
+        @community_min[:ol_rate_losses]  = valid_ol_losses.min
+        @community_max[:ol_rate_losses]  = valid_ol_losses.max
+      end
+    end
+
   end
 
   def calc_perf_stats(mps)

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -559,13 +559,13 @@ class StatisticsController < ApplicationController
 
     @my_team_no_ol_losses = all_losses.count do |mp|
       team_ol = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
-      team_ol == false
+      team_ol == true  # true = OL未発動（exbst-ov イベントなし）
     end
     @total_losses = all_losses.size
 
     @opponent_no_ol_wins = all_wins.count do |mp|
       opp_ol = mp.team_number == 1 ? mp.match.team2_ex_overlimit_before_end : mp.match.team1_ex_overlimit_before_end
-      opp_ol == false
+      opp_ol == true  # true = 相手チームOL未発動
     end
     @total_wins_all = all_wins.size
   end
@@ -585,7 +585,15 @@ class StatisticsController < ApplicationController
       exburst_damage:  (sum_field.call(:exburst_damage)  / n).round(0),
       exburst_count:   (sum_field.call(:exburst_count)   / n).round(2),
       exburst_deaths:  (sum_field.call(:exburst_deaths)  / n).round(2),
-      ol_rate:         (mps.count { |mp| mp.ex_overlimit_activated } * 100.0 / n).round(1)
+      exburst_death_rate: begin
+                            total_count  = mps.sum { |mp| mp.exburst_count.to_i }
+                            total_deaths = mps.sum { |mp| mp.exburst_deaths.to_i }
+                            total_count > 0 ? (total_deaths * 100.0 / total_count).round(1) : nil
+                          end,
+      ol_rate:         (mps.count { |mp|
+                         flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
+                         flag == false
+                       } * 100.0 / n).round(1)
     }
   end
 

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -689,8 +689,8 @@ class StatisticsController < ApplicationController
         ol_rate:            (user_perf_list.sum { |u| u[:ol_rate] }         / nu).round(1)
       }
       stat_keys = %i[score kills deaths damage_dealt damage_received exburst_damage exburst_count exburst_deaths ol_rate]
-      @community_min = stat_keys.to_h { |k| [k, user_perf_list.map { |u| u[k] }.compact.min] }
-      @community_max = stat_keys.to_h { |k| [k, user_perf_list.map { |u| u[k] }.compact.max] }
+      @community_min = stat_keys.to_h { |k| [ k, user_perf_list.map { |u| u[k] }.compact.min ] }
+      @community_max = stat_keys.to_h { |k| [ k, user_perf_list.map { |u| u[k] }.compact.max ] }
       if valid_dr.any?
         @community_min[:exburst_death_rate] = valid_dr.min
         @community_max[:exburst_death_rate] = valid_dr.max
@@ -702,7 +702,6 @@ class StatisticsController < ApplicationController
         @community_max[:ol_rate_losses]  = valid_ol_losses.max
       end
     end
-
   end
 
   def calc_perf_stats(mps)

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -22,6 +22,7 @@
           <option disabled>対戦機体別戦績（要アカウント）</option>
           <option disabled>パートナー別戦績（要アカウント）</option>
           <option disabled>対戦相手別戦績（要アカウント）</option>
+          <option disabled>パフォーマンス（要アカウント）</option>
         <% else %>
           <option value="overview" <%= 'selected' if @active_tab == 'overview' %>>総合戦績</option>
           <option value="events" <%= 'selected' if @active_tab == 'events' %>>イベント別戦績</option>
@@ -30,6 +31,7 @@
           <option value="opponent_suits" <%= 'selected' if @active_tab == 'opponent_suits' %>>対戦機体別戦績</option>
           <option value="partners" <%= 'selected' if @active_tab == 'partners' %>>パートナー別戦績</option>
           <option value="opponents" <%= 'selected' if @active_tab == 'opponents' %>>対戦相手別戦績</option>
+          <option value="performance" <%= 'selected' if @active_tab == 'performance' %>>パフォーマンス</option>
         <% end %>
       </optgroup>
     </select>
@@ -75,6 +77,7 @@
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">対戦機体別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">パートナー別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">対戦相手別戦績</span>
+        <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">パフォーマンス</span>
       <% else %>
         <%= link_to statistics_path(tab: 'overview', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
             class: "#{@active_tab == 'overview' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" do %>
@@ -103,6 +106,10 @@
         <%= link_to statistics_path(tab: 'opponents', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
             class: "#{@active_tab == 'opponents' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           対戦相手別戦績
+        <% end %>
+        <%= link_to statistics_path(tab: 'performance', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+            class: "#{@active_tab == 'performance' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
+          パフォーマンス
         <% end %>
       <% end %>
     </nav>
@@ -501,6 +508,8 @@
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-sort="number">使用回数</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-sort="number">勝利</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-sort="percent">勝率</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-sort="number">平均スコア</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-sort="number">KD比</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">よく組むパートナー機体</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap" data-sort="date">最終使用日</th>
               </tr>
@@ -529,6 +538,12 @@
                         <div class="bg-purple-600 h-2 rounded-full" style="width: <%= suit_stat[:win_rate].to_f %>%"></div>
                       </div>
                     </div>
+                  </td>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <%= suit_stat[:avg_score].nil? ? "N/A" : suit_stat[:avg_score] %>
+                  </td>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <%= suit_stat[:kd_ratio].nil? ? "N/A" : suit_stat[:kd_ratio] %>
                   </td>
                   <td class="px-6 py-4 text-sm text-gray-500">
                     <% if suit_stat[:top_partner_suits].any? %>
@@ -1158,6 +1173,162 @@
         <% end %>
       </div>
     </div>
+
+  <% elsif @active_tab == 'performance' %>
+    <!-- Performance Tab -->
+    <div class="space-y-6">
+
+      <!-- セクション1: 基本パフォーマンス統計 -->
+      <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-5 border-b border-gray-200">
+          <h3 class="text-lg font-semibold text-gray-900">基本パフォーマンス統計</h3>
+          <p class="mt-1 text-sm text-gray-500">
+            統計データあり: <span class="font-semibold"><%= @stats_total %></span> 試合
+            （<span class="text-green-600 font-semibold"><%= @stats_wins %></span> 勝 /
+            <span class="text-red-600 font-semibold"><%= @stats_losses %></span> 敗）
+          </p>
+        </div>
+
+        <% if @stats_total > 0 %>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">項目</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">全体（<%= @stats_total %>試合）</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap text-green-700">勝利時（<%= @stats_wins %>試合）</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap text-red-700">敗北時（<%= @stats_losses %>試合）</th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-200">
+                <% perf_rows = [
+                  { label: "スコア",                  key: :score,           suffix: "" },
+                  { label: "撃墜数",                  key: :kills,           suffix: "" },
+                  { label: "被撃墜数",                key: :deaths,          suffix: "" },
+                  { label: "与ダメージ",              key: :damage_dealt,    suffix: "" },
+                  { label: "被ダメージ",              key: :damage_received, suffix: "" },
+                  { label: "EXバーストダメージ",      key: :exburst_damage,  suffix: "" },
+                  { label: "EXバースト発動回数",      key: :exburst_count,   suffix: "" },
+                  { label: "EXバースト中被撃墜数",    key: :exburst_deaths,  suffix: "" },
+                  { label: "OL発動率",                key: :ol_rate,         suffix: "%" },
+                ] %>
+                <% perf_rows.each do |row| %>
+                  <tr class="hover:bg-gray-50">
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-700"><%= row[:label] %></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <%= @performance_overall ? "#{@performance_overall[row[:key]]}#{row[:suffix]}" : "-" %>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-green-700">
+                      <%= @performance_wins ? "#{@performance_wins[row[:key]]}#{row[:suffix]}" : "-" %>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-red-700">
+                      <%= @performance_losses ? "#{@performance_losses[row[:key]]}#{row[:suffix]}" : "-" %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        <% else %>
+          <div class="px-6 py-12 text-center">
+            <p class="text-gray-500">統計データのある試合がありません</p>
+            <p class="mt-1 text-xs text-gray-400">試合詳細からスコア等の統計データを入力してください</p>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- セクション2: EXバースト活用分析 -->
+      <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-5 border-b border-gray-200">
+          <h3 class="text-lg font-semibold text-gray-900">EXバースト活用分析（敗北時）</h3>
+          <p class="mt-1 text-sm text-gray-500">EXバーストを残したまま敗北したケースを分析します</p>
+        </div>
+        <div class="px-6 py-5 space-y-4">
+          <% if @stats_losses > 0 %>
+            <div class="flex items-center justify-between py-3 border-b border-gray-100">
+              <div>
+                <div class="text-sm font-medium text-gray-900">EXバースト残し敗北</div>
+                <div class="text-xs text-gray-500 mt-1">最後の撃墜時またはEX残し生存で敗北したケース</div>
+              </div>
+              <div class="text-right">
+                <div class="text-lg font-bold text-red-600">
+                  <%= @ex_remaining_on_loss %> / <%= @stats_losses %>回
+                </div>
+                <div class="text-sm text-gray-500">
+                  (<%= @stats_losses > 0 ? (@ex_remaining_on_loss * 100.0 / @stats_losses).round(1) : 0 %>%)
+                </div>
+              </div>
+            </div>
+            <div class="pl-6 space-y-3">
+              <div class="flex items-center justify-between py-2">
+                <div>
+                  <div class="text-sm text-gray-700">うち 最後の撃墜時EX残し</div>
+                </div>
+                <div class="text-right">
+                  <div class="text-sm font-semibold text-red-500">
+                    <%= @last_death_ex_on_loss %> / <%= @stats_losses %>回
+                    (<%= @stats_losses > 0 ? (@last_death_ex_on_loss * 100.0 / @stats_losses).round(1) : 0 %>%)
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center justify-between py-2">
+                <div>
+                  <div class="text-sm text-gray-700">うち 生存敗北時EX残し</div>
+                </div>
+                <div class="text-right">
+                  <div class="text-sm font-semibold text-red-500">
+                    <%= @survive_loss_ex_on_loss %> / <%= @stats_losses %>回
+                    (<%= @stats_losses > 0 ? (@survive_loss_ex_on_loss * 100.0 / @stats_losses).round(1) : 0 %>%)
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% else %>
+            <p class="text-gray-500 text-center py-4">統計データのある敗北試合がありません</p>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- セクション3: OL分析 -->
+      <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-5 border-b border-gray-200">
+          <h3 class="text-lg font-semibold text-gray-900">OL（オーバーリミット）分析</h3>
+          <p class="mt-1 text-sm text-gray-500">全試合を対象にOL発動状況を分析します</p>
+        </div>
+        <div class="px-6 py-5 space-y-4">
+          <div class="flex items-center justify-between py-3 border-b border-gray-100">
+            <div>
+              <div class="text-sm font-medium text-gray-900">自チームOL未発動で敗北</div>
+              <div class="text-xs text-gray-500 mt-1">OLを発動できずに負けた試合</div>
+            </div>
+            <div class="text-right">
+              <div class="text-lg font-bold text-orange-600">
+                <%= @my_team_no_ol_losses %> / <%= @total_losses %>回
+              </div>
+              <div class="text-sm text-gray-500">
+                (<%= @total_losses > 0 ? (@my_team_no_ol_losses * 100.0 / @total_losses).round(1) : 0 %>%)
+              </div>
+            </div>
+          </div>
+          <div class="flex items-center justify-between py-3">
+            <div>
+              <div class="text-sm font-medium text-gray-900">相手チームOL未発動で勝利</div>
+              <div class="text-xs text-gray-500 mt-1">相手にOLを発動させずに勝った試合</div>
+            </div>
+            <div class="text-right">
+              <div class="text-lg font-bold text-green-600">
+                <%= @opponent_no_ol_wins %> / <%= @total_wins_all %>回
+              </div>
+              <div class="text-sm text-gray-500">
+                (<%= @total_wins_all > 0 ? (@opponent_no_ol_wins * 100.0 / @total_wins_all).round(1) : 0 %>%)
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
   <% end %>
 </div>
 

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -16,22 +16,22 @@
       <optgroup label="個人">
         <% if viewing_as_user.is_guest %>
           <option disabled>総合戦績（要アカウント）</option>
+          <option disabled>プレイ分析（要アカウント）</option>
           <option disabled>イベント別戦績（要アカウント）</option>
           <option disabled>イベント内期間別戦績（要アカウント）</option>
           <option disabled>使用機体別戦績（要アカウント）</option>
           <option disabled>対戦機体別戦績（要アカウント）</option>
           <option disabled>パートナー別戦績（要アカウント）</option>
           <option disabled>対戦相手別戦績（要アカウント）</option>
-          <option disabled>パフォーマンス（要アカウント）</option>
         <% else %>
           <option value="overview" <%= 'selected' if @active_tab == 'overview' %>>総合戦績</option>
+          <option value="performance" <%= 'selected' if @active_tab == 'performance' %>>プレイ分析</option>
           <option value="events" <%= 'selected' if @active_tab == 'events' %>>イベント別戦績</option>
           <option value="event_progression" <%= 'selected' if @active_tab == 'event_progression' %>>イベント内期間別戦績</option>
           <option value="mobile_suits" <%= 'selected' if @active_tab == 'mobile_suits' %>>使用機体別戦績</option>
           <option value="opponent_suits" <%= 'selected' if @active_tab == 'opponent_suits' %>>対戦機体別戦績</option>
           <option value="partners" <%= 'selected' if @active_tab == 'partners' %>>パートナー別戦績</option>
           <option value="opponents" <%= 'selected' if @active_tab == 'opponents' %>>対戦相手別戦績</option>
-          <option value="performance" <%= 'selected' if @active_tab == 'performance' %>>パフォーマンス</option>
         <% end %>
       </optgroup>
     </select>
@@ -71,17 +71,21 @@
       <% if viewing_as_user.is_guest %>
         <!-- ゲストユーザー: 個人統計タブを無効化 -->
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">総合戦績</span>
+        <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">プレイ分析</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">イベント別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">イベント内期間別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">使用機体別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">対戦機体別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">パートナー別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">対戦相手別戦績</span>
-        <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">パフォーマンス</span>
       <% else %>
         <%= link_to statistics_path(tab: 'overview', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
             class: "#{@active_tab == 'overview' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" do %>
           総合戦績
+        <% end %>
+        <%= link_to statistics_path(tab: 'performance', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+            class: "#{@active_tab == 'performance' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
+          プレイ分析
         <% end %>
         <%= link_to statistics_path(tab: 'events', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
             class: "#{@active_tab == 'events' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
@@ -106,10 +110,6 @@
         <%= link_to statistics_path(tab: 'opponents', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
             class: "#{@active_tab == 'opponents' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           対戦相手別戦績
-        <% end %>
-        <%= link_to statistics_path(tab: 'performance', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
-            class: "#{@active_tab == 'performance' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
-          パフォーマンス
         <% end %>
       <% end %>
     </nav>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1178,52 +1178,107 @@
     <!-- Performance Tab -->
     <div class="space-y-6">
 
-      <!-- セクション1: 基本パフォーマンス統計 -->
-      <div class="bg-white rounded-lg shadow">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <h3 class="text-lg font-semibold text-gray-900">基本パフォーマンス統計</h3>
-          <p class="mt-1 text-sm text-gray-500">
-            統計データあり: <span class="font-semibold"><%= @stats_total %></span> 試合
-            （<span class="text-green-600 font-semibold"><%= @stats_wins %></span> 勝 /
-            <span class="text-red-600 font-semibold"><%= @stats_losses %></span> 敗）
-          </p>
+      <!-- サマリーカード -->
+      <div class="grid grid-cols-3 gap-4">
+        <div class="bg-indigo-50 border border-indigo-200 rounded-xl p-5 text-center">
+          <div class="text-3xl font-bold text-indigo-700"><%= @stats_total %></div>
+          <div class="text-xs text-indigo-500 mt-1 font-medium">統計データあり試合</div>
         </div>
+        <div class="bg-green-50 border border-green-200 rounded-xl p-5 text-center">
+          <div class="text-3xl font-bold text-green-700"><%= @stats_wins %></div>
+          <div class="text-xs text-green-600 mt-1 font-medium">勝利</div>
+        </div>
+        <div class="bg-red-50 border border-red-200 rounded-xl p-5 text-center">
+          <div class="text-3xl font-bold text-red-700"><%= @stats_losses %></div>
+          <div class="text-xs text-red-500 mt-1 font-medium">敗北</div>
+        </div>
+      </div>
 
-        <% if @stats_total > 0 %>
+      <!-- セクション1: 基本パフォーマンス統計 -->
+      <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-200">
+          <h3 class="text-base font-bold text-gray-900">基本パフォーマンス統計</h3>
+          <p class="text-xs text-gray-500 mt-0.5">試合ごとの平均値</p>
+        </div>
+        <% if @stats_total.to_i > 0 %>
           <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-              <thead class="bg-gray-50">
-                <tr>
-                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">項目</th>
-                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">全体（<%= @stats_total %>試合）</th>
-                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap text-green-700">勝利時（<%= @stats_wins %>試合）</th>
-                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap text-red-700">敗北時（<%= @stats_losses %>試合）</th>
+            <table class="min-w-full">
+              <thead>
+                <tr class="border-b border-gray-200">
+                  <th class="px-5 py-3 text-left text-xs font-medium text-gray-400 min-w-36">項目</th>
+                  <th class="px-5 py-3 text-center text-xs font-bold text-indigo-700 bg-indigo-50 min-w-28">
+                    全体<br><span class="font-normal text-indigo-400"><%= @stats_total %>試合</span>
+                  </th>
+                  <th class="px-5 py-3 text-center text-xs font-bold text-green-700 bg-green-50 min-w-28">
+                    勝利時<br><span class="font-normal text-green-500"><%= @stats_wins %>試合</span>
+                  </th>
+                  <th class="px-5 py-3 text-center text-xs font-bold text-red-700 bg-red-50 min-w-28">
+                    敗北時<br><span class="font-normal text-red-400"><%= @stats_losses %>試合</span>
+                  </th>
                 </tr>
               </thead>
-              <tbody class="bg-white divide-y divide-gray-200">
-                <% perf_rows = [
-                  { label: "スコア",                  key: :score,           suffix: "" },
-                  { label: "撃墜数",                  key: :kills,           suffix: "" },
-                  { label: "被撃墜数",                key: :deaths,          suffix: "" },
-                  { label: "与ダメージ",              key: :damage_dealt,    suffix: "" },
-                  { label: "被ダメージ",              key: :damage_received, suffix: "" },
-                  { label: "EXバーストダメージ",      key: :exburst_damage,  suffix: "" },
-                  { label: "EXバースト発動回数",      key: :exburst_count,   suffix: "" },
-                  { label: "EXバースト中被撃墜数",    key: :exburst_deaths,  suffix: "" },
-                  { label: "OL発動率",                key: :ol_rate,         suffix: "%" },
-                ] %>
-                <% perf_rows.each do |row| %>
-                  <tr class="hover:bg-gray-50">
-                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-700"><%= row[:label] %></td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      <%= @performance_overall ? "#{@performance_overall[row[:key]]}#{row[:suffix]}" : "-" %>
-                    </td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-green-700">
-                      <%= @performance_wins ? "#{@performance_wins[row[:key]]}#{row[:suffix]}" : "-" %>
-                    </td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm text-red-700">
-                      <%= @performance_losses ? "#{@performance_losses[row[:key]]}#{row[:suffix]}" : "-" %>
-                    </td>
+              <tbody>
+                <!-- 基本戦績グループ -->
+                <tr class="bg-indigo-50">
+                  <td colspan="4" class="px-5 py-2 text-xs font-semibold text-indigo-600 border-l-2 border-indigo-400">基本戦績</td>
+                </tr>
+                <% [
+                  { label: "スコア",   key: :score,  suffix: "" },
+                  { label: "撃墜数",   key: :kills,  suffix: "" },
+                  { label: "被撃墜数", key: :deaths, suffix: "" },
+                ].each_with_index do |row, i| %>
+                  <tr class="<%= i.odd? ? 'bg-gray-50' : 'bg-white' %> hover:bg-indigo-50 border-t border-gray-100">
+                    <td class="px-5 py-3 text-sm text-gray-700 border-l-2 border-indigo-200 pl-6"><%= row[:label] %></td>
+                    <% [[@performance_overall, "text-indigo-700"], [@performance_wins, "text-green-700"], [@performance_losses, "text-red-700"]].each do |perf, color| %>
+                      <td class="px-5 py-3 text-center text-sm font-semibold <%= color %>">
+                        <%= perf ? "#{perf[row[:key]]}#{row[:suffix]}" : '-' %>
+                      </td>
+                    <% end %>
+                  </tr>
+                <% end %>
+
+                <!-- ダメージグループ -->
+                <tr class="bg-purple-50">
+                  <td colspan="4" class="px-5 py-2 text-xs font-semibold text-purple-600 border-l-2 border-purple-400">ダメージ</td>
+                </tr>
+                <% [
+                  { label: "与ダメージ",         key: :damage_dealt,   suffix: "" },
+                  { label: "被ダメージ",         key: :damage_received, suffix: "" },
+                  { label: "EXバーストダメージ", key: :exburst_damage,  suffix: "" },
+                ].each_with_index do |row, i| %>
+                  <tr class="<%= i.odd? ? 'bg-gray-50' : 'bg-white' %> hover:bg-purple-50 border-t border-gray-100">
+                    <td class="px-5 py-3 text-sm text-gray-700 border-l-2 border-purple-200 pl-6"><%= row[:label] %></td>
+                    <% [[@performance_overall, "text-indigo-700"], [@performance_wins, "text-green-700"], [@performance_losses, "text-red-700"]].each do |perf, color| %>
+                      <td class="px-5 py-3 text-center text-sm font-semibold <%= color %>">
+                        <%= perf ? "#{perf[row[:key]]}#{row[:suffix]}" : '-' %>
+                      </td>
+                    <% end %>
+                  </tr>
+                <% end %>
+
+                <!-- EXバーストグループ -->
+                <tr class="bg-orange-50">
+                  <td colspan="4" class="px-5 py-2 text-xs font-semibold text-orange-600 border-l-2 border-orange-400">EXバースト / オーバーリミット</td>
+                </tr>
+                <% [
+                  { label: "発動回数",                  key: :exburst_count,      suffix: "" },
+                  { label: "バースト中被撃墜数",        key: :exburst_deaths,     suffix: "" },
+                  { label: "バースト中被撃墜率",        key: :exburst_death_rate, suffix: "%", na_if_nil: true },
+                  { label: "EXオーバーリミット発動率",  key: :ol_rate,            suffix: "%" },
+                ].each_with_index do |row, i| %>
+                  <tr class="<%= i.odd? ? 'bg-gray-50' : 'bg-white' %> hover:bg-orange-50 border-t border-gray-100">
+                    <td class="px-5 py-3 text-sm text-gray-700 border-l-2 border-orange-200 pl-6"><%= row[:label] %></td>
+                    <% [[@performance_overall, "text-indigo-700"], [@performance_wins, "text-green-700"], [@performance_losses, "text-red-700"]].each do |perf, color| %>
+                      <td class="px-5 py-3 text-center text-sm font-semibold <%= color %>">
+                        <% if perf.nil? %>
+                          <span class="text-gray-300 font-normal">-</span>
+                        <% elsif row[:na_if_nil] && perf[row[:key]].nil? %>
+                          <span class="text-gray-400 text-xs font-normal">N/A</span>
+                        <% else %>
+                          <%= "#{perf[row[:key]]}#{row[:suffix]}" %>
+                        <% end %>
+                      </td>
+                    <% end %>
                   </tr>
                 <% end %>
               </tbody>
@@ -1237,94 +1292,116 @@
         <% end %>
       </div>
 
-      <!-- セクション2: EXバースト活用分析 -->
-      <div class="bg-white rounded-lg shadow">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <h3 class="text-lg font-semibold text-gray-900">EXバースト活用分析（敗北時）</h3>
-          <p class="mt-1 text-sm text-gray-500">EXバーストを残したまま敗北したケースを分析します</p>
-        </div>
-        <div class="px-6 py-5 space-y-4">
-          <% if @stats_losses > 0 %>
-            <div class="flex items-center justify-between py-3 border-b border-gray-100">
-              <div>
-                <div class="text-sm font-medium text-gray-900">EXバースト残し敗北</div>
-                <div class="text-xs text-gray-500 mt-1">最後の撃墜時またはEX残し生存で敗北したケース</div>
-              </div>
-              <div class="text-right">
-                <div class="text-lg font-bold text-red-600">
-                  <%= @ex_remaining_on_loss %> / <%= @stats_losses %>回
-                </div>
-                <div class="text-sm text-gray-500">
-                  (<%= @stats_losses > 0 ? (@ex_remaining_on_loss * 100.0 / @stats_losses).round(1) : 0 %>%)
-                </div>
-              </div>
-            </div>
-            <div class="pl-6 space-y-3">
-              <div class="flex items-center justify-between py-2">
-                <div>
-                  <div class="text-sm text-gray-700">うち 最後の撃墜時EX残し</div>
-                </div>
-                <div class="text-right">
-                  <div class="text-sm font-semibold text-red-500">
-                    <%= @last_death_ex_on_loss %> / <%= @stats_losses %>回
-                    (<%= @stats_losses > 0 ? (@last_death_ex_on_loss * 100.0 / @stats_losses).round(1) : 0 %>%)
-                  </div>
-                </div>
-              </div>
-              <div class="flex items-center justify-between py-2">
-                <div>
-                  <div class="text-sm text-gray-700">うち 生存敗北時EX残し</div>
-                </div>
-                <div class="text-right">
-                  <div class="text-sm font-semibold text-red-500">
-                    <%= @survive_loss_ex_on_loss %> / <%= @stats_losses %>回
-                    (<%= @stats_losses > 0 ? (@survive_loss_ex_on_loss * 100.0 / @stats_losses).round(1) : 0 %>%)
-                  </div>
-                </div>
-              </div>
-            </div>
-          <% else %>
-            <p class="text-gray-500 text-center py-4">統計データのある敗北試合がありません</p>
-          <% end %>
-        </div>
-      </div>
+      <!-- セクション2 & 3: 2カラムレイアウト -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 
-      <!-- セクション3: OL分析 -->
-      <div class="bg-white rounded-lg shadow">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <h3 class="text-lg font-semibold text-gray-900">OL（オーバーリミット）分析</h3>
-          <p class="mt-1 text-sm text-gray-500">全試合を対象にOL発動状況を分析します</p>
-        </div>
-        <div class="px-6 py-5 space-y-4">
-          <div class="flex items-center justify-between py-3 border-b border-gray-100">
+        <!-- セクション2: EXバースト活用分析 -->
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+          <div class="px-6 py-4 border-b border-gray-200 flex items-center gap-3">
+            <span class="w-1 h-5 bg-orange-400 rounded-full flex-shrink-0"></span>
             <div>
-              <div class="text-sm font-medium text-gray-900">自チームOL未発動で敗北</div>
-              <div class="text-xs text-gray-500 mt-1">OLを発動できずに負けた試合</div>
-            </div>
-            <div class="text-right">
-              <div class="text-lg font-bold text-orange-600">
-                <%= @my_team_no_ol_losses %> / <%= @total_losses %>回
-              </div>
-              <div class="text-sm text-gray-500">
-                (<%= @total_losses > 0 ? (@my_team_no_ol_losses * 100.0 / @total_losses).round(1) : 0 %>%)
-              </div>
+              <h3 class="text-base font-bold text-gray-900">EXバースト活用分析</h3>
+              <p class="text-xs text-gray-400">敗北時のEXバースト残し状況</p>
             </div>
           </div>
-          <div class="flex items-center justify-between py-3">
+          <div class="px-6 py-5">
+            <% if @stats_losses.to_i > 0 %>
+              <%
+                ex_pct      = (@ex_remaining_on_loss * 100.0 / @stats_losses).round(1)
+                last_pct    = (@last_death_ex_on_loss * 100.0 / @stats_losses).round(1)
+                survive_pct = (@survive_loss_ex_on_loss * 100.0 / @stats_losses).round(1)
+              %>
+              <!-- メイン指標 -->
+              <div class="mb-5">
+                <div class="flex items-baseline justify-between mb-2">
+                  <span class="text-sm font-medium text-gray-700">EXバースト残し敗北</span>
+                  <span class="text-2xl font-bold text-orange-600"><%= ex_pct %><span class="text-sm font-normal text-gray-500">%</span></span>
+                </div>
+                <div class="w-full bg-gray-100 rounded-full h-2.5">
+                  <div class="bg-orange-400 h-2.5 rounded-full" style="width: <%= [ex_pct, 100].min %>%"></div>
+                </div>
+                <div class="text-xs text-gray-400 mt-1.5 text-right"><%= @ex_remaining_on_loss %> / <%= @stats_losses %> 回</div>
+              </div>
+              <!-- 内訳 -->
+              <div class="space-y-4 border-t border-gray-100 pt-4">
+                <div>
+                  <div class="flex items-center justify-between mb-1.5">
+                    <div class="flex items-center gap-1.5">
+                      <span class="w-2 h-2 rounded-full bg-red-400 flex-shrink-0"></span>
+                      <span class="text-sm text-gray-600">うち 自機が被撃墜</span>
+                    </div>
+                    <span class="text-sm font-bold text-red-600"><%= last_pct %>%</span>
+                  </div>
+                  <div class="w-full bg-gray-100 rounded-full h-1.5">
+                    <div class="bg-red-400 h-1.5 rounded-full" style="width: <%= [last_pct, 100].min %>%"></div>
+                  </div>
+                  <div class="text-xs text-gray-400 mt-1 text-right"><%= @last_death_ex_on_loss %> / <%= @stats_losses %> 回</div>
+                </div>
+                <div>
+                  <div class="flex items-center justify-between mb-1.5">
+                    <div class="flex items-center gap-1.5">
+                      <span class="w-2 h-2 rounded-full bg-rose-300 flex-shrink-0"></span>
+                      <span class="text-sm text-gray-600">うち パートナー機が被撃墜</span>
+                    </div>
+                    <span class="text-sm font-bold text-rose-500"><%= survive_pct %>%</span>
+                  </div>
+                  <div class="w-full bg-gray-100 rounded-full h-1.5">
+                    <div class="bg-rose-300 h-1.5 rounded-full" style="width: <%= [survive_pct, 100].min %>%"></div>
+                  </div>
+                  <div class="text-xs text-gray-400 mt-1 text-right"><%= @survive_loss_ex_on_loss %> / <%= @stats_losses %> 回</div>
+                </div>
+              </div>
+            <% else %>
+              <p class="text-gray-400 text-sm text-center py-8">統計データのある敗北試合がありません</p>
+            <% end %>
+          </div>
+        </div>
+
+        <!-- セクション3: EXオーバーリミット分析 -->
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+          <div class="px-6 py-4 border-b border-gray-200 flex items-center gap-3">
+            <span class="w-1 h-5 bg-violet-400 rounded-full flex-shrink-0"></span>
             <div>
-              <div class="text-sm font-medium text-gray-900">相手チームOL未発動で勝利</div>
-              <div class="text-xs text-gray-500 mt-1">相手にOLを発動させずに勝った試合</div>
+              <h3 class="text-base font-bold text-gray-900">EXオーバーリミット分析</h3>
+              <p class="text-xs text-gray-400">全試合を対象にEXオーバーリミット発動状況を集計</p>
             </div>
-            <div class="text-right">
-              <div class="text-lg font-bold text-green-600">
-                <%= @opponent_no_ol_wins %> / <%= @total_wins_all %>回
+          </div>
+          <div class="px-6 py-5 space-y-6">
+            <%
+              no_ol_pct     = @total_losses.to_i > 0    ? (@my_team_no_ol_losses * 100.0 / @total_losses).round(1)   : 0.0
+              opp_no_ol_pct = @total_wins_all.to_i > 0  ? (@opponent_no_ol_wins  * 100.0 / @total_wins_all).round(1) : 0.0
+            %>
+            <!-- 自チーム -->
+            <div>
+              <div class="flex items-start justify-between mb-2 gap-3">
+                <div>
+                  <div class="text-sm font-medium text-gray-700">自チームEXオーバーリミット未発動で敗北</div>
+                  <div class="text-xs text-gray-400 mt-0.5">EXオーバーリミットを発動できずに負けた試合</div>
+                </div>
+                <span class="text-2xl font-bold text-red-600 flex-shrink-0"><%= no_ol_pct %><span class="text-sm font-normal text-gray-500">%</span></span>
               </div>
-              <div class="text-sm text-gray-500">
-                (<%= @total_wins_all > 0 ? (@opponent_no_ol_wins * 100.0 / @total_wins_all).round(1) : 0 %>%)
+              <div class="w-full bg-gray-100 rounded-full h-2.5">
+                <div class="bg-red-400 h-2.5 rounded-full" style="width: <%= [no_ol_pct, 100].min %>%"></div>
               </div>
+              <div class="text-xs text-gray-400 mt-1.5 text-right"><%= @my_team_no_ol_losses %> / <%= @total_losses %> 回</div>
+            </div>
+            <!-- 相手チーム -->
+            <div>
+              <div class="flex items-start justify-between mb-2 gap-3">
+                <div>
+                  <div class="text-sm font-medium text-gray-700">相手チームEXオーバーリミット未発動で勝利</div>
+                  <div class="text-xs text-gray-400 mt-0.5">相手にEXオーバーリミットを発動させずに勝った試合</div>
+                </div>
+                <span class="text-2xl font-bold text-green-600 flex-shrink-0"><%= opp_no_ol_pct %><span class="text-sm font-normal text-gray-500">%</span></span>
+              </div>
+              <div class="w-full bg-gray-100 rounded-full h-2.5">
+                <div class="bg-green-400 h-2.5 rounded-full" style="width: <%= [opp_no_ol_pct, 100].min %>%"></div>
+              </div>
+              <div class="text-xs text-gray-400 mt-1.5 text-right"><%= @opponent_no_ol_wins %> / <%= @total_wins_all %> 回</div>
             </div>
           </div>
         </div>
+
       </div>
 
     </div>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1179,107 +1179,142 @@
     <div class="space-y-6">
 
       <!-- サマリーカード -->
-      <div class="grid grid-cols-3 gap-4">
-        <div class="bg-indigo-50 border border-indigo-200 rounded-xl p-5 text-center">
-          <div class="text-3xl font-bold text-indigo-700"><%= @stats_total %></div>
-          <div class="text-xs text-indigo-500 mt-1 font-medium">統計データあり試合</div>
+      <div class="grid grid-cols-3 gap-4 sm:gap-6">
+        <div class="bg-white rounded-lg shadow p-4 sm:p-6">
+          <div class="text-xs sm:text-sm font-medium text-gray-500">統計データあり試合</div>
+          <div class="mt-1 sm:mt-2 text-2xl sm:text-3xl font-bold text-indigo-600"><%= @stats_total %></div>
         </div>
-        <div class="bg-green-50 border border-green-200 rounded-xl p-5 text-center">
-          <div class="text-3xl font-bold text-green-700"><%= @stats_wins %></div>
-          <div class="text-xs text-green-600 mt-1 font-medium">勝利</div>
+        <div class="bg-white rounded-lg shadow p-4 sm:p-6">
+          <div class="text-xs sm:text-sm font-medium text-gray-500">勝利</div>
+          <div class="mt-1 sm:mt-2 text-2xl sm:text-3xl font-bold text-green-600"><%= @stats_wins %></div>
         </div>
-        <div class="bg-red-50 border border-red-200 rounded-xl p-5 text-center">
-          <div class="text-3xl font-bold text-red-700"><%= @stats_losses %></div>
-          <div class="text-xs text-red-500 mt-1 font-medium">敗北</div>
+        <div class="bg-white rounded-lg shadow p-4 sm:p-6">
+          <div class="text-xs sm:text-sm font-medium text-gray-500">敗北</div>
+          <div class="mt-1 sm:mt-2 text-2xl sm:text-3xl font-bold text-red-600"><%= @stats_losses %></div>
         </div>
       </div>
 
       <!-- セクション1: 基本パフォーマンス統計 -->
-      <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-        <div class="px-6 py-4 border-b border-gray-200">
-          <h3 class="text-base font-bold text-gray-900">基本パフォーマンス統計</h3>
-          <p class="text-xs text-gray-500 mt-0.5">試合ごとの平均値</p>
+      <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-5 border-b border-gray-200">
+          <h3 class="text-lg font-semibold text-gray-900">基本パフォーマンス統計</h3>
+          <p class="mt-1 text-sm text-gray-500">試合ごとのスコアやダメージ等の平均値を確認できます</p>
         </div>
         <% if @stats_total.to_i > 0 %>
           <div class="overflow-x-auto">
-            <table class="min-w-full">
-              <thead>
-                <tr class="border-b border-gray-200">
-                  <th class="px-5 py-3 text-left text-xs font-medium text-gray-400 min-w-36">項目</th>
-                  <th class="px-5 py-3 text-center text-xs font-bold text-indigo-700 bg-indigo-50 min-w-28">
-                    全体<br><span class="font-normal text-indigo-400"><%= @stats_total %>試合</span>
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">項目</th>
+                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                    全体<br><span class="normal-case font-normal"><%= @stats_total %>試合</span>
                   </th>
-                  <th class="px-5 py-3 text-center text-xs font-bold text-green-700 bg-green-50 min-w-28">
-                    勝利時<br><span class="font-normal text-green-500"><%= @stats_wins %>試合</span>
+                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                    勝利時<br><span class="normal-case font-normal"><%= @stats_wins %>試合</span>
                   </th>
-                  <th class="px-5 py-3 text-center text-xs font-bold text-red-700 bg-red-50 min-w-28">
-                    敗北時<br><span class="font-normal text-red-400"><%= @stats_losses %>試合</span>
+                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                    敗北時<br><span class="normal-case font-normal"><%= @stats_losses %>試合</span>
+                  </th>
+                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                    コミュニティ平均・分布
                   </th>
                 </tr>
               </thead>
-              <tbody>
-                <!-- 基本戦績グループ -->
-                <tr class="bg-indigo-50">
-                  <td colspan="4" class="px-5 py-2 text-xs font-semibold text-indigo-600 border-l-2 border-indigo-400">基本戦績</td>
-                </tr>
-                <% [
-                  { label: "スコア",   key: :score,  suffix: "" },
-                  { label: "撃墜数",   key: :kills,  suffix: "" },
-                  { label: "被撃墜数", key: :deaths, suffix: "" },
-                ].each_with_index do |row, i| %>
-                  <tr class="<%= i.odd? ? 'bg-gray-50' : 'bg-white' %> hover:bg-indigo-50 border-t border-gray-100">
-                    <td class="px-5 py-3 text-sm text-gray-700 border-l-2 border-indigo-200 pl-6"><%= row[:label] %></td>
-                    <% [[@performance_overall, "text-indigo-700"], [@performance_wins, "text-green-700"], [@performance_losses, "text-red-700"]].each do |perf, color| %>
-                      <td class="px-5 py-3 text-center text-sm font-semibold <%= color %>">
-                        <%= perf ? "#{perf[row[:key]]}#{row[:suffix]}" : '-' %>
-                      </td>
-                    <% end %>
+              <tbody class="bg-white divide-y divide-gray-100">
+                <%
+                  perf_groups = [
+                    {
+                      label: "基本戦績",
+                      rows: [
+                        { label: "スコア",   key: :score,  suffix: "", higher_is_better: true },
+                        { label: "撃墜数",   key: :kills,  suffix: "", higher_is_better: true },
+                        { label: "被撃墜数", key: :deaths, suffix: "", higher_is_better: false },
+                      ]
+                    },
+                    {
+                      label: "ダメージ",
+                      rows: [
+                        { label: "与ダメージ",         key: :damage_dealt,    suffix: "", higher_is_better: true },
+                        { label: "被ダメージ",         key: :damage_received, suffix: "", higher_is_better: false },
+                        { label: "EXバーストダメージ", key: :exburst_damage,  suffix: "", higher_is_better: true },
+                      ]
+                    },
+                    {
+                      label: "EXバースト",
+                      rows: [
+                        { label: "EXバースト発動回数",   key: :exburst_count,      suffix: "",  higher_is_better: true },
+                        { label: "EXバースト中被撃墜数", key: :exburst_deaths,     suffix: "",  higher_is_better: false },
+                        { label: "EXバースト中被撃墜率", key: :exburst_death_rate, suffix: "%", higher_is_better: false, na_if_nil: true },
+                      ]
+                    },
+                    {
+                      label: "EXオーバーリミット",
+                      rows: [
+                        { label: "EXオーバーリミット発動率", key: :ol_rate, suffix: "%", higher_is_better: true, community_key: :ol_rate_losses, community_perf: :losses, community_note: "※敗北時のみ" },
+                      ]
+                    },
+                  ]
+                %>
+                <% perf_groups.each do |group| %>
+                  <tr class="bg-gray-50">
+                    <td colspan="5" class="px-6 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider"><%= group[:label] %></td>
                   </tr>
-                <% end %>
-
-                <!-- ダメージグループ -->
-                <tr class="bg-purple-50">
-                  <td colspan="4" class="px-5 py-2 text-xs font-semibold text-purple-600 border-l-2 border-purple-400">ダメージ</td>
-                </tr>
-                <% [
-                  { label: "与ダメージ",         key: :damage_dealt,   suffix: "" },
-                  { label: "被ダメージ",         key: :damage_received, suffix: "" },
-                  { label: "EXバーストダメージ", key: :exburst_damage,  suffix: "" },
-                ].each_with_index do |row, i| %>
-                  <tr class="<%= i.odd? ? 'bg-gray-50' : 'bg-white' %> hover:bg-purple-50 border-t border-gray-100">
-                    <td class="px-5 py-3 text-sm text-gray-700 border-l-2 border-purple-200 pl-6"><%= row[:label] %></td>
-                    <% [[@performance_overall, "text-indigo-700"], [@performance_wins, "text-green-700"], [@performance_losses, "text-red-700"]].each do |perf, color| %>
-                      <td class="px-5 py-3 text-center text-sm font-semibold <%= color %>">
-                        <%= perf ? "#{perf[row[:key]]}#{row[:suffix]}" : '-' %>
-                      </td>
-                    <% end %>
-                  </tr>
-                <% end %>
-
-                <!-- EXバーストグループ -->
-                <tr class="bg-orange-50">
-                  <td colspan="4" class="px-5 py-2 text-xs font-semibold text-orange-600 border-l-2 border-orange-400">EXバースト / オーバーリミット</td>
-                </tr>
-                <% [
-                  { label: "発動回数",                  key: :exburst_count,      suffix: "" },
-                  { label: "バースト中被撃墜数",        key: :exburst_deaths,     suffix: "" },
-                  { label: "バースト中被撃墜率",        key: :exburst_death_rate, suffix: "%", na_if_nil: true },
-                  { label: "EXオーバーリミット発動率",  key: :ol_rate,            suffix: "%" },
-                ].each_with_index do |row, i| %>
-                  <tr class="<%= i.odd? ? 'bg-gray-50' : 'bg-white' %> hover:bg-orange-50 border-t border-gray-100">
-                    <td class="px-5 py-3 text-sm text-gray-700 border-l-2 border-orange-200 pl-6"><%= row[:label] %></td>
-                    <% [[@performance_overall, "text-indigo-700"], [@performance_wins, "text-green-700"], [@performance_losses, "text-red-700"]].each do |perf, color| %>
-                      <td class="px-5 py-3 text-center text-sm font-semibold <%= color %>">
-                        <% if perf.nil? %>
-                          <span class="text-gray-300 font-normal">-</span>
-                        <% elsif row[:na_if_nil] && perf[row[:key]].nil? %>
-                          <span class="text-gray-400 text-xs font-normal">N/A</span>
+                  <% group[:rows].each do |row| %>
+                    <tr class="hover:bg-gray-50">
+                      <td class="px-6 py-4 text-sm text-gray-700 pl-8"><%= row[:label] %></td>
+                      <% [[@performance_overall, "text-indigo-600"], [@performance_wins, "text-green-600"], [@performance_losses, "text-red-600"]].each do |perf, color| %>
+                        <td class="px-6 py-4 text-center text-sm font-semibold <%= color %>">
+                          <% if perf.nil? %>
+                            <span class="text-gray-300 font-normal">-</span>
+                          <% elsif row[:na_if_nil] && perf[row[:key]].nil? %>
+                            <span class="text-gray-400 text-xs font-normal">N/A</span>
+                          <% else %>
+                            <%= "#{perf[row[:key]]}#{row[:suffix]}" %>
+                          <% end %>
+                        </td>
+                      <% end %>
+                      <td class="px-6 py-4 text-center">
+                        <% if @community_avg.nil? %>
+                          <span class="text-gray-300">-</span>
                         <% else %>
-                          <%= "#{perf[row[:key]]}#{row[:suffix]}" %>
+                          <%
+                            c_key    = row[:community_key] || row[:key]
+                            avg_val  = @community_avg[c_key]
+                            min_val  = @community_min&.[](c_key)
+                            max_val  = @community_max&.[](c_key)
+                            u_perf   = row[:community_perf] == :losses ? @performance_losses : @performance_overall
+                            user_val = u_perf&.[](row[:key])
+                          %>
+                          <% if row[:na_if_nil] && avg_val.nil? %>
+                            <span class="text-gray-400 text-xs">N/A</span>
+                          <% elsif avg_val.nil? %>
+                            <span class="text-gray-300">-</span>
+                          <% else %>
+                            <div class="text-sm text-gray-600 font-medium"><%= "#{avg_val}#{row[:suffix]}" %></div>
+                            <% if min_val && max_val && user_val && min_val != max_val %>
+                              <%
+                                range    = (max_val - min_val).to_f
+                                user_pct = ((user_val.to_f - min_val) / range * 100).clamp(0, 100).round(1)
+                                avg_pct  = ((avg_val.to_f  - min_val) / range * 100).clamp(0, 100).round(1)
+                                good     = row[:higher_is_better] ? user_val.to_f >= avg_val.to_f : user_val.to_f <= avg_val.to_f
+                              %>
+                              <div class="relative h-1.5 bg-gray-200 rounded-full mt-2 max-w-[100px] mx-auto">
+                                <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                                <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                              </div>
+                              <div class="flex justify-between text-[10px] text-gray-400 mt-1 max-w-[100px] mx-auto">
+                                <span><%= min_val %><%= row[:suffix] %></span>
+                                <span><%= max_val %><%= row[:suffix] %></span>
+                              </div>
+                            <% end %>
+                            <% if row[:community_note] %>
+                              <div class="text-[10px] text-gray-400 mt-1"><%= row[:community_note] %></div>
+                            <% end %>
+                          <% end %>
                         <% end %>
                       </td>
-                    <% end %>
-                  </tr>
+                    </tr>
+                  <% end %>
                 <% end %>
               </tbody>
             </table>
@@ -1296,13 +1331,10 @@
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 
         <!-- セクション2: EXバースト活用分析 -->
-        <div class="bg-white rounded-xl shadow-sm border border-gray-200">
-          <div class="px-6 py-4 border-b border-gray-200 flex items-center gap-3">
-            <span class="w-1 h-5 bg-orange-400 rounded-full flex-shrink-0"></span>
-            <div>
-              <h3 class="text-base font-bold text-gray-900">EXバースト活用分析</h3>
-              <p class="text-xs text-gray-400">敗北時のEXバースト残し状況</p>
-            </div>
+        <div class="bg-white rounded-lg shadow">
+          <div class="px-6 py-5 border-b border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900">EXバースト活用分析</h3>
+            <p class="mt-1 text-sm text-gray-500">敗北時にEXバーストを残してしまった割合を確認できます</p>
           </div>
           <div class="px-6 py-5">
             <% if @stats_losses.to_i > 0 %>
@@ -1311,94 +1343,188 @@
                 last_pct    = (@last_death_ex_on_loss * 100.0 / @stats_losses).round(1)
                 survive_pct = (@survive_loss_ex_on_loss * 100.0 / @stats_losses).round(1)
               %>
-              <!-- メイン指標 -->
-              <div class="mb-5">
-                <div class="flex items-baseline justify-between mb-2">
-                  <span class="text-sm font-medium text-gray-700">EXバースト残し敗北</span>
-                  <span class="text-2xl font-bold text-orange-600"><%= ex_pct %><span class="text-sm font-normal text-gray-500">%</span></span>
+              <!-- メイン指標: あなた vs コミュニティ平均 -->
+              <div class="mb-5 pb-5 border-b border-gray-100">
+                <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">EXバースト残し敗北</div>
+                <div class="flex items-stretch gap-0">
+                  <div class="flex-1 pr-4">
+                    <div class="text-xs text-gray-400 mb-1">あなた</div>
+                    <div class="text-3xl font-bold text-red-600"><%= ex_pct %><span class="text-base font-normal text-gray-500">%</span></div>
+                    <div class="text-xs text-gray-400 mt-1"><%= @ex_remaining_on_loss %> / <%= @stats_losses %> 回</div>
+                  </div>
+                  <% if @community_ex_remaining_rate %>
+                    <div class="w-px bg-gray-200 self-stretch"></div>
+                    <div class="flex-1 pl-4">
+                      <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
+                      <div class="text-2xl font-semibold text-gray-500"><%= @community_ex_remaining_rate %><span class="text-sm font-normal">%</span></div>
+                      <% if @community_ex_remaining_min && @community_ex_remaining_max && @community_ex_remaining_min != @community_ex_remaining_max %>
+                        <%
+                          range    = (@community_ex_remaining_max - @community_ex_remaining_min).to_f
+                          user_pct = ((ex_pct - @community_ex_remaining_min) / range * 100).clamp(0, 100).round(1)
+                          avg_pct  = ((@community_ex_remaining_rate - @community_ex_remaining_min) / range * 100).clamp(0, 100).round(1)
+                          good     = ex_pct <= @community_ex_remaining_rate
+                        %>
+                        <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
+                          <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                          <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                        </div>
+                        <div class="flex justify-between text-[10px] text-gray-400 mt-1">
+                          <span><%= @community_ex_remaining_min %>%</span>
+                          <span><%= @community_ex_remaining_max %>%</span>
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
                 </div>
-                <div class="w-full bg-gray-100 rounded-full h-2.5">
-                  <div class="bg-orange-400 h-2.5 rounded-full" style="width: <%= [ex_pct, 100].min %>%"></div>
-                </div>
-                <div class="text-xs text-gray-400 mt-1.5 text-right"><%= @ex_remaining_on_loss %> / <%= @stats_losses %> 回</div>
               </div>
               <!-- 内訳 -->
-              <div class="space-y-4 border-t border-gray-100 pt-4">
+              <div class="space-y-4">
+                <!-- 自機が被撃墜 -->
                 <div>
-                  <div class="flex items-center justify-between mb-1.5">
-                    <div class="flex items-center gap-1.5">
-                      <span class="w-2 h-2 rounded-full bg-red-400 flex-shrink-0"></span>
-                      <span class="text-sm text-gray-600">うち 自機が被撃墜</span>
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm text-gray-600">自機が被撃墜</span>
+                    <div class="text-right">
+                      <span class="text-sm font-semibold text-gray-700"><%= last_pct %>%</span>
+                      <span class="text-xs text-gray-400 ml-1">(<%= @last_death_ex_on_loss %>/<%= @stats_losses %>回)</span>
                     </div>
-                    <span class="text-sm font-bold text-red-600"><%= last_pct %>%</span>
                   </div>
-                  <div class="w-full bg-gray-100 rounded-full h-1.5">
-                    <div class="bg-red-400 h-1.5 rounded-full" style="width: <%= [last_pct, 100].min %>%"></div>
-                  </div>
-                  <div class="text-xs text-gray-400 mt-1 text-right"><%= @last_death_ex_on_loss %> / <%= @stats_losses %> 回</div>
+                  <% if @community_last_death_ex_rate && @community_last_death_ex_min != @community_last_death_ex_max %>
+                    <%
+                      range        = (@community_last_death_ex_max - @community_last_death_ex_min).to_f
+                      user_pct_bar = ((last_pct - @community_last_death_ex_min) / range * 100).clamp(0, 100).round(1)
+                      avg_pct_bar  = ((@community_last_death_ex_rate - @community_last_death_ex_min) / range * 100).clamp(0, 100).round(1)
+                      good         = last_pct <= @community_last_death_ex_rate
+                    %>
+                    <div class="relative h-1.5 bg-gray-200 rounded-full mt-1.5">
+                      <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct_bar %>%"></div>
+                      <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct_bar %>%"></div>
+                    </div>
+                    <div class="relative h-4 text-[10px] text-gray-400 mt-0.5">
+                      <span class="absolute left-0"><%= @community_last_death_ex_min %>%</span>
+                      <span class="absolute -translate-x-1/2 whitespace-nowrap" style="left: <%= avg_pct_bar %>%">avg <%= @community_last_death_ex_rate %>%</span>
+                      <span class="absolute right-0"><%= @community_last_death_ex_max %>%</span>
+                    </div>
+                  <% end %>
                 </div>
+                <!-- パートナー機が被撃墜 -->
                 <div>
-                  <div class="flex items-center justify-between mb-1.5">
-                    <div class="flex items-center gap-1.5">
-                      <span class="w-2 h-2 rounded-full bg-rose-300 flex-shrink-0"></span>
-                      <span class="text-sm text-gray-600">うち パートナー機が被撃墜</span>
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm text-gray-600">パートナー機が被撃墜</span>
+                    <div class="text-right">
+                      <span class="text-sm font-semibold text-gray-700"><%= survive_pct %>%</span>
+                      <span class="text-xs text-gray-400 ml-1">(<%= @survive_loss_ex_on_loss %>/<%= @stats_losses %>回)</span>
                     </div>
-                    <span class="text-sm font-bold text-rose-500"><%= survive_pct %>%</span>
                   </div>
-                  <div class="w-full bg-gray-100 rounded-full h-1.5">
-                    <div class="bg-rose-300 h-1.5 rounded-full" style="width: <%= [survive_pct, 100].min %>%"></div>
-                  </div>
-                  <div class="text-xs text-gray-400 mt-1 text-right"><%= @survive_loss_ex_on_loss %> / <%= @stats_losses %> 回</div>
+                  <% if @community_survive_ex_rate && @community_survive_ex_min != @community_survive_ex_max %>
+                    <%
+                      range        = (@community_survive_ex_max - @community_survive_ex_min).to_f
+                      user_pct_bar = ((survive_pct - @community_survive_ex_min) / range * 100).clamp(0, 100).round(1)
+                      avg_pct_bar  = ((@community_survive_ex_rate - @community_survive_ex_min) / range * 100).clamp(0, 100).round(1)
+                      good         = survive_pct <= @community_survive_ex_rate
+                    %>
+                    <div class="relative h-1.5 bg-gray-200 rounded-full mt-1.5">
+                      <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct_bar %>%"></div>
+                      <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct_bar %>%"></div>
+                    </div>
+                    <div class="relative h-4 text-[10px] text-gray-400 mt-0.5">
+                      <span class="absolute left-0"><%= @community_survive_ex_min %>%</span>
+                      <span class="absolute -translate-x-1/2 whitespace-nowrap" style="left: <%= avg_pct_bar %>%">avg <%= @community_survive_ex_rate %>%</span>
+                      <span class="absolute right-0"><%= @community_survive_ex_max %>%</span>
+                    </div>
+                  <% end %>
                 </div>
               </div>
             <% else %>
-              <p class="text-gray-400 text-sm text-center py-8">統計データのある敗北試合がありません</p>
+              <p class="text-gray-500 text-center py-8">統計データのある敗北試合がありません</p>
             <% end %>
           </div>
         </div>
 
         <!-- セクション3: EXオーバーリミット分析 -->
-        <div class="bg-white rounded-xl shadow-sm border border-gray-200">
-          <div class="px-6 py-4 border-b border-gray-200 flex items-center gap-3">
-            <span class="w-1 h-5 bg-violet-400 rounded-full flex-shrink-0"></span>
-            <div>
-              <h3 class="text-base font-bold text-gray-900">EXオーバーリミット分析</h3>
-              <p class="text-xs text-gray-400">全試合を対象にEXオーバーリミット発動状況を集計</p>
-            </div>
+        <div class="bg-white rounded-lg shadow">
+          <div class="px-6 py-5 border-b border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900">EXオーバーリミット分析</h3>
+            <p class="mt-1 text-sm text-gray-500">全試合のEXオーバーリミット発動状況を確認できます</p>
           </div>
-          <div class="px-6 py-5 space-y-6">
+          <div class="px-6 py-5 space-y-5">
+            <% if @has_ol_data %>
             <%
-              no_ol_pct     = @total_losses.to_i > 0    ? (@my_team_no_ol_losses * 100.0 / @total_losses).round(1)   : 0.0
-              opp_no_ol_pct = @total_wins_all.to_i > 0  ? (@opponent_no_ol_wins  * 100.0 / @total_wins_all).round(1) : 0.0
+              no_ol_pct     = @total_losses.to_i > 0   ? (@my_team_no_ol_losses * 100.0 / @total_losses).round(1)   : 0.0
+              opp_no_ol_pct = @total_wins_all.to_i > 0 ? (@opponent_no_ol_wins  * 100.0 / @total_wins_all).round(1) : 0.0
             %>
-            <!-- 自チーム -->
-            <div>
-              <div class="flex items-start justify-between mb-2 gap-3">
-                <div>
-                  <div class="text-sm font-medium text-gray-700">自チームEXオーバーリミット未発動で敗北</div>
-                  <div class="text-xs text-gray-400 mt-0.5">EXオーバーリミットを発動できずに負けた試合</div>
+            <!-- 相手チーム勝利 -->
+            <div class="pb-5 border-b border-gray-100">
+              <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">相手チームEXオーバーリミット未発動で勝利</div>
+              <div class="text-xs text-gray-400 mb-3">相手にEXオーバーリミットを発動させずに勝った試合</div>
+              <div class="flex items-stretch gap-0">
+                <div class="flex-1 pr-4">
+                  <div class="text-xs text-gray-400 mb-1">あなた</div>
+                  <div class="text-3xl font-bold text-green-600"><%= opp_no_ol_pct %><span class="text-base font-normal text-gray-500">%</span></div>
+                  <div class="text-xs text-gray-400 mt-1"><%= @opponent_no_ol_wins %> / <%= @total_wins_all %> 回</div>
                 </div>
-                <span class="text-2xl font-bold text-red-600 flex-shrink-0"><%= no_ol_pct %><span class="text-sm font-normal text-gray-500">%</span></span>
+                <% if @community_opp_no_ol_win_rate %>
+                  <div class="w-px bg-gray-200 self-stretch"></div>
+                  <div class="flex-1 pl-4">
+                    <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
+                    <div class="text-2xl font-semibold text-gray-500"><%= @community_opp_no_ol_win_rate %><span class="text-sm font-normal">%</span></div>
+                    <% if @community_opp_no_ol_win_min && @community_opp_no_ol_win_max && @community_opp_no_ol_win_min != @community_opp_no_ol_win_max %>
+                      <%
+                        range    = (@community_opp_no_ol_win_max - @community_opp_no_ol_win_min).to_f
+                        user_pct = ((opp_no_ol_pct - @community_opp_no_ol_win_min) / range * 100).clamp(0, 100).round(1)
+                        avg_pct  = ((@community_opp_no_ol_win_rate - @community_opp_no_ol_win_min) / range * 100).clamp(0, 100).round(1)
+                        good     = opp_no_ol_pct >= @community_opp_no_ol_win_rate
+                      %>
+                      <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
+                        <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                        <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                      </div>
+                      <div class="flex justify-between text-[10px] text-gray-400 mt-1">
+                        <span><%= @community_opp_no_ol_win_min %>%</span>
+                        <span><%= @community_opp_no_ol_win_max %>%</span>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
-              <div class="w-full bg-gray-100 rounded-full h-2.5">
-                <div class="bg-red-400 h-2.5 rounded-full" style="width: <%= [no_ol_pct, 100].min %>%"></div>
-              </div>
-              <div class="text-xs text-gray-400 mt-1.5 text-right"><%= @my_team_no_ol_losses %> / <%= @total_losses %> 回</div>
             </div>
-            <!-- 相手チーム -->
+            <!-- 自チーム敗北 -->
             <div>
-              <div class="flex items-start justify-between mb-2 gap-3">
-                <div>
-                  <div class="text-sm font-medium text-gray-700">相手チームEXオーバーリミット未発動で勝利</div>
-                  <div class="text-xs text-gray-400 mt-0.5">相手にEXオーバーリミットを発動させずに勝った試合</div>
+              <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">自チームEXオーバーリミット未発動で敗北</div>
+              <div class="text-xs text-gray-400 mb-3">EXオーバーリミットを発動できずに負けた試合</div>
+              <div class="flex items-stretch gap-0">
+                <div class="flex-1 pr-4">
+                  <div class="text-xs text-gray-400 mb-1">あなた</div>
+                  <div class="text-3xl font-bold text-red-600"><%= no_ol_pct %><span class="text-base font-normal text-gray-500">%</span></div>
+                  <div class="text-xs text-gray-400 mt-1"><%= @my_team_no_ol_losses %> / <%= @total_losses %> 回</div>
                 </div>
-                <span class="text-2xl font-bold text-green-600 flex-shrink-0"><%= opp_no_ol_pct %><span class="text-sm font-normal text-gray-500">%</span></span>
+                <% if @community_no_ol_loss_rate %>
+                  <div class="w-px bg-gray-200 self-stretch"></div>
+                  <div class="flex-1 pl-4">
+                    <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
+                    <div class="text-2xl font-semibold text-gray-500"><%= @community_no_ol_loss_rate %><span class="text-sm font-normal">%</span></div>
+                    <% if @community_no_ol_loss_min && @community_no_ol_loss_max && @community_no_ol_loss_min != @community_no_ol_loss_max %>
+                      <%
+                        range    = (@community_no_ol_loss_max - @community_no_ol_loss_min).to_f
+                        user_pct = ((no_ol_pct - @community_no_ol_loss_min) / range * 100).clamp(0, 100).round(1)
+                        avg_pct  = ((@community_no_ol_loss_rate - @community_no_ol_loss_min) / range * 100).clamp(0, 100).round(1)
+                        good     = no_ol_pct <= @community_no_ol_loss_rate
+                      %>
+                      <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
+                        <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                        <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                      </div>
+                      <div class="flex justify-between text-[10px] text-gray-400 mt-1">
+                        <span><%= @community_no_ol_loss_min %>%</span>
+                        <span><%= @community_no_ol_loss_max %>%</span>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
-              <div class="w-full bg-gray-100 rounded-full h-2.5">
-                <div class="bg-green-400 h-2.5 rounded-full" style="width: <%= [opp_no_ol_pct, 100].min %>%"></div>
-              </div>
-              <div class="text-xs text-gray-400 mt-1.5 text-right"><%= @opponent_no_ol_wins %> / <%= @total_wins_all %> 回</div>
             </div>
+            <% else %>
+              <p class="text-gray-500 text-center py-8">EXオーバーリミットのデータがありません</p>
+            <% end %>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- 統計ページの「パフォーマンス」タブを**「プレイ分析」**にリネームし、タブ順を「総合戦績」の直後に移動
- 基本パフォーマンス統計テーブルにコミュニティ分布（レンジバー）列を追加：ユーザーの位置をドット、平均を縦線、最小/最大を両端で可視化
  - カテゴリを「基本戦績」「ダメージ」「EXバースト」「EXオーバーリミット」の4グループに分割
  - EXオーバーリミット発動率は敗北時のデータのみで比較し、※注釈を表示
- EXバースト活用分析にコミュニティ分布レンジバーを追加（残し敗北率・生存敗北率、各被撃墜パターン）
- EXオーバーリミット分析にコミュニティ分布レンジバーを追加（OL未発動敗北率・相手OL未発動勝利率）
- EXオーバーリミットのデータがないユーザー向けに「データがありません」メッセージを表示
- 各セクションの説明文を「〜を確認できます」形式に統一

## Test plan
- [ ] `/statistics?tab=performance` を開き「プレイ分析」タブが表示され、タブ順が「総合戦績」の直後になっている
- [ ] 基本パフォーマンス統計テーブルで「コミュニティ平均・分布」列にレンジバーが表示される
- [ ] EXオーバーリミット行の注釈「※敗北時のみ」が表示される
- [ ] EXバースト活用分析・EXオーバーリミット分析でもレンジバーが表示される
- [ ] OLデータがないユーザーでOLセクションが「データがありません」と表示される
- [ ] フィルター（イベント・機体）を適用して数値が変動する
- [ ] ゲストユーザーでアクセスすると overall にリダイレクトされる

Closes #100