### PR TITLE
feat: プレイ分析のEXバースト分析カードを基本パフォーマンス統計の上に移動

### DIFF
--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1194,7 +1194,210 @@
         </div>
       </div>
 
-      <!-- セクション1: 基本パフォーマンス統計 -->
+      <!-- セクション1 & 2: 2カラムレイアウト -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+
+        <!-- セクション1: EXバースト活用分析 -->
+        <div class="bg-white rounded-lg shadow">
+          <div class="px-6 py-5 border-b border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900">EXバースト活用分析</h3>
+            <p class="mt-1 text-sm text-gray-500">敗北時にEXバーストを残してしまった割合を確認できます</p>
+          </div>
+          <div class="px-6 py-5">
+            <% if @stats_losses.to_i > 0 %>
+              <%
+                ex_pct      = (@ex_remaining_on_loss * 100.0 / @stats_losses).round(1)
+                last_pct    = (@last_death_ex_on_loss * 100.0 / @stats_losses).round(1)
+                survive_pct = (@survive_loss_ex_on_loss * 100.0 / @stats_losses).round(1)
+              %>
+              <!-- メイン指標: あなた vs コミュニティ平均 -->
+              <div class="mb-5 pb-5 border-b border-gray-100">
+                <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">EXバースト残し敗北</div>
+                <div class="flex items-stretch gap-0">
+                  <div class="flex-1 pr-4">
+                    <div class="text-xs text-gray-400 mb-1">あなた</div>
+                    <div class="text-3xl font-bold text-red-600"><%= ex_pct %><span class="text-base font-normal text-gray-500">%</span></div>
+                    <div class="text-xs text-gray-400 mt-1"><%= @ex_remaining_on_loss %> / <%= @stats_losses %> 回</div>
+                  </div>
+                  <% if @community_ex_remaining_rate %>
+                    <div class="w-px bg-gray-200 self-stretch"></div>
+                    <div class="flex-1 pl-4">
+                      <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
+                      <div class="text-2xl font-semibold text-gray-500"><%= @community_ex_remaining_rate %><span class="text-sm font-normal">%</span></div>
+                      <% if @community_ex_remaining_min && @community_ex_remaining_max && @community_ex_remaining_min != @community_ex_remaining_max %>
+                        <%
+                          range    = (@community_ex_remaining_max - @community_ex_remaining_min).to_f
+                          user_pct = ((ex_pct - @community_ex_remaining_min) / range * 100).clamp(0, 100).round(1)
+                          avg_pct  = ((@community_ex_remaining_rate - @community_ex_remaining_min) / range * 100).clamp(0, 100).round(1)
+                          good     = ex_pct <= @community_ex_remaining_rate
+                        %>
+                        <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
+                          <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                          <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                        </div>
+                        <div class="flex justify-between text-[10px] text-gray-400 mt-1">
+                          <span><%= @community_ex_remaining_min %>%</span>
+                          <span><%= @community_ex_remaining_max %>%</span>
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+              <!-- 内訳 -->
+              <div class="space-y-4">
+                <!-- 自機が被撃墜 -->
+                <div>
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm text-gray-600">自機が被撃墜</span>
+                    <div class="text-right">
+                      <span class="text-sm font-semibold text-gray-700"><%= last_pct %>%</span>
+                      <span class="text-xs text-gray-400 ml-1">(<%= @last_death_ex_on_loss %>/<%= @stats_losses %>回)</span>
+                    </div>
+                  </div>
+                  <% if @community_last_death_ex_rate && @community_last_death_ex_min != @community_last_death_ex_max %>
+                    <%
+                      range        = (@community_last_death_ex_max - @community_last_death_ex_min).to_f
+                      user_pct_bar = ((last_pct - @community_last_death_ex_min) / range * 100).clamp(0, 100).round(1)
+                      avg_pct_bar  = ((@community_last_death_ex_rate - @community_last_death_ex_min) / range * 100).clamp(0, 100).round(1)
+                      good         = last_pct <= @community_last_death_ex_rate
+                    %>
+                    <div class="relative h-1.5 bg-gray-200 rounded-full mt-1.5">
+                      <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct_bar %>%"></div>
+                      <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct_bar %>%"></div>
+                    </div>
+                    <div class="relative h-4 text-[10px] text-gray-400 mt-0.5">
+                      <span class="absolute left-0"><%= @community_last_death_ex_min %>%</span>
+                      <span class="absolute -translate-x-1/2 whitespace-nowrap" style="left: <%= avg_pct_bar %>%">avg <%= @community_last_death_ex_rate %>%</span>
+                      <span class="absolute right-0"><%= @community_last_death_ex_max %>%</span>
+                    </div>
+                  <% end %>
+                </div>
+                <!-- パートナー機が被撃墜 -->
+                <div>
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm text-gray-600">パートナー機が被撃墜</span>
+                    <div class="text-right">
+                      <span class="text-sm font-semibold text-gray-700"><%= survive_pct %>%</span>
+                      <span class="text-xs text-gray-400 ml-1">(<%= @survive_loss_ex_on_loss %>/<%= @stats_losses %>回)</span>
+                    </div>
+                  </div>
+                  <% if @community_survive_ex_rate && @community_survive_ex_min != @community_survive_ex_max %>
+                    <%
+                      range        = (@community_survive_ex_max - @community_survive_ex_min).to_f
+                      user_pct_bar = ((survive_pct - @community_survive_ex_min) / range * 100).clamp(0, 100).round(1)
+                      avg_pct_bar  = ((@community_survive_ex_rate - @community_survive_ex_min) / range * 100).clamp(0, 100).round(1)
+                      good         = survive_pct <= @community_survive_ex_rate
+                    %>
+                    <div class="relative h-1.5 bg-gray-200 rounded-full mt-1.5">
+                      <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct_bar %>%"></div>
+                      <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct_bar %>%"></div>
+                    </div>
+                    <div class="relative h-4 text-[10px] text-gray-400 mt-0.5">
+                      <span class="absolute left-0"><%= @community_survive_ex_min %>%</span>
+                      <span class="absolute -translate-x-1/2 whitespace-nowrap" style="left: <%= avg_pct_bar %>%">avg <%= @community_survive_ex_rate %>%</span>
+                      <span class="absolute right-0"><%= @community_survive_ex_max %>%</span>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% else %>
+              <p class="text-gray-500 text-center py-8">統計データのある敗北試合がありません</p>
+            <% end %>
+          </div>
+        </div>
+
+        <!-- セクション2: EXオーバーリミット分析 -->
+        <div class="bg-white rounded-lg shadow">
+          <div class="px-6 py-5 border-b border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900">EXオーバーリミット分析</h3>
+            <p class="mt-1 text-sm text-gray-500">全試合のEXオーバーリミット発動状況を確認できます</p>
+          </div>
+          <div class="px-6 py-5 space-y-5">
+            <% if @has_ol_data %>
+            <%
+              no_ol_pct     = @total_losses.to_i > 0   ? (@my_team_no_ol_losses * 100.0 / @total_losses).round(1)   : 0.0
+              opp_no_ol_pct = @total_wins_all.to_i > 0 ? (@opponent_no_ol_wins  * 100.0 / @total_wins_all).round(1) : 0.0
+            %>
+            <!-- 相手チーム勝利 -->
+            <div class="pb-5 border-b border-gray-100">
+              <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">相手チームEXオーバーリミット未発動で勝利</div>
+              <div class="text-xs text-gray-400 mb-3">相手にEXオーバーリミットを発動させずに勝った試合</div>
+              <div class="flex items-stretch gap-0">
+                <div class="flex-1 pr-4">
+                  <div class="text-xs text-gray-400 mb-1">あなた</div>
+                  <div class="text-3xl font-bold text-green-600"><%= opp_no_ol_pct %><span class="text-base font-normal text-gray-500">%</span></div>
+                  <div class="text-xs text-gray-400 mt-1"><%= @opponent_no_ol_wins %> / <%= @total_wins_all %> 回</div>
+                </div>
+                <% if @community_opp_no_ol_win_rate %>
+                  <div class="w-px bg-gray-200 self-stretch"></div>
+                  <div class="flex-1 pl-4">
+                    <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
+                    <div class="text-2xl font-semibold text-gray-500"><%= @community_opp_no_ol_win_rate %><span class="text-sm font-normal">%</span></div>
+                    <% if @community_opp_no_ol_win_min && @community_opp_no_ol_win_max && @community_opp_no_ol_win_min != @community_opp_no_ol_win_max %>
+                      <%
+                        range    = (@community_opp_no_ol_win_max - @community_opp_no_ol_win_min).to_f
+                        user_pct = ((opp_no_ol_pct - @community_opp_no_ol_win_min) / range * 100).clamp(0, 100).round(1)
+                        avg_pct  = ((@community_opp_no_ol_win_rate - @community_opp_no_ol_win_min) / range * 100).clamp(0, 100).round(1)
+                        good     = opp_no_ol_pct >= @community_opp_no_ol_win_rate
+                      %>
+                      <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
+                        <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                        <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                      </div>
+                      <div class="flex justify-between text-[10px] text-gray-400 mt-1">
+                        <span><%= @community_opp_no_ol_win_min %>%</span>
+                        <span><%= @community_opp_no_ol_win_max %>%</span>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+            <!-- 自チーム敗北 -->
+            <div>
+              <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">自チームEXオーバーリミット未発動で敗北</div>
+              <div class="text-xs text-gray-400 mb-3">EXオーバーリミットを発動できずに負けた試合</div>
+              <div class="flex items-stretch gap-0">
+                <div class="flex-1 pr-4">
+                  <div class="text-xs text-gray-400 mb-1">あなた</div>
+                  <div class="text-3xl font-bold text-red-600"><%= no_ol_pct %><span class="text-base font-normal text-gray-500">%</span></div>
+                  <div class="text-xs text-gray-400 mt-1"><%= @my_team_no_ol_losses %> / <%= @total_losses %> 回</div>
+                </div>
+                <% if @community_no_ol_loss_rate %>
+                  <div class="w-px bg-gray-200 self-stretch"></div>
+                  <div class="flex-1 pl-4">
+                    <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
+                    <div class="text-2xl font-semibold text-gray-500"><%= @community_no_ol_loss_rate %><span class="text-sm font-normal">%</span></div>
+                    <% if @community_no_ol_loss_min && @community_no_ol_loss_max && @community_no_ol_loss_min != @community_no_ol_loss_max %>
+                      <%
+                        range    = (@community_no_ol_loss_max - @community_no_ol_loss_min).to_f
+                        user_pct = ((no_ol_pct - @community_no_ol_loss_min) / range * 100).clamp(0, 100).round(1)
+                        avg_pct  = ((@community_no_ol_loss_rate - @community_no_ol_loss_min) / range * 100).clamp(0, 100).round(1)
+                        good     = no_ol_pct <= @community_no_ol_loss_rate
+                      %>
+                      <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
+                        <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                        <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                      </div>
+                      <div class="flex justify-between text-[10px] text-gray-400 mt-1">
+                        <span><%= @community_no_ol_loss_min %>%</span>
+                        <span><%= @community_no_ol_loss_max %>%</span>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+            <% else %>
+              <p class="text-gray-500 text-center py-8">EXオーバーリミットのデータがありません</p>
+            <% end %>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- セクション3: 基本パフォーマンス統計 -->
       <div class="bg-white rounded-lg shadow">
         <div class="px-6 py-5 border-b border-gray-200">
           <h3 class="text-lg font-semibold text-gray-900">基本パフォーマンス統計</h3>
@@ -1347,209 +1550,6 @@
             <p class="mt-1 text-xs text-gray-400">試合詳細からスコア等の統計データを入力してください</p>
           </div>
         <% end %>
-      </div>
-
-      <!-- セクション2 & 3: 2カラムレイアウト -->
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-
-        <!-- セクション2: EXバースト活用分析 -->
-        <div class="bg-white rounded-lg shadow">
-          <div class="px-6 py-5 border-b border-gray-200">
-            <h3 class="text-lg font-semibold text-gray-900">EXバースト活用分析</h3>
-            <p class="mt-1 text-sm text-gray-500">敗北時にEXバーストを残してしまった割合を確認できます</p>
-          </div>
-          <div class="px-6 py-5">
-            <% if @stats_losses.to_i > 0 %>
-              <%
-                ex_pct      = (@ex_remaining_on_loss * 100.0 / @stats_losses).round(1)
-                last_pct    = (@last_death_ex_on_loss * 100.0 / @stats_losses).round(1)
-                survive_pct = (@survive_loss_ex_on_loss * 100.0 / @stats_losses).round(1)
-              %>
-              <!-- メイン指標: あなた vs コミュニティ平均 -->
-              <div class="mb-5 pb-5 border-b border-gray-100">
-                <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">EXバースト残し敗北</div>
-                <div class="flex items-stretch gap-0">
-                  <div class="flex-1 pr-4">
-                    <div class="text-xs text-gray-400 mb-1">あなた</div>
-                    <div class="text-3xl font-bold text-red-600"><%= ex_pct %><span class="text-base font-normal text-gray-500">%</span></div>
-                    <div class="text-xs text-gray-400 mt-1"><%= @ex_remaining_on_loss %> / <%= @stats_losses %> 回</div>
-                  </div>
-                  <% if @community_ex_remaining_rate %>
-                    <div class="w-px bg-gray-200 self-stretch"></div>
-                    <div class="flex-1 pl-4">
-                      <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
-                      <div class="text-2xl font-semibold text-gray-500"><%= @community_ex_remaining_rate %><span class="text-sm font-normal">%</span></div>
-                      <% if @community_ex_remaining_min && @community_ex_remaining_max && @community_ex_remaining_min != @community_ex_remaining_max %>
-                        <%
-                          range    = (@community_ex_remaining_max - @community_ex_remaining_min).to_f
-                          user_pct = ((ex_pct - @community_ex_remaining_min) / range * 100).clamp(0, 100).round(1)
-                          avg_pct  = ((@community_ex_remaining_rate - @community_ex_remaining_min) / range * 100).clamp(0, 100).round(1)
-                          good     = ex_pct <= @community_ex_remaining_rate
-                        %>
-                        <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
-                          <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
-                          <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
-                        </div>
-                        <div class="flex justify-between text-[10px] text-gray-400 mt-1">
-                          <span><%= @community_ex_remaining_min %>%</span>
-                          <span><%= @community_ex_remaining_max %>%</span>
-                        </div>
-                      <% end %>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
-              <!-- 内訳 -->
-              <div class="space-y-4">
-                <!-- 自機が被撃墜 -->
-                <div>
-                  <div class="flex items-center justify-between">
-                    <span class="text-sm text-gray-600">自機が被撃墜</span>
-                    <div class="text-right">
-                      <span class="text-sm font-semibold text-gray-700"><%= last_pct %>%</span>
-                      <span class="text-xs text-gray-400 ml-1">(<%= @last_death_ex_on_loss %>/<%= @stats_losses %>回)</span>
-                    </div>
-                  </div>
-                  <% if @community_last_death_ex_rate && @community_last_death_ex_min != @community_last_death_ex_max %>
-                    <%
-                      range        = (@community_last_death_ex_max - @community_last_death_ex_min).to_f
-                      user_pct_bar = ((last_pct - @community_last_death_ex_min) / range * 100).clamp(0, 100).round(1)
-                      avg_pct_bar  = ((@community_last_death_ex_rate - @community_last_death_ex_min) / range * 100).clamp(0, 100).round(1)
-                      good         = last_pct <= @community_last_death_ex_rate
-                    %>
-                    <div class="relative h-1.5 bg-gray-200 rounded-full mt-1.5">
-                      <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct_bar %>%"></div>
-                      <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct_bar %>%"></div>
-                    </div>
-                    <div class="relative h-4 text-[10px] text-gray-400 mt-0.5">
-                      <span class="absolute left-0"><%= @community_last_death_ex_min %>%</span>
-                      <span class="absolute -translate-x-1/2 whitespace-nowrap" style="left: <%= avg_pct_bar %>%">avg <%= @community_last_death_ex_rate %>%</span>
-                      <span class="absolute right-0"><%= @community_last_death_ex_max %>%</span>
-                    </div>
-                  <% end %>
-                </div>
-                <!-- パートナー機が被撃墜 -->
-                <div>
-                  <div class="flex items-center justify-between">
-                    <span class="text-sm text-gray-600">パートナー機が被撃墜</span>
-                    <div class="text-right">
-                      <span class="text-sm font-semibold text-gray-700"><%= survive_pct %>%</span>
-                      <span class="text-xs text-gray-400 ml-1">(<%= @survive_loss_ex_on_loss %>/<%= @stats_losses %>回)</span>
-                    </div>
-                  </div>
-                  <% if @community_survive_ex_rate && @community_survive_ex_min != @community_survive_ex_max %>
-                    <%
-                      range        = (@community_survive_ex_max - @community_survive_ex_min).to_f
-                      user_pct_bar = ((survive_pct - @community_survive_ex_min) / range * 100).clamp(0, 100).round(1)
-                      avg_pct_bar  = ((@community_survive_ex_rate - @community_survive_ex_min) / range * 100).clamp(0, 100).round(1)
-                      good         = survive_pct <= @community_survive_ex_rate
-                    %>
-                    <div class="relative h-1.5 bg-gray-200 rounded-full mt-1.5">
-                      <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct_bar %>%"></div>
-                      <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct_bar %>%"></div>
-                    </div>
-                    <div class="relative h-4 text-[10px] text-gray-400 mt-0.5">
-                      <span class="absolute left-0"><%= @community_survive_ex_min %>%</span>
-                      <span class="absolute -translate-x-1/2 whitespace-nowrap" style="left: <%= avg_pct_bar %>%">avg <%= @community_survive_ex_rate %>%</span>
-                      <span class="absolute right-0"><%= @community_survive_ex_max %>%</span>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
-            <% else %>
-              <p class="text-gray-500 text-center py-8">統計データのある敗北試合がありません</p>
-            <% end %>
-          </div>
-        </div>
-
-        <!-- セクション3: EXオーバーリミット分析 -->
-        <div class="bg-white rounded-lg shadow">
-          <div class="px-6 py-5 border-b border-gray-200">
-            <h3 class="text-lg font-semibold text-gray-900">EXオーバーリミット分析</h3>
-            <p class="mt-1 text-sm text-gray-500">全試合のEXオーバーリミット発動状況を確認できます</p>
-          </div>
-          <div class="px-6 py-5 space-y-5">
-            <% if @has_ol_data %>
-            <%
-              no_ol_pct     = @total_losses.to_i > 0   ? (@my_team_no_ol_losses * 100.0 / @total_losses).round(1)   : 0.0
-              opp_no_ol_pct = @total_wins_all.to_i > 0 ? (@opponent_no_ol_wins  * 100.0 / @total_wins_all).round(1) : 0.0
-            %>
-            <!-- 相手チーム勝利 -->
-            <div class="pb-5 border-b border-gray-100">
-              <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">相手チームEXオーバーリミット未発動で勝利</div>
-              <div class="text-xs text-gray-400 mb-3">相手にEXオーバーリミットを発動させずに勝った試合</div>
-              <div class="flex items-stretch gap-0">
-                <div class="flex-1 pr-4">
-                  <div class="text-xs text-gray-400 mb-1">あなた</div>
-                  <div class="text-3xl font-bold text-green-600"><%= opp_no_ol_pct %><span class="text-base font-normal text-gray-500">%</span></div>
-                  <div class="text-xs text-gray-400 mt-1"><%= @opponent_no_ol_wins %> / <%= @total_wins_all %> 回</div>
-                </div>
-                <% if @community_opp_no_ol_win_rate %>
-                  <div class="w-px bg-gray-200 self-stretch"></div>
-                  <div class="flex-1 pl-4">
-                    <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
-                    <div class="text-2xl font-semibold text-gray-500"><%= @community_opp_no_ol_win_rate %><span class="text-sm font-normal">%</span></div>
-                    <% if @community_opp_no_ol_win_min && @community_opp_no_ol_win_max && @community_opp_no_ol_win_min != @community_opp_no_ol_win_max %>
-                      <%
-                        range    = (@community_opp_no_ol_win_max - @community_opp_no_ol_win_min).to_f
-                        user_pct = ((opp_no_ol_pct - @community_opp_no_ol_win_min) / range * 100).clamp(0, 100).round(1)
-                        avg_pct  = ((@community_opp_no_ol_win_rate - @community_opp_no_ol_win_min) / range * 100).clamp(0, 100).round(1)
-                        good     = opp_no_ol_pct >= @community_opp_no_ol_win_rate
-                      %>
-                      <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
-                        <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
-                        <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
-                      </div>
-                      <div class="flex justify-between text-[10px] text-gray-400 mt-1">
-                        <span><%= @community_opp_no_ol_win_min %>%</span>
-                        <span><%= @community_opp_no_ol_win_max %>%</span>
-                      </div>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-            <!-- 自チーム敗北 -->
-            <div>
-              <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">自チームEXオーバーリミット未発動で敗北</div>
-              <div class="text-xs text-gray-400 mb-3">EXオーバーリミットを発動できずに負けた試合</div>
-              <div class="flex items-stretch gap-0">
-                <div class="flex-1 pr-4">
-                  <div class="text-xs text-gray-400 mb-1">あなた</div>
-                  <div class="text-3xl font-bold text-red-600"><%= no_ol_pct %><span class="text-base font-normal text-gray-500">%</span></div>
-                  <div class="text-xs text-gray-400 mt-1"><%= @my_team_no_ol_losses %> / <%= @total_losses %> 回</div>
-                </div>
-                <% if @community_no_ol_loss_rate %>
-                  <div class="w-px bg-gray-200 self-stretch"></div>
-                  <div class="flex-1 pl-4">
-                    <div class="text-xs text-gray-400 mb-1">コミュニティ平均・分布</div>
-                    <div class="text-2xl font-semibold text-gray-500"><%= @community_no_ol_loss_rate %><span class="text-sm font-normal">%</span></div>
-                    <% if @community_no_ol_loss_min && @community_no_ol_loss_max && @community_no_ol_loss_min != @community_no_ol_loss_max %>
-                      <%
-                        range    = (@community_no_ol_loss_max - @community_no_ol_loss_min).to_f
-                        user_pct = ((no_ol_pct - @community_no_ol_loss_min) / range * 100).clamp(0, 100).round(1)
-                        avg_pct  = ((@community_no_ol_loss_rate - @community_no_ol_loss_min) / range * 100).clamp(0, 100).round(1)
-                        good     = no_ol_pct <= @community_no_ol_loss_rate
-                      %>
-                      <div class="relative h-1.5 bg-gray-200 rounded-full mt-2">
-                        <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
-                        <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
-                      </div>
-                      <div class="flex justify-between text-[10px] text-gray-400 mt-1">
-                        <span><%= @community_no_ol_loss_min %>%</span>
-                        <span><%= @community_no_ol_loss_max %>%</span>
-                      </div>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-            <% else %>
-              <p class="text-gray-500 text-center py-8">EXオーバーリミットのデータがありません</p>
-            <% end %>
-          </div>
-        </div>
-
       </div>
 
     </div>


### PR DESCRIPTION
## Summary
- 統計ページのプレイ分析タブで、EXバースト活用分析・EXオーバーリミット分析の2カラムブロックを基本パフォーマンス統計の上に移動した
- HTMLの並び替えのみで、ロジック・スタイルの変更なし

## Test plan
- [x] 統計ページ > プレイ分析タブを開き、カードの表示順が「EXバースト活用分析 / EXオーバーリミット分析」→「基本パフォーマンス統計」になっていることを確認

## 関連Issue・PR
#122