### PR TITLE
feat: 統計ページにハイライトタブを追加

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -32,6 +32,8 @@ class StatisticsController < ApplicationController
       calculate_opponent_stats
     when "performance"
       calculate_performance_stats
+    when "highlights"
+      calculate_highlights
     end
 
     # フィルター用のデータ
@@ -837,6 +839,87 @@ class StatisticsController < ApplicationController
         }
       }
     end
+  end
+
+  def calculate_highlights
+    base_mps = MatchPlayer.joins(:match, :mobile_suit, :user)
+                          .includes(:match, :mobile_suit, :user, match: :event)
+    base_mps = base_mps.where(matches: { event_id: @filter_events }) if @filter_events.any?
+
+    stats_mps = base_mps.where.not(damage_dealt: nil)
+
+    # 最多ダメージ
+    @highlight_most_damage = stats_mps.order(damage_dealt: :desc).first
+
+    # 最多 EX バーストダメージ
+    @highlight_most_exburst_damage = base_mps.where.not(exburst_damage: nil)
+                                             .order(exburst_damage: :desc).first
+
+    # 最少被ダメージ（勝利プレイヤー単位）
+    @highlight_min_damage_received = MatchPlayer
+      .joins(:match, :mobile_suit, :user)
+      .includes(:match, :mobile_suit, :user, match: :event)
+      .where.not(damage_received: nil)
+      .where("matches.winning_team = match_players.team_number")
+      .then { |q| @filter_events.any? ? q.where(matches: { event_id: @filter_events }) : q }
+      .order(damage_received: :asc)
+      .first
+
+    # 最高スコア
+    @highlight_top_score = base_mps.where.not(score: nil).order(score: :desc).first
+
+    # 最も激しい試合（全プレイヤーの damage_dealt 合計が最大の試合）
+    intense_mps = MatchPlayer.joins(:match)
+      .includes(match: :event)
+      .where.not(damage_dealt: nil)
+    intense_mps = intense_mps.where(matches: { event_id: @filter_events }) if @filter_events.any?
+
+    best_intense = intense_mps.to_a
+      .group_by(&:match_id)
+      .filter_map do |_mid, mps|
+        next if mps.any? { |mp| mp.damage_dealt.nil? }
+        [ mps.sum(&:damage_dealt), mps.first.match ]
+      end
+      .max_by { |total, _| total }
+
+    if best_intense
+      @highlight_most_intense_total = best_intense[0]
+      @highlight_most_intense_match = best_intense[1]
+    end
+
+    # 生存時間: survival_times[0] があるものだけ対象
+    survival_mps = base_mps.where("survival_times IS NOT NULL AND jsonb_array_length(survival_times) > 0")
+
+    loaded_survival = survival_mps.to_a
+
+    # 最長 1 機体目生存時間（死亡・生存問わず）
+    longest_life_mp = loaded_survival.max_by { |mp| (mp.survival_times || [])[0].to_i }
+    @highlight_longest_first_life    = longest_life_mp
+    @highlight_longest_first_life_cs = longest_life_mp ? (longest_life_mp.survival_times || [])[0].to_i : nil
+
+    # 最短 1 機体目生存時間（死亡のみ = survival_times が 2 個以上 OR deaths >= 1）
+    died_on_first = loaded_survival.select do |mp|
+      st = mp.survival_times || []
+      st.size >= 2 || mp.deaths.to_i >= 1
+    end
+    shortest_life_mp = died_on_first.min_by { |mp| (mp.survival_times || [])[0].to_i }
+    @highlight_shortest_first_life    = shortest_life_mp
+    @highlight_shortest_first_life_cs = shortest_life_mp ? (shortest_life_mp.survival_times || [])[0].to_i : nil
+
+    # 試合時間: match_timelines.game_end_cs を使用
+    timelines_q = MatchTimeline.joins(:match)
+                               .includes(match: :event)
+                               .where.not(game_end_cs: nil)
+    timelines_q = timelines_q.where(matches: { event_id: @filter_events }) if @filter_events.any?
+
+    longest_tl  = timelines_q.order(game_end_cs: :desc).first
+    shortest_tl = timelines_q.order(game_end_cs: :asc).first
+
+    @highlight_longest_match    = longest_tl&.match
+    @highlight_longest_match_cs = longest_tl&.game_end_cs
+
+    @highlight_shortest_match    = shortest_tl&.match
+    @highlight_shortest_match_cs = shortest_tl&.game_end_cs
   end
 
   def calculate_overall_stats

--- a/app/views/statistics/_highlights.html.erb
+++ b/app/views/statistics/_highlights.html.erb
@@ -1,0 +1,78 @@
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+  <%# Row 1: ダメージ系 %>
+  <%= render 'highlights_card',
+      label:  '最多ダメージ',
+      icon:   '💥',
+      metric: @highlight_most_damage ? number_with_delimiter(@highlight_most_damage.damage_dealt) : nil,
+      unit:   'dmg',
+      mp:     @highlight_most_damage,
+      match:  @highlight_most_damage&.match %>
+
+  <%= render 'highlights_card',
+      label:  '最多 EX バーストダメージ',
+      icon:   '⚡',
+      metric: @highlight_most_exburst_damage ? number_with_delimiter(@highlight_most_exburst_damage.exburst_damage) : nil,
+      unit:   'dmg',
+      mp:     @highlight_most_exburst_damage,
+      match:  @highlight_most_exburst_damage&.match %>
+
+  <%= render 'highlights_card',
+      label:  '最も激しい試合',
+      icon:   '🔥',
+      metric: @highlight_most_intense_total ? number_with_delimiter(@highlight_most_intense_total) : nil,
+      unit:   'total dmg',
+      mp:     nil,
+      match:  @highlight_most_intense_match %>
+
+  <%# Row 2: スコア + 被ダメ + 生存時間 %>
+  <%= render 'highlights_card',
+      label:  '最高スコア',
+      icon:   '🏆',
+      metric: @highlight_top_score ? number_with_delimiter(@highlight_top_score.score) : nil,
+      unit:   'pts',
+      mp:     @highlight_top_score,
+      match:  @highlight_top_score&.match %>
+
+  <%= render 'highlights_card',
+      label:  '最少被ダメージ（勝利）',
+      icon:   '🛡️',
+      metric: @highlight_min_damage_received ? number_with_delimiter(@highlight_min_damage_received.damage_received) : nil,
+      unit:   'dmg received',
+      mp:     @highlight_min_damage_received,
+      match:  @highlight_min_damage_received&.match %>
+
+  <%= render 'highlights_card',
+      label:  '最長 1 機体目生存時間',
+      icon:   '⏳',
+      metric: @highlight_longest_first_life_cs ? format_survival_cs(@highlight_longest_first_life_cs) : nil,
+      unit:   'M:SS',
+      mp:     @highlight_longest_first_life,
+      match:  @highlight_longest_first_life&.match %>
+
+  <%# Row 3: 生存時間（短） + 試合時間 %>
+  <%= render 'highlights_card',
+      label:  '最短 1 機体目生存時間',
+      icon:   '💨',
+      metric: @highlight_shortest_first_life_cs ? format_survival_cs(@highlight_shortest_first_life_cs) : nil,
+      unit:   'M:SS',
+      mp:     @highlight_shortest_first_life,
+      match:  @highlight_shortest_first_life&.match %>
+
+  <%= render 'highlights_card',
+      label:  '最長試合時間',
+      icon:   '⏱️',
+      metric: @highlight_longest_match_cs ? format_survival_cs(@highlight_longest_match_cs) : nil,
+      unit:   'M:SS',
+      mp:     nil,
+      match:  @highlight_longest_match %>
+
+  <%= render 'highlights_card',
+      label:  '最短試合時間',
+      icon:   '🏁',
+      metric: @highlight_shortest_match_cs ? format_survival_cs(@highlight_shortest_match_cs) : nil,
+      unit:   'M:SS',
+      mp:     nil,
+      match:  @highlight_shortest_match %>
+
+</div>

--- a/app/views/statistics/_highlights_card.html.erb
+++ b/app/views/statistics/_highlights_card.html.erb
@@ -1,0 +1,76 @@
+<%# locals: label, icon, desc, metric, unit, mp (MatchPlayer|nil), match (Match|nil) %>
+<div class="rounded-xl overflow-hidden shadow-sm flex flex-col bg-white">
+
+  <%# グラジエントヘッダー %>
+  <div class="bg-gradient-to-br from-indigo-500 to-violet-600 px-5 pt-5 pb-5">
+    <div class="flex items-center gap-2 mb-3">
+      <span class="text-lg leading-none"><%= icon %></span>
+      <p class="text-sm font-bold text-white"><%= label %></p>
+    </div>
+    <% if metric %>
+      <div class="flex items-baseline gap-1.5">
+        <span class="text-3xl font-bold text-white tabular-nums leading-none"><%= metric %></span>
+        <span class="text-sm text-indigo-200"><%= unit %></span>
+      </div>
+    <% else %>
+      <p class="text-sm text-indigo-200 mt-1">データがありません</p>
+    <% end %>
+  </div>
+
+  <% if metric && match %>
+    <%
+      team1 = match.match_players.select { |p| p.team_number == 1 }.sort_by(&:position)
+      team2 = match.match_players.select { |p| p.team_number == 2 }.sort_by(&:position)
+      w = match.winning_team
+    %>
+
+    <%# カード本体 %>
+    <div class="px-5 py-4 flex-1 space-y-3">
+
+      <%# プレイヤー行（MatchPlayer ベースのカードのみ） %>
+      <% if mp %>
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="text-sm font-semibold text-gray-800"><%= mp.user.nickname %></span>
+          <span class="text-gray-300 text-xs">·</span>
+          <span class="text-sm text-gray-600"><%= mp.mobile_suit.name %></span>
+          <%= cost_badge(mp.mobile_suit.cost) %>
+        </div>
+      <% end %>
+
+      <%# 対戦カード %>
+      <div class="text-xs text-gray-500 space-y-1">
+        <div class="flex items-start gap-1.5 flex-wrap leading-relaxed">
+          <span class="<%= w == 1 ? 'font-semibold text-gray-800' : 'text-gray-500' %>">
+            <%= team1.map { |p| "#{p.user.nickname}(#{p.mobile_suit.name})" }.join(' & ') %>
+          </span>
+          <span class="text-gray-300 shrink-0">vs</span>
+          <span class="<%= w == 2 ? 'font-semibold text-gray-800' : 'text-gray-500' %>">
+            <%= team2.map { |p| "#{p.user.nickname}(#{p.mobile_suit.name})" }.join(' & ') %>
+          </span>
+        </div>
+        <div class="flex items-center gap-1.5 text-gray-400">
+          <span><%= match.event.name %></span>
+          <span>·</span>
+          <span><%= match.played_at.strftime('%-m/%-d') %></span>
+        </div>
+      </div>
+    </div>
+
+    <%# アクション %>
+    <div class="border-t border-gray-100 px-5 py-3 flex items-center gap-3 bg-gray-50">
+      <%= link_to match_path(match),
+          class: "text-xs font-semibold text-indigo-600 hover:text-indigo-800 transition-colors" do %>
+        試合詳細 →
+      <% end %>
+      <% if match.video_url %>
+        <span class="text-gray-200">|</span>
+        <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer",
+            class: "inline-flex items-center gap-1 text-xs font-medium text-gray-400 hover:text-gray-600 transition-colors" do %>
+          <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3">
+          配信を見る
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -12,6 +12,7 @@
       <select id="mobile-tab-select" onchange="navigateToTab(this.value)" class="block w-full appearance-none rounded-lg border-2 border-indigo-300 bg-white py-3 pl-4 pr-10 text-base font-medium text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500">
       <optgroup label="全体">
         <option value="overall" <%= 'selected' if @active_tab == 'overall' %>>全体統計</option>
+        <option value="highlights" <%= 'selected' if @active_tab == 'highlights' %>>ハイライト</option>
       </optgroup>
       <optgroup label="個人">
         <% if viewing_as_user.is_guest %>
@@ -61,6 +62,10 @@
       <%= link_to statistics_path(tab: 'overall'),
           class: "#{@active_tab == 'overall' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" do %>
         全体統計
+      <% end %>
+      <%= link_to statistics_path(tab: 'highlights'),
+          class: "#{@active_tab == 'highlights' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" do %>
+        ハイライト
       <% end %>
 
       <!-- 区切り -->
@@ -116,15 +121,15 @@
   </div>
 
   <!-- Common Filters -->
-  <% if @active_tab == 'overall' %>
-    <!-- 全体統計タブ: シンプルなイベント選択 -->
+  <% if @active_tab == 'overall' || @active_tab == 'highlights' %>
+    <!-- 全体系タブ: シンプルなイベント選択 -->
     <div class="bg-white shadow rounded-lg px-6 py-4 mb-6">
       <div class="flex items-center flex-wrap gap-2">
         <span class="text-sm font-medium text-gray-700 mr-2">対象:</span>
-        <%= link_to "全イベント", statistics_path(tab: 'overall'),
+        <%= link_to "全イベント", statistics_path(tab: @active_tab),
             class: "px-3 py-1.5 text-sm font-medium rounded-md #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
         <% @all_events.each do |event| %>
-          <%= link_to event.name, statistics_path(tab: 'overall', events: [event.id]),
+          <%= link_to event.name, statistics_path(tab: @active_tab, events: [event.id]),
               class: "px-3 py-1.5 text-sm font-medium rounded-md #{@filter_events.include?(event.id) ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
         <% end %>
       </div>
@@ -1173,6 +1178,9 @@
         <% end %>
       </div>
     </div>
+
+  <% elsif @active_tab == 'highlights' %>
+    <%= render 'highlights' %>
 
   <% elsif @active_tab == 'performance' %>
     <!-- Performance Tab -->


### PR DESCRIPTION
## Summary

- 統計ページの「全体」カテゴリに **ハイライト** タブを追加（ゲストも閲覧可）
- 以下 9 枚のカードを表示（各カードから試合詳細・配信アーカイブへ遷移可）

| カード | 指標 |
|--------|------|
| 💥 最多ダメージ | `damage_dealt` 最大の MatchPlayer |
| ⚡ 最多 EX バーストダメージ | `exburst_damage` 最大の MatchPlayer |
| 🔥 最も激しい試合 | 全プレイヤー `damage_dealt` 合計最大の Match |
| 🏆 最高スコア | `score` 最大の MatchPlayer |
| 🛡️ 最少被ダメージ（勝利） | 勝利時 `damage_received` 最小の MatchPlayer |
| ⏳ 最長 1 機体目生存時間 | `survival_times[0]` 最大の MatchPlayer |
| 💨 最短 1 機体目生存時間 | `survival_times[0]` 最小の MatchPlayer（死亡のみ） |
| ⏱️ 最長試合時間 | `match_timelines.game_end_cs` 最大の Match |
| 🏁 最短試合時間 | `match_timelines.game_end_cs` 最小の Match |

- 既存のイベントフィルターに対応
- カードデザイン: インディゴ→バイオレットのグラジエントヘッダー + 白メトリクス

## Test plan

- [ ] ハイライトタブが全体カテゴリに表示される（デスクトップ・モバイル両方）
- [ ] 各カードに正しいレコード値・プレイヤー情報・試合情報が表示される
- [ ] 「試合詳細 →」リンクで試合詳細画面に遷移できる
- [ ] `video_url` がある試合カードに「配信を見る」ボタンが表示される
- [ ] イベントフィルターで絞り込んだ場合、対象イベント内のレコードが表示される
- [ ] 統計データがない項目は「データがありません」と表示される
- [ ] ゲストユーザーでもハイライトタブが閲覧できる

## 関連 Issue・PR

#126