### PR TITLE
feat: お知らせ閲覧ユーザー確認機能を管理画面に追加

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -1,9 +1,13 @@
 module Admin
   class AnnouncementsController < BaseController
-    before_action :set_announcement, only: [ :edit, :update, :destroy ]
+    before_action :set_announcement, only: [ :show, :edit, :update, :destroy ]
 
     def index
       @announcements = Announcement.order(published_at: :desc)
+    end
+
+    def show
+      @readers = @announcement.read_by_users.order(:nickname)
     end
 
     def new

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -34,7 +34,9 @@
                 <%= announcement.published_at.strftime('%Y/%m/%d %H:%M') %> 〜
                 <%= announcement.expires_at ? announcement.expires_at.strftime('%Y/%m/%d %H:%M') : "期限なし" %>
               </td>
-              <td class="px-6 py-4 text-sm text-gray-500"><%= announcement.user_announcement_reads.count %>人</td>
+              <td class="px-6 py-4 text-sm text-gray-500">
+                <%= link_to "#{announcement.user_announcement_reads.count}人", admin_announcement_path(announcement), class: "text-indigo-600 hover:text-indigo-900 hover:underline" %>
+              </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                 <%= link_to "編集", edit_admin_announcement_path(announcement), class: "text-blue-600 hover:text-blue-900 mr-3" %>
                 <%= button_to "削除", admin_announcement_path(announcement), method: :delete, data: { turbo_confirm: "お知らせ「#{announcement.title}」を削除しますか？" }, class: "text-red-600 hover:text-red-900" %>

--- a/app/views/admin/announcements/show.html.erb
+++ b/app/views/admin/announcements/show.html.erb
@@ -1,0 +1,27 @@
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+    <div>
+      <h1 class="text-2xl sm:text-3xl font-bold text-gray-900"><%= @announcement.title %></h1>
+      <p class="mt-2 text-sm text-gray-600">閲覧ユーザー一覧</p>
+    </div>
+    <%= link_to "一覧に戻る", admin_announcements_path, class: "text-sm text-indigo-600 hover:text-indigo-500" %>
+  </div>
+
+  <div class="bg-white shadow sm:rounded-lg">
+    <div class="px-6 py-4 border-b border-gray-200">
+      <p class="text-sm text-gray-600">既読: <span class="font-semibold text-gray-900"><%= @readers.count %>人</span></p>
+    </div>
+
+    <% if @readers.any? %>
+      <ul class="divide-y divide-gray-200">
+        <% @readers.each do |user| %>
+          <li class="px-6 py-3 text-sm text-gray-800"><%= user.nickname %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <div class="px-6 py-8 text-center text-sm text-gray-500">
+        まだ誰も閲覧していません
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,7 +96,7 @@ Rails.application.routes.draw do
 
   # Admin
   namespace :admin do
-    resources :announcements, except: [ :show ]
+    resources :announcements
     resources :users, except: [ :show ] do
       member do
         post :switch_view


### PR DESCRIPTION
## Summary
- 管理画面のお知らせ一覧で、既読数をクリックすると閲覧ユーザー一覧ページへ遷移するように変更
- `Admin::AnnouncementsController` に `show` アクションを追加
- お知らせ詳細ページ（`show.html.erb`）を新規作成し、閲覧ユーザー名を一覧表示

## Test plan
- [ ] 管理画面のお知らせ一覧で既読数がリンクになっていることを確認
- [ ] リンクをクリックするとお知らせ詳細ページに遷移することを確認
- [ ] 既読ユーザーがいる場合にニックネーム一覧が表示されることを確認
- [ ] 既読ユーザーがいない場合に「まだ誰も閲覧していません」と表示されることを確認

Closes #116