### PR TITLE
fix: EXバースト中被撃墜数が常に0になるバグを修正

### DIFF
--- a/app/controllers/concerns/match_stats_importable.rb
+++ b/app/controllers/concerns/match_stats_importable.rb
@@ -130,7 +130,7 @@ module MatchStatsImportable
       # exburst_deaths: 被撃墜時刻がバースト区間内に含まれる数
       exburst_deaths = player_events.select { |e| e["is_point"] }.count do |death|
         cs = death["start_cs"]
-        burst_events.any? { |b| b["start_cs"] && b["end_cs"] && b["start_cs"] <= cs && cs < b["end_cs"] }
+        burst_events.any? { |b| b["start_cs"] && b["end_cs"] && b["start_cs"] <= cs && cs <= b["end_cs"] }
       end
 
       # EXゾーン判定ヘルパー


### PR DESCRIPTION
## Summary
- タイムラインから算出する `exburst_deaths` がバースト中の被撃墜でも常に0になるバグを修正

## 原因
バースト中に被撃墜されると、スクレイパーはバーストの `end_cs` を死亡時刻と同じ値で記録する。
判定条件が `cs < end_cs`（厳密な小なり）だったため、`cs == end_cs` のケースが除外されていた。

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `match_stats_importable.rb` バースト区間判定 | `cs < b["end_cs"]` | `cs <= b["end_cs"]` |

## ⚠️ 本番デプロイ後の追加作業
タイムラインデータを持つ全試合（現在118試合）で `recalculate_timeline_derived_stats` を再実行して `exburst_deaths` を再計算する必要がある。

```ruby
# bin/rails runner で実行
include MatchStatsImportable
Match.joins(:match_timeline).find_each do |match|
  @match = match
  recalculate_timeline_derived_stats
end
```

## Test plan
- [ ] マッチ#366 を開き、りーん（デルタプラス）の `exburst_deaths` が1になっていることを確認
- [ ] 統計ページ > パフォーマンスタブ でEXバースト中被撃墜数が非ゼロの値を示すことを確認

Closes #110