### PR TITLE
feat: 対戦履歴一覧に詳細条件フィルター機能を追加

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -31,6 +31,70 @@ class MatchesController < ApplicationController
       ).distinct if streaming_user_ids.any?
     end
 
+    # 統計条件フィルター共通: 対象プレイヤー
+    stat_player_id = params[:stat_player_id].present? ? params[:stat_player_id].to_i : nil
+
+    # フィルター: OL条件（排他選択）
+    ol_filter = params[:ol_filter].presence_in(%w[ol_unused_win ol_unused_loss])
+    case ol_filter
+    when "ol_unused_win"
+      # 勝利チームがOL未発動だった試合
+      scope = @matches.where(
+        "(winning_team = 1 AND team1_ex_overlimit_before_end = TRUE) OR " \
+        "(winning_team = 2 AND team2_ex_overlimit_before_end = TRUE)"
+      )
+      if stat_player_id
+        scope = scope.joins(:match_players).where(
+          "match_players.user_id = ? AND match_players.team_number = matches.winning_team",
+          stat_player_id
+        )
+        @matches = scope.distinct
+      else
+        @matches = scope
+      end
+    when "ol_unused_loss"
+      # 敗北チームがOL未発動だった試合
+      scope = @matches.where(
+        "(winning_team = 1 AND team2_ex_overlimit_before_end = TRUE) OR " \
+        "(winning_team = 2 AND team1_ex_overlimit_before_end = TRUE)"
+      )
+      if stat_player_id
+        scope = scope.joins(:match_players).where(
+          "match_players.user_id = ? AND match_players.team_number != matches.winning_team",
+          stat_player_id
+        )
+        @matches = scope.distinct
+      else
+        @matches = scope
+      end
+    end
+
+    # フィルター: EX条件（チェックボックス）
+    stat_filters = Array(params[:stat_filters]).reject(&:blank?)
+    if stat_filters.include?("ex_leftover_loss")
+      scope = @matches.joins(:match_players).where(
+        "match_players.team_number != matches.winning_team AND " \
+        "(match_players.last_death_ex_available = TRUE OR match_players.survive_loss_ex_available = TRUE)"
+      )
+      scope = scope.where(match_players: { user_id: stat_player_id }) if stat_player_id
+      @matches = scope.distinct
+    end
+
+    # フィルター: ダメージ閾値（以上/以下切り替え対応）
+    if params[:damage_dealt_val].present? && (dealt_val = params[:damage_dealt_val].to_i) > 0
+      dealt_op = params[:damage_dealt_dir] == "lte" ? "<=" : ">="
+      scope = @matches.joins(:match_players).where("match_players.damage_dealt #{dealt_op} ?", dealt_val)
+      scope = scope.where(match_players: { user_id: stat_player_id }) if stat_player_id
+      @matches = scope.distinct
+    end
+
+    if params[:damage_received_val].present? && (received_val = params[:damage_received_val].to_i) > 0
+      received_op = params[:damage_received_dir] == "lte" ? "<=" : ">="
+      scope = @matches.joins(:match_players).where("match_players.damage_received #{received_op} ?", received_val)
+      scope = scope.where(match_players: { user_id: stat_player_id }) if stat_player_id
+      @matches = scope.distinct
+    end
+
     @per_page = [ 10, 20, 50 ].include?(params[:per].to_i) ? params[:per].to_i : 20
     @matches = @matches.page(params[:page]).per(@per_page)
     @emojis = MasterEmoji.active.ordered
@@ -44,6 +108,13 @@ class MatchesController < ApplicationController
     @filter_events = params[:events].present? ? params[:events].reject(&:blank?).map(&:to_i) : []
     @filter_users = params[:users].present? ? params[:users].reject(&:blank?).map(&:to_i) : []
     @filter_streaming_users = params[:streaming_users].present? ? params[:streaming_users].reject(&:blank?).map(&:to_i) : []
+    @filter_stat_player_id = stat_player_id
+    @filter_ol_filter = ol_filter
+    @filter_stat_filters = stat_filters
+    @filter_damage_dealt_val = params[:damage_dealt_val].presence
+    @filter_damage_dealt_dir = params[:damage_dealt_dir].presence_in(%w[gte lte]) || "gte"
+    @filter_damage_received_val = params[:damage_received_val].presence
+    @filter_damage_received_dir = params[:damage_received_dir].presence_in(%w[gte lte]) || "gte"
   end
 
   def show

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -56,6 +56,126 @@
         </div>
       </div>
 
+      <!-- 詳細条件（折りたたみ） -->
+      <% stat_section_active = @filter_ol_filter.present? || @filter_stat_filters.any? || @filter_stat_player_id.present? || @filter_damage_dealt_val.present? || @filter_damage_received_val.present? %>
+      <details class="group border-t border-gray-100 pt-3" <%= 'open' if stat_section_active %>>
+        <summary class="stat-summary cursor-pointer w-full flex items-center justify-between rounded-lg px-4 py-2.5 text-sm font-medium transition-colors mb-1
+                        <%= stat_section_active ? 'bg-indigo-50 text-indigo-700 hover:bg-indigo-100' : 'bg-gray-100 text-gray-600 hover:bg-gray-200' %>">
+          <span class="flex items-center gap-2">
+            <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L13 13.414V19a1 1 0 01-.553.894l-4 2A1 1 0 017 21v-7.586L3.293 6.707A1 1 0 013 6V4z"/>
+            </svg>
+            詳細条件
+            <% if stat_section_active %>
+              <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-semibold bg-indigo-600 text-white">設定中</span>
+            <% end %>
+          </span>
+          <svg class="h-4 w-4 shrink-0 transition-transform duration-200 group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+          </svg>
+        </summary>
+
+        <!-- 対象プレイヤー -->
+        <div class="mb-4">
+          <label class="block text-xs font-medium text-gray-500 mb-1.5">対象プレイヤー</label>
+          <div class="relative inline-block w-full sm:w-56">
+            <select name="stat_player_id"
+                    class="w-full appearance-none rounded-lg border border-gray-300 bg-white pl-3 pr-8 py-2 text-sm text-gray-800 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+              <option value="">指定なし</option>
+              <% @all_users.each do |user| %>
+                <option value="<%= user.id %>" <%= 'selected' if @filter_stat_player_id == user.id %>>
+                  <%= user.nickname %>
+                </option>
+              <% end %>
+            </select>
+            <div class="pointer-events-none absolute inset-y-0 right-2 flex items-center text-gray-400">
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        <!-- OL条件（セグメントコントロール） -->
+        <div class="mb-4">
+          <label class="block text-xs font-medium text-gray-500 mb-1.5">OL条件</label>
+          <div class="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-0.5 gap-px">
+            <% [["", "指定なし"], ["ol_unused_win", "OL未発動勝利"], ["ol_unused_loss", "OL未発動敗北"]].each do |value, label| %>
+              <label class="cursor-pointer">
+                <input type="radio" name="ol_filter" value="<%= value %>"
+                       <%= 'checked' if @filter_ol_filter.to_s == value %>
+                       class="peer sr-only">
+                <span class="block px-3 py-1.5 rounded-md text-sm font-medium transition-all whitespace-nowrap
+                             text-gray-500 hover:text-gray-700
+                             peer-checked:bg-white peer-checked:text-indigo-700 peer-checked:shadow-sm">
+                  <%= label %>
+                </span>
+              </label>
+            <% end %>
+          </div>
+        </div>
+
+        <!-- EX条件（ピルトグル） -->
+        <div class="mb-4">
+          <label class="block text-xs font-medium text-gray-500 mb-1.5">EX条件</label>
+          <div class="flex flex-wrap gap-2">
+            <label class="cursor-pointer select-none">
+              <input type="checkbox" name="stat_filters[]" value="ex_leftover_loss"
+                     <%= 'checked' if @filter_stat_filters.include?('ex_leftover_loss') %>
+                     class="peer sr-only">
+              <span class="inline-flex items-center px-3 py-1.5 rounded-full border text-sm font-medium transition-all
+                           border-gray-200 text-gray-400 bg-gray-50 hover:border-gray-300 hover:text-gray-600 hover:bg-gray-100
+                           peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:border-indigo-600 peer-checked:hover:bg-indigo-700">
+                EXバースト残し敗北
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <!-- ダメージ閾値 -->
+        <div>
+          <label class="block text-xs font-medium text-gray-500 mb-1.5">ダメージ</label>
+          <div class="flex flex-wrap gap-3">
+            <div class="flex items-center gap-2 bg-gray-50 rounded-lg border border-gray-200 px-3 py-2">
+              <span class="text-xs font-medium text-gray-500 whitespace-nowrap">与ダメ</span>
+              <input type="number" name="damage_dealt_val" min="0" placeholder="—"
+                     value="<%= @filter_damage_dealt_val %>"
+                     class="w-20 bg-transparent border-0 text-sm text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-0 p-0">
+              <div class="inline-flex rounded border border-gray-200 bg-white text-xs font-medium overflow-hidden">
+                <label class="cursor-pointer">
+                  <input type="radio" name="damage_dealt_dir" value="gte"
+                         <%= 'checked' if @filter_damage_dealt_dir != 'lte' %> class="peer sr-only">
+                  <span class="block px-2 py-1 transition-colors text-gray-500 peer-checked:bg-indigo-600 peer-checked:text-white">以上</span>
+                </label>
+                <label class="cursor-pointer border-l border-gray-200">
+                  <input type="radio" name="damage_dealt_dir" value="lte"
+                         <%= 'checked' if @filter_damage_dealt_dir == 'lte' %> class="peer sr-only">
+                  <span class="block px-2 py-1 transition-colors text-gray-500 peer-checked:bg-indigo-600 peer-checked:text-white">以下</span>
+                </label>
+              </div>
+            </div>
+            <div class="flex items-center gap-2 bg-gray-50 rounded-lg border border-gray-200 px-3 py-2">
+              <span class="text-xs font-medium text-gray-500 whitespace-nowrap">被ダメ</span>
+              <input type="number" name="damage_received_val" min="0" placeholder="—"
+                     value="<%= @filter_damage_received_val %>"
+                     class="w-20 bg-transparent border-0 text-sm text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-0 p-0">
+              <div class="inline-flex rounded border border-gray-200 bg-white text-xs font-medium overflow-hidden">
+                <label class="cursor-pointer">
+                  <input type="radio" name="damage_received_dir" value="gte"
+                         <%= 'checked' if @filter_damage_received_dir != 'lte' %> class="peer sr-only">
+                  <span class="block px-2 py-1 transition-colors text-gray-500 peer-checked:bg-indigo-600 peer-checked:text-white">以上</span>
+                </label>
+                <label class="cursor-pointer border-l border-gray-200">
+                  <input type="radio" name="damage_received_dir" value="lte"
+                         <%= 'checked' if @filter_damage_received_dir == 'lte' %> class="peer sr-only">
+                  <span class="block px-2 py-1 transition-colors text-gray-500 peer-checked:bg-indigo-600 peer-checked:text-white">以下</span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </details>
+
       <div class="flex space-x-3">
         <%= form.submit "適用", class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
         <%= link_to "クリア", matches_path, class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded" %>
@@ -92,13 +212,13 @@
               <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
             <% else %>
               <%= link_to label,
-                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]),
+                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], streaming_users: params[:streaming_users], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]),
                     class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
             <% end %>
           <% end %>
         </div>
       </div>
-      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
+      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -185,7 +305,7 @@
     <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
       <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
         <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
-        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users]) } %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
       </div>
     <% end %>
   </div>
@@ -329,4 +449,7 @@
       align-items: center;
     }
   }
+  /* summary デフォルトマーカー非表示 */
+  .stat-summary { list-style: none; }
+  .stat-summary::-webkit-details-marker { display: none; }
 </style>


### PR DESCRIPTION
## Summary
- 対戦履歴一覧のフィルターに「詳細条件」セクションを追加
- **OL条件**（指定なし／OL未発動勝利／OL未発動敗北）をセグメントコントロールで排他選択
- **EXバースト残し敗北**をピルトグルで選択
- **与ダメージ・被ダメージ**の閾値指定（以上/以下の切り替え対応）
- **対象プレイヤー**を指定して全統計条件を特定プレイヤーに絞り込み
- 詳細条件セクションは折りたたみ式。フィルター適用中はボタンが「設定中」バッジ付きのインディゴ配色に変化

## Test plan
- [ ] OL未発動勝利フィルターを適用し、勝利チームの `teamN_ex_overlimit_before_end = true` の試合のみ表示されることを確認
- [ ] OL未発動敗北フィルターを適用し、敗北チームの `teamN_ex_overlimit_before_end = true` の試合のみ表示されることを確認
- [ ] OL条件と対象プレイヤーを組み合わせ、指定プレイヤーが勝利/敗北チームにいる試合のみ表示されることを確認
- [ ] EXバースト残し敗北フィルターを適用し、敗北チームに `last_death_ex_available / survive_loss_ex_available = true` のプレイヤーがいる試合のみ表示されることを確認
- [ ] 与ダメ「3000以上」で適用し、いずれかのプレイヤーの `damage_dealt >= 3000` の試合のみ表示されることを確認
- [ ] 与ダメ「以下」に切り替えて適用し、`<=` で絞り込まれることを確認
- [ ] 詳細条件を閉じた状態でフィルター適用し、ページ再読込後も「設定中」バッジが表示されセクションが自動展開されることを確認
- [ ] ソート切り替え・ページネーションで詳細条件のパラメーターが引き継がれることを確認

関連Issue:
#108