### PR TITLE
feat: 試合詳細の対戦統計とプレイ分析にn機体目の生存時間を追加

### DIFF
--- a/app/controllers/concerns/match_stats_importable.rb
+++ b/app/controllers/concerns/match_stats_importable.rb
@@ -151,10 +151,9 @@ module MatchStatsImportable
         ex_available_at.call(game_end_cs)
       end
 
-      # 生存時間: 各ライフの duration を計算して配列で保存
-      # - 死亡で終わったライフ: centiseconds（整数）
-      # - 1機体目 survived: game_end_cs の実値（常に集計対象）
-      # - 2機体目以降 survived: nil（試合詳細では「生存」表示、統計では除外）
+      # 生存時間: 各ライフの duration を計算して配列で保存（全て整数 cs）
+      # - 全ライフ実時間を格納（死亡・生存問わず）
+      # - 生存判定: survival_times.size > mp.deaths.to_i（最終ライフが生存で終わった）
       death_times = player_events.select { |e| e["is_point"] }
                                   .sort_by { |e| e["start_cs"] || 0 }
                                   .map { |e| e["start_cs"] }
@@ -173,8 +172,8 @@ module MatchStatsImportable
         # 一度も死なず生存 → 1機体目に実時間を格納
         survival_times = game_end_cs != Float::INFINITY ? [ game_end_cs.to_i ] : []
       elsif alive_at_end
-        # 最終ライフを生存で終えた → 末尾に nil
-        survival_times << nil
+        # 最終ライフを生存で終えた → 残り時間（実値）を格納
+        survival_times << (game_end_cs.to_i - prev)
       end
 
       mp.update!(

--- a/app/controllers/concerns/match_stats_importable.rb
+++ b/app/controllers/concerns/match_stats_importable.rb
@@ -151,11 +151,38 @@ module MatchStatsImportable
         ex_available_at.call(game_end_cs)
       end
 
+      # 生存時間: 各ライフの duration を計算して配列で保存
+      # - 死亡で終わったライフ: centiseconds（整数）
+      # - 1機体目 survived: game_end_cs の実値（常に集計対象）
+      # - 2機体目以降 survived: nil（試合詳細では「生存」表示、統計では除外）
+      death_times = player_events.select { |e| e["is_point"] }
+                                  .sort_by { |e| e["start_cs"] || 0 }
+                                  .map { |e| e["start_cs"] }
+                                  .compact
+
+      survival_times = []
+      prev = 0
+      death_times.each do |t|
+        survival_times << (t - prev)
+        prev = t
+      end
+
+      alive_at_end = group_key != last_death_group && game_end_cs != Float::INFINITY
+
+      if death_times.empty?
+        # 一度も死なず生存 → 1機体目に実時間を格納
+        survival_times = game_end_cs != Float::INFINITY ? [ game_end_cs.to_i ] : []
+      elsif alive_at_end
+        # 最終ライフを生存で終えた → 末尾に nil
+        survival_times << nil
+      end
+
       mp.update!(
         exburst_count:             exburst_count,
         exburst_deaths:            exburst_deaths,
         last_death_ex_available:   last_death_ex_available,
-        survive_loss_ex_available: survive_loss_ex_available
+        survive_loss_ex_available: survive_loss_ex_available,
+        survival_times:            survival_times
       )
     end
   end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -722,6 +722,9 @@ class StatisticsController < ApplicationController
         @community_losses_avg, @community_losses_min, @community_losses_max = result if result
       end
     end
+
+    # 生存時間統計
+    @survival_time_stats = calculate_survival_time_stats(stats_mps)
   end
 
   def calc_perf_stats(mps)
@@ -749,6 +752,54 @@ class StatisticsController < ApplicationController
                          flag == false
                        } * 100.0 / n).round(1)
     }
+  end
+
+  # 生存時間統計を計算する
+  # @param user_mps [Array<MatchPlayer>] フィルター済みのユーザー match_player 一覧
+  # @return [Array<Hash>] ライフ番号ごとの統計配列。survival_times データがない場合は []
+  def calculate_survival_time_stats(user_mps)
+    # survival_times が存在するものだけ対象
+    user_st_mps = user_mps.select { |mp| mp.survival_times.present? }
+    return [] if user_st_mps.empty?
+
+    # コミュニティデータ（非ゲストかつ survival_times 存在）
+    community_mps = MatchPlayer.joins(:user)
+      .where(users: { is_guest: false })
+      .where("survival_times IS NOT NULL AND jsonb_array_length(survival_times) > 0")
+      .to_a
+
+    # 最大ライフ数を決定（ユーザーとコミュニティ両方から）
+    max_lives = [ user_st_mps, community_mps ].flat_map { |mps|
+      mps.map { |mp| (mp.survival_times || []).size }
+    }.max.to_i
+    return [] if max_lives == 0
+
+    max_lives.times.map do |n|
+      # ユーザー側
+      # life n+1 が存在するプレイヤーを対象とする（配列長 >= n+1）
+      mps_with_life = user_st_mps.select { |mp| (mp.survival_times || []).size > n }
+      died_values   = mps_with_life.map  { |mp| mp.survival_times[n] }.compact  # nil = 生存 → 除外
+      survived_count = mps_with_life.count { |mp| mp.survival_times[n].nil? }
+
+      user_avg_cs = died_values.any? ? (died_values.sum.to_f / died_values.size).round : nil
+
+      # コミュニティ側: ユーザー別の平均を計算してから avg/min/max を算出
+      community_user_avgs = community_mps.group_by(&:user_id).filter_map do |_uid, mps|
+        vals = mps.filter_map { |mp| (mp.survival_times || [])[n] }
+        next unless vals.any?
+        (vals.sum.to_f / vals.size).round
+      end
+
+      {
+        n:               n + 1,
+        user_count:      died_values.size,
+        survived_count:  survived_count,
+        user_avg_cs:     user_avg_cs,
+        community_avg_cs: community_user_avgs.any? ? (community_user_avgs.sum.to_f / community_user_avgs.size).round : nil,
+        community_min_cs: community_user_avgs.min,
+        community_max_cs: community_user_avgs.max
+      }
+    end
   end
 
   def calculate_overall_stats

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -540,6 +540,10 @@ class StatisticsController < ApplicationController
     win_mps  = stats_mps.select { |mp| mp.match.winning_team == mp.team_number }
     loss_mps = stats_mps.reject { |mp| mp.match.winning_team == mp.team_number }
 
+    # by_user.each ループ内で win_mps/loss_mps が上書きされるため先に退避する
+    user_win_mps  = win_mps
+    user_loss_mps = loss_mps
+
     @stats_total  = stats_mps.size
     @stats_wins   = win_mps.size
     @stats_losses = loss_mps.size
@@ -723,8 +727,11 @@ class StatisticsController < ApplicationController
       end
     end
 
-    # 生存時間統計
-    @survival_time_stats = calculate_survival_time_stats(stats_mps)
+    # 生存時間統計（全体・勝利時・敗北時）
+    # 注意: by_user.each ループ内で win_mps/loss_mps が上書きされるため、事前に退避した変数を使う
+    @survival_time_stats         = calculate_survival_time_stats(stats_mps,       community_scope: :all)
+    @survival_time_stats_wins    = calculate_survival_time_stats(user_win_mps,    community_scope: :wins)
+    @survival_time_stats_losses  = calculate_survival_time_stats(user_loss_mps,   community_scope: :losses)
   end
 
   def calc_perf_stats(mps)
@@ -756,17 +763,23 @@ class StatisticsController < ApplicationController
 
   # 生存時間統計を計算する
   # @param user_mps [Array<MatchPlayer>] フィルター済みのユーザー match_player 一覧
+  # @param community_scope [Symbol] :all / :wins / :losses — コミュニティ側の勝敗絞り込み
   # @return [Array<Hash>] ライフ番号ごとの統計配列。survival_times データがない場合は []
-  def calculate_survival_time_stats(user_mps)
+  def calculate_survival_time_stats(user_mps, community_scope: :all)
     # survival_times が存在するものだけ対象
     user_st_mps = user_mps.select { |mp| mp.survival_times.present? }
     return [] if user_st_mps.empty?
 
     # コミュニティデータ（非ゲストかつ survival_times 存在）
-    community_mps = MatchPlayer.joins(:user)
+    community_q = MatchPlayer.joins(:match, :user)
       .where(users: { is_guest: false })
       .where("survival_times IS NOT NULL AND jsonb_array_length(survival_times) > 0")
-      .to_a
+    community_q = case community_scope
+    when :wins   then community_q.where("matches.winning_team = match_players.team_number")
+    when :losses then community_q.where("matches.winning_team != match_players.team_number")
+    else community_q
+    end
+    community_mps = community_q.to_a
 
     # 最大ライフ数を決定（ユーザーとコミュニティ両方から）
     max_lives = [ user_st_mps, community_mps ].flat_map { |mps|
@@ -775,29 +788,53 @@ class StatisticsController < ApplicationController
     return [] if max_lives == 0
 
     max_lives.times.map do |n|
-      # ユーザー側
-      # life n+1 が存在するプレイヤーを対象とする（配列長 >= n+1）
-      mps_with_life = user_st_mps.select { |mp| (mp.survival_times || []).size > n }
-      died_values   = mps_with_life.map  { |mp| mp.survival_times[n] }.compact  # nil = 生存 → 除外
-      survived_count = mps_with_life.count { |mp| mp.survival_times[n].nil? }
+      mps_with_life  = user_st_mps.select    { |mp| (mp.survival_times || []).size > n }
+      comm_with_life = community_mps.select  { |mp| (mp.survival_times || []).size > n }
 
-      user_avg_cs = died_values.any? ? (died_values.sum.to_f / died_values.size).round : nil
+      # 死亡・生存を分離（survival_times.size > deaths なら最終ライフは生存）
+      survived_life = ->(mp, idx) {
+        st = mp.survival_times || []
+        idx == st.size - 1 && st.size > mp.deaths.to_i
+      }
+      user_died_mps     = mps_with_life.reject  { |mp| survived_life.(mp, n) }
+      user_survived_mps = mps_with_life.select  { |mp| survived_life.(mp, n) }
+      comm_died_mps     = comm_with_life.reject  { |mp| survived_life.(mp, n) }
+      comm_survived_mps = comm_with_life.select  { |mp| survived_life.(mp, n) }
 
-      # コミュニティ側: ユーザー別の平均を計算してから avg/min/max を算出
-      community_user_avgs = community_mps.group_by(&:user_id).filter_map do |_uid, mps|
-        vals = mps.filter_map { |mp| (mp.survival_times || [])[n] }
+      # 死亡統計
+      died_values    = user_died_mps.map { |mp| mp.survival_times[n] }
+      died_avg_cs    = died_values.any? ? (died_values.sum.to_f / died_values.size).round : nil
+      died_comm_avgs = comm_died_mps.group_by(&:user_id).filter_map do |_uid, mps|
+        vals = mps.map { |mp| (mp.survival_times || [])[n] }.compact
+        next unless vals.any?
+        (vals.sum.to_f / vals.size).round
+      end
+
+      # 生存統計（全ライフ実時間あり）
+      survived_values    = user_survived_mps.map { |mp| mp.survival_times[n] }
+      survived_avg_cs    = survived_values.any? ? (survived_values.sum.to_f / survived_values.size).round : nil
+      survived_comm_avgs = comm_survived_mps.group_by(&:user_id).filter_map do |_uid, mps|
+        vals = mps.map { |mp| (mp.survival_times || [])[n] }.compact
         next unless vals.any?
         (vals.sum.to_f / vals.size).round
       end
 
       {
-        n:               n + 1,
-        user_count:      died_values.size,
-        survived_count:  survived_count,
-        user_avg_cs:     user_avg_cs,
-        community_avg_cs: community_user_avgs.any? ? (community_user_avgs.sum.to_f / community_user_avgs.size).round : nil,
-        community_min_cs: community_user_avgs.min,
-        community_max_cs: community_user_avgs.max
+        n: n + 1,
+        died: {
+          user_count:       user_died_mps.size,
+          user_avg_cs:      died_avg_cs,
+          community_avg_cs: died_comm_avgs.any? ? (died_comm_avgs.sum.to_f / died_comm_avgs.size).round : nil,
+          community_min_cs: died_comm_avgs.min,
+          community_max_cs: died_comm_avgs.max
+        },
+        survived: {
+          user_count:       user_survived_mps.size,
+          user_avg_cs:      survived_avg_cs,
+          community_avg_cs: survived_comm_avgs.any? ? (survived_comm_avgs.sum.to_f / survived_comm_avgs.size).round : nil,
+          community_min_cs: survived_comm_avgs.min,
+          community_max_cs: survived_comm_avgs.max
+        }
       }
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,6 +35,13 @@ module ApplicationHelper
     content_tag(:span, cost, class: "px-2 inline-flex text-xs leading-5 font-semibold rounded-full", style: style)
   end
 
+  # centiseconds を "M:SS" 形式の文字列に変換する
+  def format_survival_cs(cs)
+    return nil unless cs
+    total_sec = cs / 100
+    "#{total_sec / 60}:#{format('%02d', total_sec % 60)}"
+  end
+
   # コスト帯の組み合わせ（例："3000+2500"）を2つのバッジで表示
   def cost_combo_badges(cost_combo)
     costs = cost_combo.split("+").map(&:strip)

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -13,8 +13,8 @@ export default class extends Controller {
 
   show() {
     const tooltip = this.contentTarget
-    tooltip.classList.remove("hidden")
     this._position()
+    tooltip.classList.remove("hidden")
     document.addEventListener("click", this._outsideClickHandler)
   }
 

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -154,13 +154,13 @@
                       <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">EXバースト中被撃墜</th>
                       <th class="px-3 py-2 text-right <%= is_winner ? 'text-gray-300' : '' %>" rowspan="<%= row_span %>">EXバースト残し</th>
                       <% if survival_col_count > 0 %>
-                        <th colspan="<%= survival_col_count %>" class="px-3 py-2 text-center text-indigo-600 border-l border-indigo-200 bg-indigo-50 normal-case tracking-normal font-semibold">生存時間</th>
+                        <th colspan="<%= survival_col_count %>" class="px-3 py-2 text-center normal-case tracking-normal font-medium">生存時間</th>
                       <% end %>
                     </tr>
                     <% if survival_col_count > 0 %>
                       <tr>
                         <% survival_col_count.times do |n| %>
-                          <th class="px-3 py-2 text-center text-indigo-400 border-l border-indigo-100 bg-indigo-50 normal-case font-medium"><%= n + 1 %>機体目</th>
+                          <th class="px-3 py-2 text-center normal-case font-medium"><%= n + 1 %>機体目</th>
                         <% end %>
                       </tr>
                     <% end %>
@@ -195,13 +195,16 @@
                           <% end %>
                         </td>
                         <% survival_col_count.times do |n| %>
-                          <td class="px-3 py-2 text-center whitespace-nowrap bg-indigo-50/40 <%= n == 0 ? 'border-l border-indigo-200' : 'border-l border-indigo-100' %>">
+                          <td class="px-3 py-2 text-right text-gray-700 whitespace-nowrap">
                             <% if n >= st.size %>
                               <span class="text-gray-300">—</span>
-                            <% elsif st[n].nil? %>
-                              <span class="px-1.5 py-0.5 rounded bg-green-100 text-green-700 text-xs font-semibold">生存</span>
                             <% else %>
-                              <span class="text-gray-700 font-mono"><%= format_survival_cs(st[n]) %></span>
+                              <% if n == st.size - 1 && st.size > player.deaths.to_i %>
+                                <span class="mr-1 px-1 py-0.5 rounded bg-green-100 text-green-700 text-[10px] font-semibold">生存</span>
+                              <% else %>
+                                <span class="mr-1 px-1 py-0.5 rounded bg-red-100 text-red-700 text-[10px] font-semibold">被撃破</span>
+                              <% end %>
+                              <%= format_survival_cs(st[n]) %>
                             <% end %>
                           </td>
                         <% end %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -119,6 +119,10 @@
       <!-- 対戦統計セクション -->
       <% all_players = team1_players + team2_players %>
       <% has_stats = all_players.any?(&:has_stats?) || !@match.team1_ex_overlimit_before_end.nil? || !@match.team2_ex_overlimit_before_end.nil? %>
+      <%
+        # 生存時間列数: 全プレイヤーの survival_times 配列長の最大値
+        survival_col_count = all_players.map { |p| (p.survival_times || []).size }.max.to_i
+      %>
       <% if has_stats %>
         <div class="mt-8">
           <h2 class="text-lg font-bold text-gray-900 mb-4">対戦統計</h2>
@@ -148,10 +152,14 @@
                       <th class="px-3 py-2 text-right">EXバースト回数</th>
                       <th class="px-3 py-2 text-right">EXバースト中被撃墜</th>
                       <th class="px-3 py-2 text-right <%= is_winner ? 'text-gray-300' : '' %>">EXバースト残し</th>
+                      <% survival_col_count.times do |n| %>
+                        <th class="px-3 py-2 text-right text-indigo-500"><%= n + 1 %>機体目<br><span class="font-normal text-gray-400 normal-case">生存時間</span></th>
+                      <% end %>
                     </tr>
                   </thead>
                   <tbody class="divide-y divide-gray-100">
                     <% players.each do |player| %>
+                      <% st = player.survival_times || [] %>
                       <tr class="bg-white hover:bg-gray-50">
                         <td class="px-3 py-2 font-medium text-gray-900 whitespace-nowrap">
                           <div class="flex items-center gap-2">
@@ -178,6 +186,17 @@
                             <span class="text-gray-300">―</span>
                           <% end %>
                         </td>
+                        <% survival_col_count.times do |n| %>
+                          <td class="px-3 py-2 text-right text-gray-700 whitespace-nowrap">
+                            <% if n >= st.size %>
+                              <span class="text-gray-300">—</span>
+                            <% elsif st[n].nil? %>
+                              <span class="px-1.5 py-0.5 rounded bg-green-100 text-green-700 text-xs font-semibold">生存</span>
+                            <% else %>
+                              <%= format_survival_cs(st[n]) %>
+                            <% end %>
+                          </td>
+                        <% end %>
                       </tr>
                     <% end %>
                   </tbody>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -142,20 +142,28 @@
                 <table class="min-w-full text-sm border border-gray-200 rounded-lg overflow-hidden">
                   <thead class="bg-gray-50 text-xs text-gray-500 uppercase">
                     <tr>
-                      <th class="px-3 py-2 text-left">プレイヤー</th>
-                      <th class="px-3 py-2 text-right">スコア</th>
-                      <th class="px-3 py-2 text-right">撃墜</th>
-                      <th class="px-3 py-2 text-right">被撃墜</th>
-                      <th class="px-3 py-2 text-right">与ダメージ</th>
-                      <th class="px-3 py-2 text-right">被ダメージ</th>
-                      <th class="px-3 py-2 text-right">EXバーストダメージ</th>
-                      <th class="px-3 py-2 text-right">EXバースト回数</th>
-                      <th class="px-3 py-2 text-right">EXバースト中被撃墜</th>
-                      <th class="px-3 py-2 text-right <%= is_winner ? 'text-gray-300' : '' %>">EXバースト残し</th>
-                      <% survival_col_count.times do |n| %>
-                        <th class="px-3 py-2 text-right text-indigo-500"><%= n + 1 %>機体目<br><span class="font-normal text-gray-400 normal-case">生存時間</span></th>
+                      <% row_span = survival_col_count > 0 ? 2 : 1 %>
+                      <th class="px-3 py-2 text-left" rowspan="<%= row_span %>">プレイヤー</th>
+                      <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">スコア</th>
+                      <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">撃墜</th>
+                      <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">被撃墜</th>
+                      <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">与ダメージ</th>
+                      <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">被ダメージ</th>
+                      <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">EXバーストダメージ</th>
+                      <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">EXバースト回数</th>
+                      <th class="px-3 py-2 text-right" rowspan="<%= row_span %>">EXバースト中被撃墜</th>
+                      <th class="px-3 py-2 text-right <%= is_winner ? 'text-gray-300' : '' %>" rowspan="<%= row_span %>">EXバースト残し</th>
+                      <% if survival_col_count > 0 %>
+                        <th colspan="<%= survival_col_count %>" class="px-3 py-2 text-center text-indigo-600 border-l border-indigo-200 bg-indigo-50 normal-case tracking-normal font-semibold">生存時間</th>
                       <% end %>
                     </tr>
+                    <% if survival_col_count > 0 %>
+                      <tr>
+                        <% survival_col_count.times do |n| %>
+                          <th class="px-3 py-2 text-center text-indigo-400 border-l border-indigo-100 bg-indigo-50 normal-case font-medium"><%= n + 1 %>機体目</th>
+                        <% end %>
+                      </tr>
+                    <% end %>
                   </thead>
                   <tbody class="divide-y divide-gray-100">
                     <% players.each do |player| %>
@@ -187,13 +195,13 @@
                           <% end %>
                         </td>
                         <% survival_col_count.times do |n| %>
-                          <td class="px-3 py-2 text-right text-gray-700 whitespace-nowrap">
+                          <td class="px-3 py-2 text-center whitespace-nowrap bg-indigo-50/40 <%= n == 0 ? 'border-l border-indigo-200' : 'border-l border-indigo-100' %>">
                             <% if n >= st.size %>
                               <span class="text-gray-300">—</span>
                             <% elsif st[n].nil? %>
                               <span class="px-1.5 py-0.5 rounded bg-green-100 text-green-700 text-xs font-semibold">生存</span>
                             <% else %>
-                              <%= format_survival_cs(st[n]) %>
+                              <span class="text-gray-700 font-mono"><%= format_survival_cs(st[n]) %></span>
                             <% end %>
                           </td>
                         <% end %>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1541,6 +1541,111 @@
                     </tr>
                   <% end %>
                 <% end %>
+
+                <%# 生存時間グループ — 動的行数のため perf_groups とは別に描画 %>
+                <% if @survival_time_stats.present? %>
+                  <tr class="bg-gray-50">
+                    <td colspan="7" class="px-6 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                      <span class="inline-flex items-center gap-1.5">
+                        生存時間
+                        <span data-controller="tooltip"
+                              data-action="mouseenter->tooltip#show mouseleave->tooltip#hide">
+                          <button type="button"
+                                  class="text-gray-400 hover:text-gray-600 focus:outline-none cursor-help"
+                                  data-action="click->tooltip#toggle"
+                                  aria-label="生存時間の集計方法について">
+                            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                              <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+                            </svg>
+                          </button>
+                          <div data-tooltip-target="content"
+                               class="hidden z-50 w-64 bg-gray-900 text-white text-xs rounded-lg shadow-xl p-3
+                                      text-left font-normal normal-case tracking-normal pointer-events-none">
+                            <p class="font-semibold text-white mb-1.5">集計方法について</p>
+                            <ul class="text-gray-300 space-y-1">
+                              <li><span class="text-green-400 font-semibold">生存：</span>そのライフで生存したまま試合終了した試合の平均時間</li>
+                              <li><span class="text-rose-400 font-semibold">被撃破：</span>そのライフで被撃破して終わった試合の平均時間</li>
+                            </ul>
+                            <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900"></div>
+                          </div>
+                        </span>
+                      </span>
+                    </td>
+                  </tr>
+                  <%
+                    st_cols = [
+                      { stats_arr: @survival_time_stats,        color: "text-indigo-600", border: "border-l-2 border-indigo-300" },
+                      { stats_arr: @survival_time_stats_wins,   color: "text-green-600",  border: "border-l-2 border-green-300" },
+                      { stats_arr: @survival_time_stats_losses, color: "text-red-600",    border: "border-l-2 border-red-300"   },
+                    ]
+                    st_max_n = st_cols.map { |c| c[:stats_arr].size }.max.to_i
+                  %>
+                  <% st_max_n.times do |i| %>
+                    <%# n機体目 区切り行 %>
+                    <tr class="bg-gray-50/50">
+                      <td colspan="7" class="px-6 py-1.5 text-xs font-medium text-gray-400 pl-10">
+                        <%= i + 1 %>機体目
+                      </td>
+                    </tr>
+                    <%# 死亡・生存 サブ行 %>
+                    <%
+                      overall_grp = @survival_time_stats[i]
+                      sub_outcomes = [
+                        { key: :survived, label: "生存", label_color: "text-green-600", show: overall_grp&.dig(:survived, :user_count).to_i > 0 },
+                        { key: :died,     label: "被撃破", label_color: "text-red-600",   show: overall_grp&.dig(:died,     :user_count).to_i > 0 },
+                      ]
+                    %>
+                    <% sub_outcomes.each do |outcome| %>
+                      <% next unless outcome[:show] %>
+                      <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-3 pl-12">
+                          <span class="text-sm font-semibold <%= outcome[:label_color] %>"><%= outcome[:label] %></span>
+                        </td>
+                        <% st_cols.each do |col| %>
+                          <% grp = col[:stats_arr][i] %>
+                          <% st = grp&.dig(outcome[:key]) %>
+                          <td class="px-6 py-3 text-center text-sm font-semibold <%= col[:color] %> <%= col[:border] %>">
+                            <% if st.nil? || st[:user_avg_cs].nil? %>
+                              <span class="text-gray-300 font-normal">-</span>
+                            <% else %>
+                              <%= format_survival_cs(st[:user_avg_cs]) %>
+                              <div class="text-xs font-normal text-gray-400 mt-0.5"><%= st[:user_count] %>試合</div>
+                            <% end %>
+                          </td>
+                          <td class="px-6 py-3 text-center">
+                            <% if st && st[:community_avg_cs] && st[:user_avg_cs] %>
+                              <%
+                                c_avg = st[:community_avg_cs]
+                                c_min = st[:community_min_cs]
+                                c_max = st[:community_max_cs]
+                                u_cs  = st[:user_avg_cs]
+                              %>
+                              <div class="text-sm text-gray-600 font-medium"><%= format_survival_cs(c_avg) %></div>
+                              <% if c_min && c_max && c_min != c_max %>
+                                <%
+                                  range   = (c_max - c_min).to_f
+                                  u_pct   = ((u_cs  - c_min) / range * 100).clamp(0, 100).round(1)
+                                  avg_pct = ((c_avg - c_min) / range * 100).clamp(0, 100).round(1)
+                                  good    = u_cs >= c_avg
+                                %>
+                                <div class="relative h-1.5 bg-gray-200 rounded-full mt-2 max-w-[100px] mx-auto">
+                                  <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                                  <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= u_pct %>%"></div>
+                                </div>
+                                <div class="flex justify-between text-[10px] text-gray-400 mt-1 max-w-[100px] mx-auto">
+                                  <span><%= format_survival_cs(c_min) %></span>
+                                  <span><%= format_survival_cs(c_max) %></span>
+                                </div>
+                              <% end %>
+                            <% else %>
+                              <span class="text-gray-300">-</span>
+                            <% end %>
+                          </td>
+                        <% end %>
+                      </tr>
+                    <% end %>
+                  <% end %>
+                <% end %>
               </tbody>
             </table>
           </div>
@@ -1551,84 +1656,6 @@
           </div>
         <% end %>
       </div>
-
-      <!-- セクション4: 生存時間統計 -->
-      <% if @survival_time_stats.present? %>
-        <div class="bg-white rounded-lg shadow">
-          <div class="px-6 py-5 border-b border-gray-200">
-            <h3 class="text-lg font-semibold text-gray-900">生存時間</h3>
-            <p class="mt-1 text-sm text-gray-500">機体ごとの平均生存時間（タイムラインデータのある試合のみ）</p>
-          </div>
-          <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-              <thead class="bg-gray-50">
-                <tr class="border-b border-gray-200">
-                  <th rowspan="2" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider align-middle">機体</th>
-                  <th colspan="2" class="px-4 py-2 text-center text-sm font-semibold text-indigo-700 border-l-2 border-indigo-300 bg-indigo-50">
-                    <span class="inline-flex items-center gap-1.5 justify-center">
-                      <span class="w-2 h-2 rounded-full bg-indigo-400 shrink-0"></span>全体
-                    </span>
-                  </th>
-                </tr>
-                <tr>
-                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-500 whitespace-nowrap border-l-2 border-indigo-300">値</th>
-                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-400 whitespace-nowrap"><%= render "statistics/community_distribution_header" %></th>
-                </tr>
-              </thead>
-              <tbody class="bg-white divide-y divide-gray-100">
-                <% @survival_time_stats.each do |st| %>
-                  <tr class="hover:bg-gray-50">
-                    <td class="px-6 py-3 text-sm font-medium text-gray-700 whitespace-nowrap">
-                      <%= st[:n] %>機体目
-                    </td>
-                    <%
-                      user_val = st[:user_avg_cs] ? format_survival_cs(st[:user_avg_cs]) : nil
-                      comm_avg = st[:community_avg_cs]
-                      comm_min = st[:community_min_cs]
-                      comm_max = st[:community_max_cs]
-                      count_label = "#{st[:user_count]}試合"
-                      count_label += " <span class='text-orange-400'>※生存#{st[:survived_count]}試合を除く</span>" if st[:n] > 1 && st[:survived_count] > 0
-                    %>
-                    <td class="px-6 py-3 text-center border-l-2 border-indigo-300">
-                      <% if user_val %>
-                        <span class="text-sm font-semibold text-gray-800"><%= user_val %></span>
-                        <div class="text-xs text-gray-400 mt-0.5"><%= count_label.html_safe %></div>
-                      <% else %>
-                        <span class="text-gray-300 text-sm">—</span>
-                      <% end %>
-                    </td>
-                    <td class="px-6 py-3 text-center">
-                      <% if comm_avg && comm_min && comm_max && user_val %>
-                        <%
-                          user_cs  = st[:user_avg_cs]
-                          range    = (comm_max - comm_min).to_f
-                          user_pct = range > 0 ? ([ [ (user_cs - comm_min) * 100.0 / range, 0 ].max, 100 ].min).round(1) : 50
-                          good     = user_cs >= comm_avg
-                        %>
-                        <div class="text-xs text-gray-600 font-medium"><%= format_survival_cs(comm_avg) %></div>
-                        <div class="relative mt-1 max-w-[100px] mx-auto">
-                          <div class="w-full bg-gray-200 rounded-full" style="height:6px"></div>
-                          <div class="absolute top-0 left-0 h-full rounded-full bg-indigo-400" style="width: <%= user_pct %>%"></div>
-                          <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
-                        </div>
-                        <div class="flex justify-between text-[10px] text-gray-400 mt-1 max-w-[100px] mx-auto">
-                          <span><%= format_survival_cs(comm_min) %></span>
-                          <span><%= format_survival_cs(comm_max) %></span>
-                        </div>
-                      <% else %>
-                        <span class="text-gray-300 text-xs">—</span>
-                      <% end %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
-          <p class="px-6 py-2 text-xs text-gray-400">
-            ※ 1機体目は試合終了まで生存した場合も実時間を含みます。2機体目以降は死亡で終了したケースのみ集計対象です。
-          </p>
-        </div>
-      <% end %>
 
     </div>
 

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1552,6 +1552,84 @@
         <% end %>
       </div>
 
+      <!-- セクション4: 生存時間統計 -->
+      <% if @survival_time_stats.present? %>
+        <div class="bg-white rounded-lg shadow">
+          <div class="px-6 py-5 border-b border-gray-200">
+            <h3 class="text-lg font-semibold text-gray-900">生存時間</h3>
+            <p class="mt-1 text-sm text-gray-500">機体ごとの平均生存時間（タイムラインデータのある試合のみ）</p>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr class="border-b border-gray-200">
+                  <th rowspan="2" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider align-middle">機体</th>
+                  <th colspan="2" class="px-4 py-2 text-center text-sm font-semibold text-indigo-700 border-l-2 border-indigo-300 bg-indigo-50">
+                    <span class="inline-flex items-center gap-1.5 justify-center">
+                      <span class="w-2 h-2 rounded-full bg-indigo-400 shrink-0"></span>全体
+                    </span>
+                  </th>
+                </tr>
+                <tr>
+                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-500 whitespace-nowrap border-l-2 border-indigo-300">値</th>
+                  <th class="px-6 py-2 text-center text-xs font-medium text-gray-400 whitespace-nowrap"><%= render "statistics/community_distribution_header" %></th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-100">
+                <% @survival_time_stats.each do |st| %>
+                  <tr class="hover:bg-gray-50">
+                    <td class="px-6 py-3 text-sm font-medium text-gray-700 whitespace-nowrap">
+                      <%= st[:n] %>機体目
+                    </td>
+                    <%
+                      user_val = st[:user_avg_cs] ? format_survival_cs(st[:user_avg_cs]) : nil
+                      comm_avg = st[:community_avg_cs]
+                      comm_min = st[:community_min_cs]
+                      comm_max = st[:community_max_cs]
+                      count_label = "#{st[:user_count]}試合"
+                      count_label += " <span class='text-orange-400'>※生存#{st[:survived_count]}試合を除く</span>" if st[:n] > 1 && st[:survived_count] > 0
+                    %>
+                    <td class="px-6 py-3 text-center border-l-2 border-indigo-300">
+                      <% if user_val %>
+                        <span class="text-sm font-semibold text-gray-800"><%= user_val %></span>
+                        <div class="text-xs text-gray-400 mt-0.5"><%= count_label.html_safe %></div>
+                      <% else %>
+                        <span class="text-gray-300 text-sm">—</span>
+                      <% end %>
+                    </td>
+                    <td class="px-6 py-3 text-center">
+                      <% if comm_avg && comm_min && comm_max && user_val %>
+                        <%
+                          user_cs  = st[:user_avg_cs]
+                          range    = (comm_max - comm_min).to_f
+                          user_pct = range > 0 ? ([ [ (user_cs - comm_min) * 100.0 / range, 0 ].max, 100 ].min).round(1) : 50
+                          good     = user_cs >= comm_avg
+                        %>
+                        <div class="text-xs text-gray-600 font-medium"><%= format_survival_cs(comm_avg) %></div>
+                        <div class="relative mt-1 max-w-[100px] mx-auto">
+                          <div class="w-full bg-gray-200 rounded-full" style="height:6px"></div>
+                          <div class="absolute top-0 left-0 h-full rounded-full bg-indigo-400" style="width: <%= user_pct %>%"></div>
+                          <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
+                        </div>
+                        <div class="flex justify-between text-[10px] text-gray-400 mt-1 max-w-[100px] mx-auto">
+                          <span><%= format_survival_cs(comm_min) %></span>
+                          <span><%= format_survival_cs(comm_max) %></span>
+                        </div>
+                      <% else %>
+                        <span class="text-gray-300 text-xs">—</span>
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+          <p class="px-6 py-2 text-xs text-gray-400">
+            ※ 1機体目は試合終了まで生存した場合も実時間を含みます。2機体目以降は死亡で終了したケースのみ集計対象です。
+          </p>
+        </div>
+      <% end %>
+
     </div>
 
   <% end %>

--- a/db/migrate/20260305124943_add_survival_times_to_match_players.rb
+++ b/db/migrate/20260305124943_add_survival_times_to_match_players.rb
@@ -1,0 +1,5 @@
+class AddSurvivalTimesToMatchPlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :match_players, :survival_times, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_27_124645) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_05_124943) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -59,6 +59,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_27_124645) do
     t.bigint "mobile_suit_id", null: false
     t.integer "position", null: false
     t.integer "score"
+    t.jsonb "survival_times"
     t.boolean "survive_loss_ex_available"
     t.integer "team_number", null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/vsmobile.rake
+++ b/lib/tasks/vsmobile.rake
@@ -1,0 +1,26 @@
+namespace :vsmobile do
+  desc "match_timeline が存在する全試合の survival_times を再計算する"
+  task backfill_survival_times: :environment do
+    matches = Match.joins(:match_timeline).includes(:match_timeline, match_players: :user)
+    total   = matches.count
+    puts "対象試合数: #{total}"
+
+    # MatchStatsImportable の recalculate_timeline_derived_stats を再利用するため
+    # 一時的にコントローラー風のコンテキストを作るのではなく、concern を直接 include したクラスを使う
+    runner = Class.new do
+      include MatchStatsImportable
+      attr_accessor :match
+
+      def initialize(match)
+        @match = match
+      end
+    end
+
+    matches.find_each.with_index(1) do |match, i|
+      runner.new(match).send(:recalculate_timeline_derived_stats)
+      print "\r#{i}/#{total} 完了" if (i % 10).zero? || i == total
+    end
+
+    puts "\n完了"
+  end
+end


### PR DESCRIPTION
## Summary

- `match_players` に `survival_times` jsonb カラムを追加（マイグレーション）
- `recalculate_timeline_derived_stats` でタイムラインの `is_point` イベントから各ライフの生存時間を計算・保存
  - 全ライフ実時間を整数で格納（死亡・生存問わず）
  - 生存判定: `survival_times.size > deaths`（最終ライフが生存で終わったか）
- バックフィル Rake タスク `rails vsmobile:backfill_survival_times` を追加
- `format_survival_cs` ヘルパーを追加（centiseconds → M:SS 変換）
- 試合詳細の対戦統計テーブルに動的な生存時間列を追加
  - 各ライフの左に「生存」（緑）または「被撃破」（赤）バッジを表示
- `calculate_survival_time_stats` を大幅リファクタ
  - ライフごとに `died` / `survived` サブ統計を算出
  - 全体・勝利時・敗北時の3軸で集計（`community_scope` パラメーター）
  - 変数シャドウイングバグ修正（`user_win_mps` / `user_loss_mps` を事前に退避）
- プレイ分析の基本パフォーマンス統計に「生存時間（秒）」セクションを統合
  - n機体目ごとに「生存」「被撃破」のサブ行に分け、それぞれ平均・コミュニティ分布を表示
  - 全体・勝利時・敗北時の3列構成
  - ℹ️ ツールチップで集計方法を説明
- ツールチップの初回フラッシュを修正（`_position()` を表示前に呼ぶよう変更）
- ツールチップのアイコン基準位置を修正（`data-controller` をアイコンのみにラップ）

## Test plan

- [x] タイムラインデータのある試合詳細を開き、対戦統計に「1機体目」「2機体目」…の列が表示される
- [x] 生存したライフに「生存」（緑）バッジ、被撃破したライフに「被撃破」（赤）バッジが表示される
- [x] 統計ページのプレイ分析タブの「生存時間（秒）」セクションに、ライフごとの生存・被撃破サブ行が表示される
- [x] 全体・勝利時・敗北時で生存時間の平均とコミュニティ分布が正しく表示される
- [x] ℹ️ アイコンにマウスオーバーするとツールチップが正しくアイコンを指して表示される
- [x] `rails vsmobile:backfill_survival_times` を実行して既存データにエラーが出ない

## 関連Issue・PR

#124