### PR TITLE
feat: 統計個人タブのフィルターUIを統一リデザイン

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -39,7 +39,16 @@ class StatisticsController < ApplicationController
     # フィルター用のデータ
     @all_events = Event.order(held_on: :desc)
     @all_mobile_suits = MobileSuit.order(:name)
-    @all_partners = User.regular_users.where.not(id: viewing_as_user.id).order(:nickname)
+    all_partners = User.regular_users.where.not(id: viewing_as_user.id).order(:nickname)
+    if @filter_events.any?
+      partner_ids_in_events = MatchPlayer.joins(:match)
+                                         .where(matches: { event_id: @filter_events })
+                                         .where.not(user_id: viewing_as_user.id)
+                                         .distinct
+                                         .pluck(:user_id)
+      all_partners = all_partners.where(id: partner_ids_in_events)
+    end
+    @all_partners = all_partners
   end
 
   private

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -135,106 +135,74 @@
       </div>
     </div>
   <% else %>
-  <% stat_filter_active_count = @filter_events.size + @filter_mobile_suits.size + @filter_partners.size + @filter_costs.size %>
-  <% if stat_filter_active_count > 0 %>
-    <% stat_cost_chip_colors = { 3000 => 'bg-red-500 text-white border-red-500', 2500 => 'bg-orange-500 text-white border-orange-500', 2000 => 'bg-yellow-400 text-white border-yellow-400', 1500 => 'bg-green-500 text-white border-green-500' } %>
-    <% stat_base_chip = { tab: @active_tab } %>
-    <% stat_chip_url = ->(overrides) { statistics_path(stat_base_chip.merge({ events: @filter_events, mobile_suits: @filter_mobile_suits, partners: @filter_partners, costs: @filter_costs }.merge(overrides))) } %>
-    <% x_svg = '<svg class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>'.html_safe %>
-  <% end %>
-  <details class="group/filter bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6">
-    <summary class="filter-summary select-none cursor-pointer flex items-start justify-between gap-3 px-5 py-4 border-b border-transparent group-open/filter:border-gray-100 hover:bg-gray-50/70 transition-colors">
-      <div class="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 flex-1 min-w-0">
-        <div class="flex items-center gap-2 shrink-0">
-          <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-indigo-50 text-indigo-500">
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L13 13.414V19a1 1 0 01-.553.894l-4 2A1 1 0 017 21v-7.586L3.293 6.707A1 1 0 013 6V4z"/>
-            </svg>
-          </div>
-          <span class="text-base font-semibold text-gray-800">フィルター</span>
-        </div>
-        <% if stat_filter_active_count > 0 %>
-          <% @all_events.select { |e| @filter_events.include?(e.id) }.each do |event| %>
-            <span class="filter-chip"><span class="filter-chip-label">イベント: <%= event.name %></span><%= link_to stat_chip_url.call(events: @filter_events - [event.id]), class: "filter-chip-x" do %><%= x_svg %><% end %></span>
-          <% end %>
-          <% @all_mobile_suits.select { |s| @filter_mobile_suits.include?(s.id) }.each do |suit| %>
-            <span class="filter-chip"><span class="filter-chip-label"><%= suit.name %></span><%= link_to stat_chip_url.call(mobile_suits: @filter_mobile_suits - [suit.id]), class: "filter-chip-x" do %><%= x_svg %><% end %></span>
-          <% end %>
-          <% @all_partners.select { |p| @filter_partners.include?(p.id) }.each do |partner| %>
-            <span class="filter-chip"><span class="filter-chip-label">パートナー: <%= partner.nickname %></span><%= link_to stat_chip_url.call(partners: @filter_partners - [partner.id]), class: "filter-chip-x" do %><%= x_svg %><% end %></span>
-          <% end %>
-          <% @filter_costs.each do |cost| %>
-            <span class="inline-flex items-center gap-1 pl-2.5 pr-1 py-0.5 rounded-full text-xs font-semibold border <%= stat_cost_chip_colors[cost] %>">
-              <%= cost %><%= link_to stat_chip_url.call(costs: @filter_costs - [cost]), class: "flex items-center opacity-80 hover:opacity-100 ml-0.5" do %><%= x_svg %><% end %>
-            </span>
-          <% end %>
-          <%= link_to "すべてクリア", statistics_path(tab: @active_tab), class: "text-xs font-medium text-red-400 hover:text-red-600 transition-colors shrink-0" %>
-        <% end %>
-      </div>
-      <svg class="h-4 w-4 text-gray-400 transition-transform duration-200 group-open/filter:rotate-180 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-      </svg>
-    </summary>
-
-    <div class="filter-body px-5 pb-5">
-      <!-- フィルターフォーム -->
-      <%= form_with url: statistics_path, method: :get, local: true, class: "mt-4 space-y-4" do |form| %>
-        <%= hidden_field_tag :tab, @active_tab %>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div class="space-y-1.5">
-            <label class="text-xs font-semibold text-gray-500 uppercase tracking-wide">イベント</label>
-            <select name="events[]" id="event-filter" multiple class="w-full">
-              <% @all_events.each do |event| %>
-                <option value="<%= event.id %>" <%= 'selected' if @filter_events.include?(event.id) %>>
-                  <%= event.name %> (<%= event.held_on.strftime('%Y/%m/%d') %>)
-                </option>
-              <% end %>
-            </select>
-          </div>
-          <div class="space-y-1.5">
-            <label class="text-xs font-semibold text-gray-500 uppercase tracking-wide">パートナー</label>
-            <select name="partners[]" id="partner-filter" multiple class="w-full">
-              <% @all_partners.each do |partner| %>
-                <option value="<%= partner.id %>" <%= 'selected' if @filter_partners.include?(partner.id) %>>
-                  <%= partner.nickname %>
-                </option>
-              <% end %>
-            </select>
-          </div>
-        </div>
-
-        <!-- 機体・コスト（統合・連動） -->
-        <div class="rounded-xl border border-gray-200 bg-gray-50/40 p-4 space-y-3">
-          <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide">機体・コスト</p>
-          <div class="flex flex-wrap items-center gap-2">
-            <% [3000, 2500, 2000, 1500].each do |cost| %>
-              <label class="cursor-pointer select-none">
-                <input type="checkbox" name="costs[]" value="<%= cost %>"
-                       <%= 'checked' if @filter_costs.include?(cost) %>
-                       class="sr-only stat-cost-filter-cb">
-                <span class="cost-pill cost-pill-<%= cost %> inline-flex items-center px-3 py-1.5 rounded-full border text-sm font-semibold transition-all shadow-sm">
-                  <%= cost %>
-                </span>
-              </label>
-            <% end %>
-            <span class="text-xs text-gray-400 ml-1">コストを選ぶと機体リストが絞り込まれます</span>
-          </div>
-          <select name="mobile_suits[]" id="mobile-suit-filter" multiple class="w-full">
-            <% @all_mobile_suits.each do |suit| %>
-              <option value="<%= suit.id %>" data-cost="<%= suit.cost %>" <%= 'selected' if @filter_mobile_suits.include?(suit.id) %>>
-                <%= suit.name %> (<%= suit.cost %>)
-              </option>
-            <% end %>
-          </select>
-        </div>
-
-        <div class="flex items-center justify-end gap-3 pt-2 border-t border-gray-100">
-          <%= link_to "クリア", statistics_path(tab: @active_tab), class: "px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors" %>
-          <%= form.submit "適用", class: "px-5 py-2 text-sm font-semibold text-white bg-indigo-600 hover:bg-indigo-700 active:bg-indigo-800 rounded-lg shadow-sm transition-colors cursor-pointer" %>
-        </div>
+  <%
+    ev_base   = { tab: @active_tab, partners: @filter_partners, costs: @filter_costs, mobile_suits: @filter_mobile_suits }
+    pt_base   = { tab: @active_tab, events: @filter_events, costs: @filter_costs, mobile_suits: @filter_mobile_suits }
+    suit_base = { tab: @active_tab, events: @filter_events, partners: @filter_partners }
+    no_suit_cost = @filter_mobile_suits.empty? && @filter_costs.empty?
+    seg_btn = "px-3 py-1.5 rounded-lg text-sm font-semibold transition-all whitespace-nowrap"
+  %>
+  <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4 space-y-3">
+    <!-- イベント -->
+    <div class="flex items-center flex-wrap gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">イベント</span>
+      <%= link_to "全イベント", statistics_path(ev_base),
+          class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      <% @all_events.each do |event| %>
+        <%= link_to event.name, statistics_path(ev_base.merge(events: [event.id])),
+            class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events == [event.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
       <% end %>
     </div>
-  </details>
+
+    <!-- パートナー -->
+    <div class="flex items-center flex-wrap gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">パートナー</span>
+      <%= link_to "全員", statistics_path(pt_base),
+          class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_partners.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      <% @all_partners.each do |partner| %>
+        <%= link_to partner.nickname, statistics_path(pt_base.merge(partners: [partner.id])),
+            class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_partners == [partner.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      <% end %>
+    </div>
+
+    <!-- 機体・コスト -->
+    <div class="flex flex-wrap items-center gap-3">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">機体・コスト</span>
+      <div class="flex rounded-xl bg-gray-100 p-1 gap-0.5 shrink-0">
+        <%= link_to "全体", statistics_path(suit_base),
+            class: "#{seg_btn} #{no_suit_cost ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}" %>
+        <% [[3000, 'bg-red-500 text-white shadow-sm', 'text-red-500 hover:bg-red-100/80'],
+            [2500, 'bg-orange-500 text-white shadow-sm', 'text-orange-500 hover:bg-orange-100/80'],
+            [2000, 'bg-yellow-400 text-gray-900 shadow-sm', 'text-yellow-600 hover:bg-yellow-100/80'],
+            [1500, 'bg-green-500 text-white shadow-sm', 'text-green-600 hover:bg-green-100/80']].each do |cost, active_cls, inactive_cls| %>
+          <% is_cost_active = @filter_costs == [cost] && @filter_mobile_suits.empty? %>
+          <% cost_target = is_cost_active ? statistics_path(suit_base) : statistics_path(suit_base.merge(costs: [cost])) %>
+          <%= link_to cost.to_s, cost_target,
+              class: "#{seg_btn} #{is_cost_active ? active_cls : inactive_cls}" %>
+        <% end %>
+      </div>
+      <div class="flex-1 min-w-[180px] max-w-xs">
+        <select id="stat-suit-select" class="w-full">
+          <option value="">機体を検索...</option>
+          <% visible_suits = @filter_costs.any? ? @all_mobile_suits.select { |s| @filter_costs.include?(s.cost) } : @all_mobile_suits %>
+          <% visible_suits.each do |suit| %>
+            <option value="<%= suit.id %>" <%= 'selected' if @filter_mobile_suits.include?(suit.id) %>>
+              <%= suit.name %> (<%= suit.cost %>)
+            </option>
+          <% end %>
+        </select>
+      </div>
+      <% unless no_suit_cost %>
+        <%= link_to statistics_path(suit_base),
+            class: "flex items-center gap-1 text-xs text-gray-400 hover:text-red-500 transition-colors shrink-0" do %>
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+          クリア
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 
   <% end %>
 
@@ -2186,83 +2154,41 @@
   })();
 </script>
 
-<!-- Initialize Charts and Tom Select -->
+<!-- Initialize Charts and Statistics page -->
 <script>
+  // 機体セレクトの変更でナビゲート（コスト・機体フィルター）
+  window.navigateStatSuit = function(suitId) {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('mobile_suits[]');
+    url.searchParams.delete('costs[]');
+    if (suitId) { url.searchParams.set('mobile_suits[]', suitId); }
+    window.location.href = url.toString();
+  };
+
   (function() {
-    // TomSelectインスタンスを管理
-    const tomSelectSelectors = ['#event-filter', '#mobile-suit-filter', '#partner-filter'];
-    const placeholders = {
-      '#event-filter': 'イベントを選択...',
-      '#mobile-suit-filter': '機体を選択...',
-      '#partner-filter': 'パートナーを選択...'
-    };
-
-    function destroyTomSelects() {
-      tomSelectSelectors.forEach(selector => {
-        const element = document.querySelector(selector);
-        if (element && element.tomselect) {
-          element.tomselect.destroy();
+    function initStatSuitSelect() {
+      const el = document.querySelector('#stat-suit-select');
+      if (!el || el.tomselect) return;
+      new TomSelect('#stat-suit-select', {
+        placeholder: '機体を検索...',
+        maxOptions: null,
+        dropdownParent: 'body',
+        onChange: function(value) {
+          navigateStatSuit(value);
         }
       });
     }
 
-    // TomSelect 初期化前に機体オプションを全件キャプチャ
-    let allStatSuitOptions = [];
-    const statNativeSelect = document.querySelector('#mobile-suit-filter');
-    if (statNativeSelect) {
-      allStatSuitOptions = Array.from(statNativeSelect.options).map(opt => ({
-        value: opt.value,
-        text: opt.text,
-        cost: parseInt(opt.dataset.cost)
-      }));
+    function destroyStatSuitSelect() {
+      const el = document.querySelector('#stat-suit-select');
+      if (el && el.tomselect) el.tomselect.destroy();
     }
 
-    function initTomSelects() {
-      tomSelectSelectors.forEach(selector => {
-        const element = document.querySelector(selector);
-        if (element && !element.tomselect) {
-          new TomSelect(selector, {
-            plugins: ['remove_button'],
-            placeholder: placeholders[selector],
-            maxOptions: null,
-            dropdownParent: 'body'
-          });
-        }
-      });
-      syncStatSuitsToSelectedCosts();
-      document.querySelectorAll('.stat-cost-filter-cb').forEach(cb => {
-        cb.removeEventListener('change', syncStatSuitsToSelectedCosts);
-        cb.addEventListener('change', syncStatSuitsToSelectedCosts);
-      });
-    }
-
-    function syncStatSuitsToSelectedCosts() {
-      const ts = document.querySelector('#mobile-suit-filter')?.tomselect;
-      if (!ts || allStatSuitOptions.length === 0) return;
-
-      const selectedCosts = Array.from(document.querySelectorAll('.stat-cost-filter-cb:checked'))
-        .map(cb => parseInt(cb.value));
-
-      const visible = selectedCosts.length === 0
-        ? allStatSuitOptions
-        : allStatSuitOptions.filter(o => selectedCosts.includes(o.cost));
-
-      const visibleValues = new Set(visible.map(o => String(o.value)));
-      const current = [].concat(ts.getValue()).filter(Boolean);
-      current.forEach(v => { if (!visibleValues.has(String(v))) ts.removeItem(v, true); });
-
-      ts.clearOptions();
-      visible.forEach(o => ts.addOption({ value: String(o.value), text: o.text }));
-      ts.refreshOptions(false);
-    }
-
-    // Turboキャッシュ前にTomSelectを破棄
-    document.addEventListener('turbo:before-cache', destroyTomSelects);
+    document.addEventListener('turbo:before-cache', destroyStatSuitSelect);
 
     // Initialize function that will be called on load
     window.initializeStatisticsPage = function() {
-      // Initialize Tom Select
-      initTomSelects();
+      initStatSuitSelect();
 
       // Sortable tables
       if (typeof initSortableTables === 'function') {
@@ -2457,26 +2383,6 @@
       gap: 1.5rem;
     }
   }
-  /* summary マーカー非表示 */
-  .filter-summary { list-style: none; }
-  .filter-summary::-webkit-details-marker { display: none; }
-  /* フィルターパネル開閉アニメーション */
-  details.group\/filter > .filter-body { animation: filterSlideIn 160ms ease-out; }
-  @keyframes filterSlideIn {
-    from { opacity: 0; transform: translateY(-6px); }
-    to   { opacity: 1; transform: translateY(0); }
-  }
-  /* アクティブフィルターチップ */
-  .filter-chip {
-    display: inline-flex; align-items: center; gap: 2px;
-    padding: 0.2rem 0.25rem 0.2rem 0.6rem;
-    border-radius: 9999px; font-size: 0.7rem; font-weight: 500;
-    background: white; border: 1px solid #c7d2fe; color: #4338ca;
-    box-shadow: 0 1px 2px rgba(0,0,0,.06);
-  }
-  .filter-chip-label { white-space: nowrap; }
-  .filter-chip-x { display: flex; align-items: center; color: #a5b4fc; transition: color .15s; }
-  .filter-chip-x:hover { color: #4338ca; }
   /* コストフィルターピル（未選択） */
   .cost-pill-3000 { background: #FEE2E2; color: #991B1B; border-color: #FCA5A5; }
   .cost-pill-2500 { background: #FFEDD5; color: #C2410C; border-color: #FDBA74; }


### PR DESCRIPTION
## Summary
- 全個人タブのフィルターUIを `<details>` 折りたたみ式からボタン式カードに刷新
- **イベント**: 「全イベント」＋各イベントのボタン（シングルセレクト、クリックで即反映）
- **パートナー**: 「全員」＋各パートナーのボタン（シングルセレクト、クリックで即反映）
  - イベントを選択した場合、そのイベントに参加したメンバーのみボタンを表示
- **機体・コスト**: セグメントコントロール形式のコストボタン（全体/3000/2500/2000/1500）＋検索付き機体TomSelect
  - コストを選択すると、機体リストが該当コストのみに絞り込まれる

## Test plan
- [x] 各個人タブ（総合戦績、プレイ分析、イベント別、機体別等）でフィルターカードが常時表示される
- [x] イベントボタンをクリックすると選択状態（インジゴ）になり、データが絞り込まれる
- [x] イベント選択後、パートナーボタンがそのイベント参加者のみに絞り込まれる
- [x] 「全員」ボタンでパートナーフィルターがリセットされる
- [x] コストボタンをクリックすると機体リストが該当コストのみになる
- [x] 機体TomSelectでテキスト入力検索ができる
- [x] 機体を選択すると即ナビゲートされる
- [x] 「クリア」リンクでコスト・機体フィルターがリセットされる
- [x] 全体・ハイライトタブは従来のシンプルなイベントボタン表示のまま

Closes #138