### PR TITLE
feat: フィルター機能の拡張（コスト・使用機体）

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -51,6 +51,22 @@ class MatchesController < ApplicationController
       end
     end
 
+    # フィルター: 使用機体（複数選択対応）
+    if params[:mobile_suits].present?
+      mobile_suit_ids = params[:mobile_suits].reject(&:blank?).map(&:to_i)
+      if mobile_suit_ids.any?
+        @matches = @matches.joins(:match_players).where(match_players: { mobile_suit_id: mobile_suit_ids }).distinct
+      end
+    end
+
+    # フィルター: コスト（複数選択対応）
+    if params[:costs].present?
+      cost_values = params[:costs].reject(&:blank?).map(&:to_i)
+      if cost_values.any?
+        @matches = @matches.joins(match_players: :mobile_suit).where(mobile_suits: { cost: cost_values }).distinct
+      end
+    end
+
     # 統計条件フィルター共通: 対象プレイヤー
     stat_player_id = params[:stat_player_id].present? ? params[:stat_player_id].to_i : nil
 
@@ -150,6 +166,7 @@ class MatchesController < ApplicationController
     # フィルター用のデータ
     @all_events = Event.order(held_on: :desc)
     @all_users = User.regular_users.order(:nickname)
+    @all_mobile_suits = MobileSuit.all.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
 
     # 選択されたフィルター値
     @filter_events = params[:events].present? ? params[:events].reject(&:blank?).map(&:to_i) : []
@@ -157,6 +174,8 @@ class MatchesController < ApplicationController
     @filter_users_mode = params[:users_mode].presence_in(%w[or and]) || "or"
     @filter_streaming_users = params[:streaming_users].present? ? params[:streaming_users].reject(&:blank?).map(&:to_i) : []
     @filter_streaming_users_mode = params[:streaming_users_mode].presence_in(%w[or and]) || "or"
+    @filter_mobile_suits = params[:mobile_suits].present? ? params[:mobile_suits].reject(&:blank?).map(&:to_i) : []
+    @filter_costs = params[:costs].present? ? params[:costs].reject(&:blank?).map(&:to_i) : []
     @filter_stat_player_id = stat_player_id
     @filter_ol_filter = ol_filter
     @filter_stat_filters = stat_filters

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -48,6 +48,7 @@ class StatisticsController < ApplicationController
     @filter_events = params[:events].present? ? params[:events].map(&:to_i) : []
     @filter_mobile_suits = params[:mobile_suits].present? ? params[:mobile_suits].map(&:to_i) : []
     @filter_partners = params[:partners].present? ? params[:partners].map(&:to_i) : []
+    @filter_costs = params[:costs].present? ? params[:costs].map(&:to_i) : []
   end
 
   def apply_filters
@@ -64,6 +65,11 @@ class StatisticsController < ApplicationController
     # 機体フィルター（ログインユーザーが使用した機体）
     if @filter_mobile_suits.any?
       @filtered_matches = @filtered_matches.where(mobile_suit_id: @filter_mobile_suits)
+    end
+
+    # コストフィルター（ログインユーザーが使用した機体のコスト）
+    if @filter_costs.any?
+      @filtered_matches = @filtered_matches.where(mobile_suit_id: MobileSuit.where(cost: @filter_costs))
     end
 
     # パートナーフィルター

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -83,6 +83,40 @@
             <% end %>
           </select>
         </div>
+
+        <!-- 使用機体選択 -->
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <label class="block text-sm font-medium text-gray-700">使用機体</label>
+            <span class="inline-flex rounded border border-gray-200 bg-white text-xs font-medium overflow-hidden">
+              <span class="block px-2 py-1 bg-indigo-600 text-white">OR</span>
+            </span>
+          </div>
+          <select name="mobile_suits[]" id="mobile-suit-filter" multiple class="w-full">
+            <% @all_mobile_suits.each do |suit| %>
+              <option value="<%= suit.id %>" <%= 'selected' if @filter_mobile_suits.include?(suit.id) %>>
+                <%= suit.name %> (<%= suit.cost %>)
+              </option>
+            <% end %>
+          </select>
+        </div>
+      </div>
+
+      <!-- コストフィルター -->
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-2">コスト</label>
+        <div class="flex flex-wrap gap-2">
+          <% [3000, 2500, 2000, 1500].each do |cost| %>
+            <label class="cursor-pointer select-none">
+              <input type="checkbox" name="costs[]" value="<%= cost %>"
+                     <%= 'checked' if @filter_costs.include?(cost) %>
+                     class="sr-only">
+              <span class="cost-pill cost-pill-<%= cost %> inline-flex items-center px-3 py-1.5 rounded-full border text-sm font-medium transition-all">
+                <%= cost %>
+              </span>
+            </label>
+          <% end %>
+        </div>
       </div>
 
       <!-- 詳細条件（折りたたみ） -->
@@ -247,13 +281,13 @@
               <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
             <% else %>
               <%= link_to label,
-                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]),
+                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], mobile_suits: params[:mobile_suits], costs: params[:costs], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]),
                     class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
             <% end %>
           <% end %>
         </div>
       </div>
-      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
+      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], mobile_suits: params[:mobile_suits], costs: params[:costs], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -340,7 +374,7 @@
     <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
       <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
         <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
-        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], mobile_suits: params[:mobile_suits], costs: params[:costs], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
       </div>
     <% end %>
   </div>
@@ -429,11 +463,12 @@
 <script>
   (function() {
     // TomSelectインスタンスを管理
-    const selectors = ['#event-filter', '#user-filter', '#streaming-user-filter'];
+    const selectors = ['#event-filter', '#user-filter', '#streaming-user-filter', '#mobile-suit-filter'];
     const placeholders = {
       '#event-filter': 'イベントを選択...',
       '#user-filter': '参加ユーザーを選択...',
-      '#streaming-user-filter': '配信台ユーザーを選択...'
+      '#streaming-user-filter': '配信台ユーザーを選択...',
+      '#mobile-suit-filter': '機体を選択...'
     };
 
     function destroyTomSelects() {
@@ -487,4 +522,13 @@
   /* summary デフォルトマーカー非表示 */
   .stat-summary { list-style: none; }
   .stat-summary::-webkit-details-marker { display: none; }
+  /* コストフィルターピル */
+  .cost-pill-3000 { background: #FEE2E2; color: #991B1B; border-color: #FCA5A5; }
+  .cost-pill-2500 { background: #FFEDD5; color: #C2410C; border-color: #FDBA74; }
+  .cost-pill-2000 { background: #FEF9C3; color: #A16207; border-color: #FDE047; }
+  .cost-pill-1500 { background: #DCFCE7; color: #166534; border-color: #86EFAC; }
+  input:checked + .cost-pill-3000 { background: #DC2626; color: white; border-color: #DC2626; }
+  input:checked + .cost-pill-2500 { background: #EA580C; color: white; border-color: #EA580C; }
+  input:checked + .cost-pill-2000 { background: #CA8A04; color: white; border-color: #CA8A04; }
+  input:checked + .cost-pill-1500 { background: #16A34A; color: white; border-color: #16A34A; }
 </style>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -84,35 +84,35 @@
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">パートナー別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">対戦相手別戦績</span>
       <% else %>
-        <%= link_to statistics_path(tab: 'overview', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+        <%= link_to statistics_path(tab: 'overview', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'overview' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" do %>
           総合戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'performance', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+        <%= link_to statistics_path(tab: 'performance', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'performance' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           プレイ分析
         <% end %>
-        <%= link_to statistics_path(tab: 'events', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+        <%= link_to statistics_path(tab: 'events', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'events' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           イベント別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'event_progression', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+        <%= link_to statistics_path(tab: 'event_progression', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'event_progression' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           イベント内期間別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'mobile_suits', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+        <%= link_to statistics_path(tab: 'mobile_suits', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'mobile_suits' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           使用機体別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'opponent_suits', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+        <%= link_to statistics_path(tab: 'opponent_suits', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'opponent_suits' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           対戦機体別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'partners', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+        <%= link_to statistics_path(tab: 'partners', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'partners' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           パートナー別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'opponents', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners]),
+        <%= link_to statistics_path(tab: 'opponents', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'opponents' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           対戦相手別戦績
         <% end %>
@@ -175,6 +175,23 @@
                 </option>
               <% end %>
             </select>
+          </div>
+        </div>
+
+        <!-- Cost Filter -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-2">コスト</label>
+          <div class="flex flex-wrap gap-2">
+            <% [3000, 2500, 2000, 1500].each do |cost| %>
+              <label class="cursor-pointer select-none">
+                <input type="checkbox" name="costs[]" value="<%= cost %>"
+                       <%= 'checked' if @filter_costs.include?(cost) %>
+                       class="sr-only">
+                <span class="cost-pill cost-pill-<%= cost %> inline-flex items-center px-3 py-1.5 rounded-full border text-sm font-medium transition-all">
+                  <%= cost %>
+                </span>
+              </label>
+            <% end %>
           </div>
         </div>
 
@@ -1919,4 +1936,13 @@
       gap: 1.5rem;
     }
   }
+  /* コストフィルターピル */
+  .cost-pill-3000 { background: #FEE2E2; color: #991B1B; border-color: #FCA5A5; }
+  .cost-pill-2500 { background: #FFEDD5; color: #C2410C; border-color: #FDBA74; }
+  .cost-pill-2000 { background: #FEF9C3; color: #A16207; border-color: #FDE047; }
+  .cost-pill-1500 { background: #DCFCE7; color: #166534; border-color: #86EFAC; }
+  input:checked + .cost-pill-3000 { background: #DC2626; color: white; border-color: #DC2626; }
+  input:checked + .cost-pill-2500 { background: #EA580C; color: white; border-color: #EA580C; }
+  input:checked + .cost-pill-2000 { background: #CA8A04; color: white; border-color: #CA8A04; }
+  input:checked + .cost-pill-1500 { background: #16A34A; color: white; border-color: #16A34A; }
 </style>


### PR DESCRIPTION
## Summary

- 統計ページの個人統計フィルターにコスト絞り込みを追加（1500 / 2000 / 2500 / 3000）
- 対戦履歴ページに使用機体フィルター（Tom Select）とコスト絞り込みを追加
- コストフィルターのピルは `cost_badge` と同じカラーデザインを適用（OFF=淡色、ON=濃色）

## Test plan

- [x] 統計ページ > 個人統計タブでコストを選択し、対象試合が絞り込まれること
- [x] 統計ページ > タブ切り替え時にコストフィルターが維持されること
- [x] 対戦履歴 > 使用機体で絞り込み、該当機体が出場した試合のみ表示されること
- [x] 対戦履歴 > コストで絞り込み、該当コストが出場した試合のみ表示されること
- [x] 使用機体とコストを同時指定すると AND 条件で絞り込まれること
- [x] ソート切り替え・表示件数変更時にフィルター値が維持されること
- [x] クリアボタンでフィルターがリセットされること

Closes #130