### PR TITLE
feat: 統計のプレイ分析テーブルに勝利時・敗北時のコミュニティ平均・分布列を追加

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -646,60 +646,80 @@ class StatisticsController < ApplicationController
       .where(has_stats_sql).where(users: { is_guest: false }).to_a
     if all_stats_mps.any?
       by_user = all_stats_mps.group_by(&:user_id)
-      user_perf_list = by_user.map do |_uid, mps|
-        n  = mps.size
-        sf = ->(f) { mps.sum { |mp| mp.send(f).to_f } }
-        total_ex   = mps.sum { |mp| mp.exburst_count.to_i }
-        total_ex_d = mps.sum { |mp| mp.exburst_deaths.to_i }
-        ol_count   = mps.count { |mp|
-          flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
-          flag == false
-        }
-        loss_mps   = mps.select { |mp| mp.match.winning_team && mp.match.winning_team != mp.team_number }
-        ol_loss_count = loss_mps.count { |mp|
+
+      build_perf = lambda do |subset|
+        m = subset.size
+        next nil if m == 0
+        sf = ->(f) { subset.sum { |mp| mp.send(f).to_f } }
+        total_ex   = subset.sum { |mp| mp.exburst_count.to_i }
+        total_ex_d = subset.sum { |mp| mp.exburst_deaths.to_i }
+        ol_count = subset.count { |mp|
           flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
           flag == false
         }
         {
-          score:              (sf.call(:score)          / n).round(1),
-          kills:              (sf.call(:kills)           / n).round(2),
-          deaths:             (sf.call(:deaths)          / n).round(2),
-          damage_dealt:       (sf.call(:damage_dealt)    / n).round(0),
-          damage_received:    (sf.call(:damage_received) / n).round(0),
-          exburst_damage:     (sf.call(:exburst_damage)  / n).round(0),
-          exburst_count:      (sf.call(:exburst_count)   / n).round(2),
-          exburst_deaths:     (sf.call(:exburst_deaths)  / n).round(2),
+          score:              (sf.call(:score)          / m).round(1),
+          kills:              (sf.call(:kills)           / m).round(2),
+          deaths:             (sf.call(:deaths)          / m).round(2),
+          damage_dealt:       (sf.call(:damage_dealt)    / m).round(0),
+          damage_received:    (sf.call(:damage_received) / m).round(0),
+          exburst_damage:     (sf.call(:exburst_damage)  / m).round(0),
+          exburst_count:      (sf.call(:exburst_count)   / m).round(2),
+          exburst_deaths:     (sf.call(:exburst_deaths)  / m).round(2),
           exburst_death_rate: total_ex > 0 ? (total_ex_d * 100.0 / total_ex).round(1) : nil,
-          ol_rate:            (ol_count * 100.0 / n).round(1),
-          ol_rate_losses:     loss_mps.any? ? (ol_loss_count * 100.0 / loss_mps.size).round(1) : nil
+          ol_rate:            (ol_count * 100.0 / m).round(1)
         }
       end
-      nu = user_perf_list.size
-      valid_dr = user_perf_list.map { |u| u[:exburst_death_rate] }.compact
-      @community_avg = {
-        score:              (user_perf_list.sum { |u| u[:score] }          / nu).round(1),
-        kills:              (user_perf_list.sum { |u| u[:kills] }           / nu).round(2),
-        deaths:             (user_perf_list.sum { |u| u[:deaths] }          / nu).round(2),
-        damage_dealt:       (user_perf_list.sum { |u| u[:damage_dealt] }    / nu).round(0),
-        damage_received:    (user_perf_list.sum { |u| u[:damage_received] } / nu).round(0),
-        exburst_damage:     (user_perf_list.sum { |u| u[:exburst_damage] }  / nu).round(0),
-        exburst_count:      (user_perf_list.sum { |u| u[:exburst_count] }   / nu).round(2),
-        exburst_deaths:     (user_perf_list.sum { |u| u[:exburst_deaths] }  / nu).round(2),
-        exburst_death_rate: valid_dr.any? ? (valid_dr.sum / valid_dr.size).round(1) : nil,
-        ol_rate:            (user_perf_list.sum { |u| u[:ol_rate] }         / nu).round(1)
-      }
-      stat_keys = %i[score kills deaths damage_dealt damage_received exburst_damage exburst_count exburst_deaths ol_rate]
-      @community_min = stat_keys.to_h { |k| [ k, user_perf_list.map { |u| u[k] }.compact.min ] }
-      @community_max = stat_keys.to_h { |k| [ k, user_perf_list.map { |u| u[k] }.compact.max ] }
-      if valid_dr.any?
-        @community_min[:exburst_death_rate] = valid_dr.min
-        @community_max[:exburst_death_rate] = valid_dr.max
+
+      build_community = lambda do |list|
+        next nil unless list.any?
+        n = list.size
+        valid_dr = list.map { |u| u[:exburst_death_rate] }.compact
+        avg = {
+          score:              (list.sum { |u| u[:score] }          / n).round(1),
+          kills:              (list.sum { |u| u[:kills] }           / n).round(2),
+          deaths:             (list.sum { |u| u[:deaths] }          / n).round(2),
+          damage_dealt:       (list.sum { |u| u[:damage_dealt] }    / n).round(0),
+          damage_received:    (list.sum { |u| u[:damage_received] } / n).round(0),
+          exburst_damage:     (list.sum { |u| u[:exburst_damage] }  / n).round(0),
+          exburst_count:      (list.sum { |u| u[:exburst_count] }   / n).round(2),
+          exburst_deaths:     (list.sum { |u| u[:exburst_deaths] }  / n).round(2),
+          exburst_death_rate: valid_dr.any? ? (valid_dr.sum / valid_dr.size).round(1) : nil,
+          ol_rate:            (list.sum { |u| u[:ol_rate] }         / n).round(1)
+        }
+        stat_keys = %i[score kills deaths damage_dealt damage_received exburst_damage exburst_count exburst_deaths ol_rate]
+        min_h = stat_keys.to_h { |k| [k, list.map { |u| u[k] }.compact.min] }
+        max_h = stat_keys.to_h { |k| [k, list.map { |u| u[k] }.compact.max] }
+        if valid_dr.any?
+          min_h[:exburst_death_rate] = valid_dr.min
+          max_h[:exburst_death_rate] = valid_dr.max
+        end
+        [avg, min_h, max_h]
       end
-      valid_ol_losses = user_perf_list.map { |u| u[:ol_rate_losses] }.compact
-      if valid_ol_losses.any?
-        @community_avg[:ol_rate_losses]  = (valid_ol_losses.sum / valid_ol_losses.size).round(1)
-        @community_min[:ol_rate_losses]  = valid_ol_losses.min
-        @community_max[:ol_rate_losses]  = valid_ol_losses.max
+
+      user_perf_list   = []
+      user_wins_list   = []
+      user_losses_list = []
+      by_user.each do |_uid, mps|
+        overall  = build_perf.call(mps)
+        win_mps  = mps.select { |mp| mp.match.winning_team == mp.team_number }
+        loss_mps = mps.select { |mp| mp.match.winning_team && mp.match.winning_team != mp.team_number }
+        user_perf_list   << overall                    if overall
+        user_wins_list   << build_perf.call(win_mps)   if win_mps.any?
+        user_losses_list << build_perf.call(loss_mps)  if loss_mps.any?
+      end
+
+      if user_perf_list.any?
+        result = build_community.call(user_perf_list)
+        @community_avg, @community_min, @community_max = result if result
+      end
+      if user_wins_list.any?
+        result = build_community.call(user_wins_list)
+        @community_wins_avg, @community_wins_min, @community_wins_max = result if result
+      end
+      if user_losses_list.any?
+        result = build_community.call(user_losses_list)
+        @community_losses_avg, @community_losses_min, @community_losses_max = result if result
       end
     end
   end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -688,13 +688,13 @@ class StatisticsController < ApplicationController
           ol_rate:            (list.sum { |u| u[:ol_rate] }         / n).round(1)
         }
         stat_keys = %i[score kills deaths damage_dealt damage_received exburst_damage exburst_count exburst_deaths ol_rate]
-        min_h = stat_keys.to_h { |k| [k, list.map { |u| u[k] }.compact.min] }
-        max_h = stat_keys.to_h { |k| [k, list.map { |u| u[k] }.compact.max] }
+        min_h = stat_keys.to_h { |k| [ k, list.map { |u| u[k] }.compact.min ] }
+        max_h = stat_keys.to_h { |k| [ k, list.map { |u| u[k] }.compact.max ] }
         if valid_dr.any?
           min_h[:exburst_death_rate] = valid_dr.min
           max_h[:exburst_death_rate] = valid_dr.max
         end
-        [avg, min_h, max_h]
+        [ avg, min_h, max_h ]
       end
 
       user_perf_list   = []

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1204,20 +1204,37 @@
           <div class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200">
               <thead class="bg-gray-50">
+                <tr class="border-b border-gray-200">
+                  <th rowspan="2" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider align-middle">項目</th>
+                  <th colspan="2" class="px-4 py-2 text-center text-sm font-semibold text-indigo-700 border-l-2 border-indigo-300 bg-indigo-50">
+                    <span class="inline-flex items-center gap-1.5 justify-center">
+                      <span class="w-2 h-2 rounded-full bg-indigo-400 shrink-0"></span>全体
+                    </span>
+                  </th>
+                  <th colspan="2" class="px-4 py-2 text-center text-sm font-semibold text-green-700 border-l-2 border-green-300 bg-green-50">
+                    <span class="inline-flex items-center gap-1.5 justify-center">
+                      <span class="w-2 h-2 rounded-full bg-green-400 shrink-0"></span>勝利時
+                    </span>
+                  </th>
+                  <th colspan="2" class="px-4 py-2 text-center text-sm font-semibold text-red-700 border-l-2 border-red-300 bg-red-50">
+                    <span class="inline-flex items-center gap-1.5 justify-center">
+                      <span class="w-2 h-2 rounded-full bg-red-400 shrink-0"></span>敗北時
+                    </span>
+                  </th>
+                </tr>
                 <tr>
-                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">項目</th>
-                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                    全体<br><span class="normal-case font-normal"><%= @stats_total %>試合</span>
+                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-500 whitespace-nowrap border-l-2 border-indigo-300">
+                    値<br><span class="font-normal text-gray-400"><%= @stats_total %>試合</span>
                   </th>
-                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                    勝利時<br><span class="normal-case font-normal"><%= @stats_wins %>試合</span>
+                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-400 whitespace-nowrap">コミュニティ平均・分布</th>
+                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-500 whitespace-nowrap border-l-2 border-green-300">
+                    値<br><span class="font-normal text-gray-400"><%= @stats_wins %>試合</span>
                   </th>
-                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                    敗北時<br><span class="normal-case font-normal"><%= @stats_losses %>試合</span>
+                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-400 whitespace-nowrap">コミュニティ平均・分布</th>
+                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-500 whitespace-nowrap border-l-2 border-red-300">
+                    値<br><span class="font-normal text-gray-400"><%= @stats_losses %>試合</span>
                   </th>
-                  <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                    コミュニティ平均・分布
-                  </th>
+                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-400 whitespace-nowrap">コミュニティ平均・分布</th>
                 </tr>
               </thead>
               <tbody class="bg-white divide-y divide-gray-100">
@@ -1250,69 +1267,74 @@
                     {
                       label: "EXオーバーリミット",
                       rows: [
-                        { label: "EXオーバーリミット発動率", key: :ol_rate, suffix: "%", higher_is_better: true, community_key: :ol_rate_losses, community_perf: :losses, community_note: "※敗北時のみ" },
+                        { label: "EXオーバーリミット発動率", key: :ol_rate, suffix: "%", higher_is_better: true },
                       ]
                     },
                   ]
                 %>
+                <%
+                  perf_columns = [
+                    { perf: @performance_overall, color: "text-indigo-600", border: "border-l-2 border-indigo-300",
+                      c_avg: @community_avg,        c_min: @community_min,        c_max: @community_max },
+                    { perf: @performance_wins,    color: "text-green-600",  border: "border-l-2 border-green-300",
+                      c_avg: @community_wins_avg,   c_min: @community_wins_min,   c_max: @community_wins_max },
+                    { perf: @performance_losses,  color: "text-red-600",    border: "border-l-2 border-red-300",
+                      c_avg: @community_losses_avg, c_min: @community_losses_min, c_max: @community_losses_max },
+                  ]
+                %>
                 <% perf_groups.each do |group| %>
                   <tr class="bg-gray-50">
-                    <td colspan="5" class="px-6 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider"><%= group[:label] %></td>
+                    <td colspan="7" class="px-6 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider"><%= group[:label] %></td>
                   </tr>
                   <% group[:rows].each do |row| %>
                     <tr class="hover:bg-gray-50">
                       <td class="px-6 py-4 text-sm text-gray-700 pl-8"><%= row[:label] %></td>
-                      <% [[@performance_overall, "text-indigo-600"], [@performance_wins, "text-green-600"], [@performance_losses, "text-red-600"]].each do |perf, color| %>
-                        <td class="px-6 py-4 text-center text-sm font-semibold <%= color %>">
-                          <% if perf.nil? %>
+                      <% perf_columns.each do |col| %>
+                        <td class="px-6 py-4 text-center text-sm font-semibold <%= col[:color] %> <%= col[:border] %>">
+                          <% if col[:perf].nil? %>
                             <span class="text-gray-300 font-normal">-</span>
-                          <% elsif row[:na_if_nil] && perf[row[:key]].nil? %>
+                          <% elsif row[:na_if_nil] && col[:perf][row[:key]].nil? %>
                             <span class="text-gray-400 text-xs font-normal">N/A</span>
                           <% else %>
-                            <%= "#{perf[row[:key]]}#{row[:suffix]}" %>
+                            <%= "#{col[:perf][row[:key]]}#{row[:suffix]}" %>
+                          <% end %>
+                        </td>
+                        <td class="px-6 py-4 text-center">
+                          <% if col[:c_avg].nil? %>
+                            <span class="text-gray-300">-</span>
+                          <% else %>
+                            <%
+                              avg_val  = col[:c_avg][row[:key]]
+                              min_val  = col[:c_min]&.[](row[:key])
+                              max_val  = col[:c_max]&.[](row[:key])
+                              user_val = col[:perf]&.[](row[:key])
+                            %>
+                            <% if row[:na_if_nil] && avg_val.nil? %>
+                              <span class="text-gray-400 text-xs">N/A</span>
+                            <% elsif avg_val.nil? %>
+                              <span class="text-gray-300">-</span>
+                            <% else %>
+                              <div class="text-sm text-gray-600 font-medium"><%= "#{avg_val}#{row[:suffix]}" %></div>
+                              <% if min_val && max_val && user_val && min_val != max_val %>
+                                <%
+                                  range    = (max_val - min_val).to_f
+                                  user_pct = ((user_val.to_f - min_val) / range * 100).clamp(0, 100).round(1)
+                                  avg_pct  = ((avg_val.to_f  - min_val) / range * 100).clamp(0, 100).round(1)
+                                  good     = row[:higher_is_better] ? user_val.to_f >= avg_val.to_f : user_val.to_f <= avg_val.to_f
+                                %>
+                                <div class="relative h-1.5 bg-gray-200 rounded-full mt-2 max-w-[100px] mx-auto">
+                                  <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                                  <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                                </div>
+                                <div class="flex justify-between text-[10px] text-gray-400 mt-1 max-w-[100px] mx-auto">
+                                  <span><%= min_val %><%= row[:suffix] %></span>
+                                  <span><%= max_val %><%= row[:suffix] %></span>
+                                </div>
+                              <% end %>
+                            <% end %>
                           <% end %>
                         </td>
                       <% end %>
-                      <td class="px-6 py-4 text-center">
-                        <% if @community_avg.nil? %>
-                          <span class="text-gray-300">-</span>
-                        <% else %>
-                          <%
-                            c_key    = row[:community_key] || row[:key]
-                            avg_val  = @community_avg[c_key]
-                            min_val  = @community_min&.[](c_key)
-                            max_val  = @community_max&.[](c_key)
-                            u_perf   = row[:community_perf] == :losses ? @performance_losses : @performance_overall
-                            user_val = u_perf&.[](row[:key])
-                          %>
-                          <% if row[:na_if_nil] && avg_val.nil? %>
-                            <span class="text-gray-400 text-xs">N/A</span>
-                          <% elsif avg_val.nil? %>
-                            <span class="text-gray-300">-</span>
-                          <% else %>
-                            <div class="text-sm text-gray-600 font-medium"><%= "#{avg_val}#{row[:suffix]}" %></div>
-                            <% if min_val && max_val && user_val && min_val != max_val %>
-                              <%
-                                range    = (max_val - min_val).to_f
-                                user_pct = ((user_val.to_f - min_val) / range * 100).clamp(0, 100).round(1)
-                                avg_pct  = ((avg_val.to_f  - min_val) / range * 100).clamp(0, 100).round(1)
-                                good     = row[:higher_is_better] ? user_val.to_f >= avg_val.to_f : user_val.to_f <= avg_val.to_f
-                              %>
-                              <div class="relative h-1.5 bg-gray-200 rounded-full mt-2 max-w-[100px] mx-auto">
-                                <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
-                                <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
-                              </div>
-                              <div class="flex justify-between text-[10px] text-gray-400 mt-1 max-w-[100px] mx-auto">
-                                <span><%= min_val %><%= row[:suffix] %></span>
-                                <span><%= max_val %><%= row[:suffix] %></span>
-                              </div>
-                            <% end %>
-                            <% if row[:community_note] %>
-                              <div class="text-[10px] text-gray-400 mt-1"><%= row[:community_note] %></div>
-                            <% end %>
-                          <% end %>
-                        <% end %>
-                      </td>
                     </tr>
                   <% end %>
                 <% end %>


### PR DESCRIPTION
## Summary
- 「基本パフォーマンス統計」テーブルを5列構成から7列構成に拡張し、全体・勝利時・敗北時それぞれにコミュニティ平均・分布列を追加
- `StatisticsController` にて `build_perf` / `build_community` lambda を抽出してロジックを整理し、勝利時・敗北時のコミュニティ集計（avg/min/max）を新規計算
- テーブルヘッダーを2段構成にリデザイン（1段目: グループ名＋色ドット、2段目: 値・コミュニティ平均・分布のサブヘッダー）
- データ行の背景を白に統一し、カラーの左ボーダー線でグループを区切るモダンなデザインを採用

## Test plan
- [ ] 統計 → プレイ分析タブを開き、7列テーブルが表示されることを確認
- [ ] 2段ヘッダー（全体・勝利時・敗北時のグループ名 + 値/コミュニティ平均・分布のサブヘッダー）が正しく表示されることを確認
- [ ] コミュニティ（勝利時）列・コミュニティ（敗北時）列に平均値とレンジバーが表示されることを確認
- [ ] 勝利/敗北試合が0件のユーザーで「-」表示になることを確認
- [ ] EXバースト中被撃墜率（na_if_nil）が各列で N/A 表示されることを確認

Closes #118