### PR TITLE
style: 統計ページ全体タブのフィルター UI を個人タブのフォーマットに統一

### DIFF
--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -122,15 +122,15 @@
 
   <!-- Common Filters -->
   <% if @active_tab == 'overall' || @active_tab == 'highlights' %>
-    <!-- 全体系タブ: シンプルなイベント選択 -->
-    <div class="bg-white shadow rounded-lg px-6 py-4 mb-6">
+    <!-- 全体系タブ: イベント選択 -->
+    <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4 space-y-3">
       <div class="flex items-center flex-wrap gap-2">
-        <span class="text-sm font-medium text-gray-700 mr-2">対象:</span>
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">イベント</span>
         <%= link_to "全イベント", statistics_path(tab: @active_tab),
-            class: "px-3 py-1.5 text-sm font-medium rounded-md #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+            class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
         <% @all_events.each do |event| %>
           <%= link_to event.name, statistics_path(tab: @active_tab, events: [event.id]),
-              class: "px-3 py-1.5 text-sm font-medium rounded-md #{@filter_events.include?(event.id) ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+              class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events == [event.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 全体タブ（全体統計・ハイライト）のフィルターコンテナを `rounded-xl shadow-sm ring-1` の新式スタイルに変更
- ラベルを `対象:` から `イベント`（`text-xs font-semibold uppercase tracking-wide`）に変更し、個人タブと表記・スタイルを統一
- ボタンに `transition-colors` を追加
- イベントのアクティブ判定を `include?` から `==` による単一選択方式（個人タブと同方式）に変更

## Test plan
- [x] 全体統計タブのフィルターが個人タブと同じ見た目になっていること
- [x] ハイライトタブのフィルターも同様に統一されていること
- [x] 全イベント・各イベントの選択が正しく動作すること（アクティブ状態の青ハイライト）

## 関連 Issue・PR
#141