### PR TITLE
feat: 対戦履歴フィルターにEXバースト条件を追加・ダメージフィルターのバグ修正

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -91,11 +91,36 @@ class MatchesController < ApplicationController
 
     # フィルター: EX条件（チェックボックス）
     stat_filters = Array(params[:stat_filters]).reject(&:blank?)
+
     if stat_filters.include?("ex_leftover_loss")
       scope = @matches.joins(:match_players).where(
         "match_players.team_number != matches.winning_team AND " \
         "(match_players.last_death_ex_available = TRUE OR match_players.survive_loss_ex_available = TRUE)"
       )
+      scope = scope.where(match_players: { user_id: stat_player_id }) if stat_player_id
+      @matches = scope.distinct
+    end
+
+    if stat_filters.include?("ex_leftover_win")
+      # 敗北チームにEXバースト残しプレイヤーがいる試合（= 勝利チームがEXを残させた試合）
+      scope = @matches.where(
+        "EXISTS (SELECT 1 FROM match_players mp WHERE mp.match_id = matches.id " \
+        "AND mp.team_number != matches.winning_team " \
+        "AND (mp.last_death_ex_available = TRUE OR mp.survive_loss_ex_available = TRUE))"
+      )
+      if stat_player_id
+        scope = scope.joins(:match_players).where(
+          "match_players.user_id = ? AND match_players.team_number = matches.winning_team",
+          stat_player_id
+        )
+        @matches = scope.distinct
+      else
+        @matches = scope
+      end
+    end
+
+    if stat_filters.include?("exburst_death")
+      scope = @matches.joins(:match_players).where("match_players.exburst_deaths > 0")
       scope = scope.where(match_players: { user_id: stat_player_id }) if stat_player_id
       @matches = scope.distinct
     end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -101,14 +101,16 @@ class MatchesController < ApplicationController
     end
 
     # フィルター: ダメージ閾値（以上/以下切り替え対応）
-    if params[:damage_dealt_val].present? && (dealt_val = params[:damage_dealt_val].to_i) > 0
+    if params[:damage_dealt_val].present?
+      dealt_val = params[:damage_dealt_val].to_i
       dealt_op = params[:damage_dealt_dir] == "lte" ? "<=" : ">="
       scope = @matches.joins(:match_players).where("match_players.damage_dealt #{dealt_op} ?", dealt_val)
       scope = scope.where(match_players: { user_id: stat_player_id }) if stat_player_id
       @matches = scope.distinct
     end
 
-    if params[:damage_received_val].present? && (received_val = params[:damage_received_val].to_i) > 0
+    if params[:damage_received_val].present?
+      received_val = params[:damage_received_val].to_i
       received_op = params[:damage_received_dir] == "lte" ? "<=" : ">="
       scope = @matches.joins(:match_players).where("match_players.damage_received #{received_op} ?", received_val)
       scope = scope.where(match_players: { user_id: stat_player_id }) if stat_player_id

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -148,16 +148,22 @@
         <div class="mb-4">
           <label class="block text-xs font-medium text-gray-500 mb-1.5">EX条件</label>
           <div class="flex flex-wrap gap-2">
-            <label class="cursor-pointer select-none">
-              <input type="checkbox" name="stat_filters[]" value="ex_leftover_loss"
-                     <%= 'checked' if @filter_stat_filters.include?('ex_leftover_loss') %>
-                     class="peer sr-only">
-              <span class="inline-flex items-center px-3 py-1.5 rounded-full border text-sm font-medium transition-all
-                           border-gray-200 text-gray-400 bg-gray-50 hover:border-gray-300 hover:text-gray-600 hover:bg-gray-100
-                           peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:border-indigo-600 peer-checked:hover:bg-indigo-700">
-                EXバースト残し敗北
-              </span>
-            </label>
+            <% [
+              ["ex_leftover_win",  "EXバーストを使わせず勝利"],
+              ["ex_leftover_loss", "EXバーストを残して敗北"],
+              ["exburst_death",    "EXバースト中被撃墜あり"],
+            ].each do |value, label| %>
+              <label class="cursor-pointer select-none">
+                <input type="checkbox" name="stat_filters[]" value="<%= value %>"
+                       <%= 'checked' if @filter_stat_filters.include?(value) %>
+                       class="peer sr-only">
+                <span class="inline-flex items-center px-3 py-1.5 rounded-full border text-sm font-medium transition-all
+                             border-gray-200 text-gray-400 bg-gray-50 hover:border-gray-300 hover:text-gray-600 hover:bg-gray-100
+                             peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:border-indigo-600 peer-checked:hover:bg-indigo-700">
+                  <%= label %>
+                </span>
+              </label>
+            <% end %>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- 対戦履歴の詳細条件フィルター「EX条件」に2つのチェックボックスを追加
  - **EXバーストを使わせず勝利**: 敗北チームの誰かがEXバーストを残して負けた試合（`last_death_ex_available` / `survive_loss_ex_available`）。対象プレイヤー指定時は勝利チームにいることも条件
  - **EXバースト中被撃墜あり**: `exburst_deaths > 0` のプレイヤーがいる試合。対象プレイヤー指定時はそのプレイヤーのみ対象
- 既存の「EXバーストを残して敗北」と合わせてループで描画するようリファクタ
- DBマイグレーションなし（既存カラムを利用）
- **バグ修正**: ダメージフィルターに `0` を入力してもフィルターが適用されなかった問題を修正（`> 0` ガードを除去）

## Test plan

- [x] 「EXバーストを使わせず勝利」チェックで、敗北チームにEXバースト残しプレイヤーがいる試合のみ表示されることを確認
- [x] 「EXバースト中被撃墜あり」チェックで、`exburst_deaths > 0` の試合のみ表示されることを確認
- [x] 対象プレイヤーを指定した場合も正しく絞り込まれることを確認
- [x] 被ダメフィルターに `0` を入力（以下）で、被ダメ0の試合が表示されることを確認
- [x] 既存の「EXバーストを残して敗北」フィルターが引き続き動作することを確認

Closes #128