### PR TITLE
feat: 対戦履歴フィルターにAND/OR切り替え機能を追加

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -20,15 +20,35 @@ class MatchesController < ApplicationController
     # フィルター: 参加ユーザー（複数選択対応）
     if params[:users].present?
       user_ids = params[:users].reject(&:blank?).map(&:to_i)
-      @matches = @matches.joins(:match_players).where(match_players: { user_id: user_ids }).distinct if user_ids.any?
+      if user_ids.any?
+        if params[:users_mode] == "and"
+          user_ids.each do |uid|
+            @matches = @matches.where(
+              "EXISTS (SELECT 1 FROM match_players mp WHERE mp.match_id = matches.id AND mp.user_id = ?)", uid
+            )
+          end
+        else
+          @matches = @matches.joins(:match_players).where(match_players: { user_id: user_ids }).distinct
+        end
+      end
     end
 
     # フィルター: 配信台ユーザー（複数選択対応）
     if params[:streaming_users].present?
       streaming_user_ids = params[:streaming_users].reject(&:blank?).map(&:to_i)
-      @matches = @matches.joins(:match_players).where(
-        match_players: { user_id: streaming_user_ids, team_number: 1, position: 1 }
-      ).distinct if streaming_user_ids.any?
+      if streaming_user_ids.any?
+        if params[:streaming_users_mode] == "and"
+          streaming_user_ids.each do |uid|
+            @matches = @matches.where(
+              "EXISTS (SELECT 1 FROM match_players mp WHERE mp.match_id = matches.id AND mp.user_id = ? AND mp.team_number = 1 AND mp.position = 1)", uid
+            )
+          end
+        else
+          @matches = @matches.joins(:match_players).where(
+            match_players: { user_id: streaming_user_ids, team_number: 1, position: 1 }
+          ).distinct
+        end
+      end
     end
 
     # 統計条件フィルター共通: 対象プレイヤー
@@ -107,7 +127,9 @@ class MatchesController < ApplicationController
     # 選択されたフィルター値
     @filter_events = params[:events].present? ? params[:events].reject(&:blank?).map(&:to_i) : []
     @filter_users = params[:users].present? ? params[:users].reject(&:blank?).map(&:to_i) : []
+    @filter_users_mode = params[:users_mode].presence_in(%w[or and]) || "or"
     @filter_streaming_users = params[:streaming_users].present? ? params[:streaming_users].reject(&:blank?).map(&:to_i) : []
+    @filter_streaming_users_mode = params[:streaming_users_mode].presence_in(%w[or and]) || "or"
     @filter_stat_player_id = stat_player_id
     @filter_ol_filter = ol_filter
     @filter_stat_filters = stat_filters

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -33,7 +33,19 @@
 
         <!-- 参加ユーザー選択 -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">参加ユーザー</label>
+          <div class="flex items-center justify-between mb-2">
+            <label class="block text-sm font-medium text-gray-700">参加ユーザー</label>
+            <div class="inline-flex rounded border border-gray-200 bg-white text-xs font-medium overflow-hidden">
+              <label class="cursor-pointer">
+                <input type="radio" name="users_mode" value="or" <%= 'checked' if @filter_users_mode != 'and' %> class="peer sr-only">
+                <span class="block px-2 py-1 transition-colors text-gray-500 peer-checked:bg-indigo-600 peer-checked:text-white">OR</span>
+              </label>
+              <label class="cursor-pointer border-l border-gray-200">
+                <input type="radio" name="users_mode" value="and" <%= 'checked' if @filter_users_mode == 'and' %> class="peer sr-only">
+                <span class="block px-2 py-1 transition-colors text-gray-500 peer-checked:bg-indigo-600 peer-checked:text-white">AND</span>
+              </label>
+            </div>
+          </div>
           <select name="users[]" id="user-filter" multiple class="w-full">
             <% @all_users.each do |user| %>
               <option value="<%= user.id %>" <%= 'selected' if @filter_users.include?(user.id) %>>
@@ -45,7 +57,19 @@
 
         <!-- 配信台ユーザー選択 -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">配信台ユーザー</label>
+          <div class="flex items-center justify-between mb-2">
+            <label class="block text-sm font-medium text-gray-700">配信台ユーザー</label>
+            <div class="inline-flex rounded border border-gray-200 bg-white text-xs font-medium overflow-hidden">
+              <label class="cursor-pointer">
+                <input type="radio" name="streaming_users_mode" value="or" <%= 'checked' if @filter_streaming_users_mode != 'and' %> class="peer sr-only">
+                <span class="block px-2 py-1 transition-colors text-gray-500 peer-checked:bg-indigo-600 peer-checked:text-white">OR</span>
+              </label>
+              <label class="cursor-pointer border-l border-gray-200">
+                <input type="radio" name="streaming_users_mode" value="and" <%= 'checked' if @filter_streaming_users_mode == 'and' %> class="peer sr-only">
+                <span class="block px-2 py-1 transition-colors text-gray-500 peer-checked:bg-indigo-600 peer-checked:text-white">AND</span>
+              </label>
+            </div>
+          </div>
           <select name="streaming_users[]" id="streaming-user-filter" multiple class="w-full">
             <% @all_users.each do |user| %>
               <option value="<%= user.id %>" <%= 'selected' if @filter_streaming_users.include?(user.id) %>>
@@ -212,13 +236,13 @@
               <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
             <% else %>
               <%= link_to label,
-                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], streaming_users: params[:streaming_users], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]),
+                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]),
                     class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
             <% end %>
           <% end %>
         </div>
       </div>
-      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
+      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -305,7 +329,7 @@
     <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
       <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
         <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
-        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], streaming_users: params[:streaming_users], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
       </div>
     <% end %>
   </div>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -21,7 +21,12 @@
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         <!-- イベント選択 -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">イベント</label>
+          <div class="flex items-center justify-between mb-2">
+            <label class="block text-sm font-medium text-gray-700">イベント</label>
+            <span class="inline-flex rounded border border-gray-200 bg-white text-xs font-medium overflow-hidden">
+              <span class="block px-2 py-1 bg-indigo-600 text-white">OR</span>
+            </span>
+          </div>
           <select name="events[]" id="event-filter" multiple class="w-full">
             <% @all_events.each do |event| %>
               <option value="<%= event.id %>" <%= 'selected' if @filter_events.include?(event.id) %>>


### PR DESCRIPTION
## Summary
- 参加ユーザーフィルターに AND / OR モード切り替えトグルを追加
- 配信台ユーザーフィルターにも同様の AND / OR トグルを追加
- AND モードは EXISTS サブクエリで実装（選択ユーザー数分の WHERE を AND 結合）
- ソート切り替え・表示件数切り替え時も `users_mode` / `streaming_users_mode` を引き継ぎ

## Test plan
- [ ] 参加ユーザーを2人選択 → OR: いずれかが参加している試合が表示される
- [ ] 参加ユーザーを2人選択 → AND: 両者が同じ試合に参加しているものだけ表示される
- [ ] 配信台ユーザーを2人選択 → OR / AND 各モードで正しく絞り込まれる
- [ ] ソート切り替え・件数切り替え後もAND/ORモードが保持される
- [ ] ユーザー未選択時にトグルが表示されることを確認（挙動に影響なし）

Closes #112