### PR TITLE
fix: プレイ分析・自己比較バーグラフの表示不具合を修正

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -839,17 +839,21 @@ class StatisticsController < ApplicationController
     n = mps.size
     return nil if n == 0
 
-    sum_field = ->(field) { mps.sum { |mp| mp.send(field).to_f } }
+    # nil フィールドを除外して平均を計算する（nil.to_f = 0 による不正な平均を防ぐ）
+    avg_field = ->(field) {
+      valid = mps.select { |mp| mp.send(field).present? }
+      valid.any? ? (valid.sum { |mp| mp.send(field).to_f } / valid.size) : nil
+    }
     {
       count:           n,
-      score:           (sum_field.call(:score)          / n).round(1),
-      kills:           (sum_field.call(:kills)           / n).round(2),
-      deaths:          (sum_field.call(:deaths)          / n).round(2),
-      damage_dealt:    (sum_field.call(:damage_dealt)    / n).round(0),
-      damage_received: (sum_field.call(:damage_received) / n).round(0),
-      exburst_damage:  (sum_field.call(:exburst_damage)  / n).round(0),
-      exburst_count:   (sum_field.call(:exburst_count)   / n).round(2),
-      exburst_deaths:  (sum_field.call(:exburst_deaths)  / n).round(2),
+      score:           avg_field.call(:score)&.round(1),
+      kills:           avg_field.call(:kills)&.round(2),
+      deaths:          avg_field.call(:deaths)&.round(2),
+      damage_dealt:    avg_field.call(:damage_dealt)&.round(0),
+      damage_received: avg_field.call(:damage_received)&.round(0),
+      exburst_damage:  avg_field.call(:exburst_damage)&.round(0),
+      exburst_count:   avg_field.call(:exburst_count)&.round(2),
+      exburst_deaths:  avg_field.call(:exburst_deaths)&.round(2),
       exburst_death_rate: begin
                             total_count  = mps.sum { |mp| mp.exburst_count.to_i }
                             total_deaths = mps.sum { |mp| mp.exburst_deaths.to_i }

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1925,6 +1925,8 @@
                             <span class="text-gray-300 font-normal">-</span>
                           <% elsif row[:na_if_nil] && col[:perf][row[:key]].nil? %>
                             <span class="text-gray-400 text-xs font-normal">N/A</span>
+                          <% elsif col[:perf][row[:key]].nil? %>
+                            <span class="text-gray-300 font-normal">-</span>
                           <% else %>
                             <%= "#{col[:perf][row[:key]]}#{row[:suffix]}" %>
                           <% end %>
@@ -2007,23 +2009,25 @@
                                   hi    = [user_val.to_f, cmp_val.to_f].max
                                   span  = hi - lo
                                 %>
-                                <% if span >= 0.001 %>
-                                  <%
-                                    pad      = span * 0.5
-                                    dyn_min  = [[(lo - pad).round(2), 0].max, lo].min
-                                    dyn_max  = [(hi + pad).round(2), hi].max
-                                    dyn_range = dyn_max - dyn_min
-                                    user_pct = ((user_val.to_f - dyn_min) / dyn_range * 100).clamp(0, 100).round(1)
-                                    avg_pct  = ((cmp_val.to_f  - dyn_min) / dyn_range * 100).clamp(0, 100).round(1)
-                                  %>
-                                  <div class="relative h-1.5 bg-gray-200 rounded-full mt-2 max-w-[100px] mx-auto">
-                                    <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
-                                    <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= good ? 'bg-green-500' : 'bg-red-500' %>" style="left: <%= user_pct %>%"></div>
-                                  </div>
-                                  <div class="flex justify-between text-[10px] text-gray-400 mt-1 max-w-[100px] mx-auto">
-                                    <span><%= dyn_min %><%= row[:suffix] %></span>
-                                    <span><%= dyn_max %><%= row[:suffix] %></span>
-                                  </div>
+                                <%
+                                  pad       = span >= 0.001 ? span * 0.5 : [user_val.to_f * 0.1, 0.5].max
+                                  dyn_min   = [[(lo - pad).round(2), 0].max, lo].min
+                                  dyn_max   = [(hi + pad).round(2), hi].max
+                                  dyn_range = dyn_max - dyn_min
+                                  user_pct  = (dyn_range > 0 ? (user_val.to_f - dyn_min) / dyn_range * 100 : 50).clamp(0, 100).round(1)
+                                  avg_pct   = (dyn_range > 0 ? (cmp_val.to_f  - dyn_min) / dyn_range * 100 : 50).clamp(0, 100).round(1)
+                                  dot_color = span >= 0.001 ? (good ? 'bg-green-500' : 'bg-red-500') : 'bg-gray-400'
+                                %>
+                                <div class="relative h-1.5 bg-gray-200 rounded-full mt-2 max-w-[100px] mx-auto">
+                                  <div class="absolute -top-1 -bottom-1 w-0.5 bg-gray-400 rounded-full" style="left: <%= avg_pct %>%"></div>
+                                  <div class="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm <%= dot_color %>" style="left: <%= user_pct %>%"></div>
+                                </div>
+                                <div class="flex justify-between text-[10px] text-gray-400 mt-1 max-w-[100px] mx-auto">
+                                  <span><%= dyn_min %><%= row[:suffix] %></span>
+                                  <span><%= dyn_max %><%= row[:suffix] %></span>
+                                </div>
+                                <% if span < 0.001 %>
+                                  <span class="text-xs text-gray-400">差分なし</span>
                                 <% end %>
                                 <% unless diff.abs < 0.005 %>
                                   <span class="inline-block mt-1 px-1.5 py-0.5 rounded text-xs font-semibold <%= good ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' %>">


### PR DESCRIPTION
## Summary
- 自己比較（同コスト帯平均）のバーグラフが、フィルター機体とコスト帯平均の値が等しい場合に表示されない不具合を修正
- `calc_perf_stats` で nil フィールドを `0` として平均に含めていた問題を修正

## 原因
- **バーグラフ非表示**: `span < 0.001`（値が等しい）のときバー描画をスキップする条件があり、グラフが一切表示されなかった
- **平均値の不正確さ（予防的修正）**: `nil.to_f = 0.0` により、統計データが存在しないフィールドが 0 として平均に混入する可能性があった

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `calc_perf_stats` の平均計算 | `nil.to_f = 0` を含む全レコードで割る | nil フィールドを除外したレコードのみで平均を算出 |
| 自己比較バー（等値時） | `span < 0.001` のとき非描画 | フォールバックパディング（`max(val*0.1, 0.5)`）で常に描画、グレードットで「差分なし」表示 |
| 自己比較バー（0値時） | `dyn_min` が負になる可能性 | `0` フロアを維持し負の軸ラベルが出ない |
| nil フィールドの値セル | 未対応（エラーになる可能性） | `-` を表示 |

## Test plan
- [x] 統計ページ → プレイ分析タブ → 機体フィルター（νガンダムHWS）→ 比較対象：自分 → コスト範囲：3000コスト を選択
- [x] 被撃墜数（敗北時、3000コスト平均）列にバーグラフ・「差分なし」が表示されること
- [x] 値が異なる他の指標（スコア・キル数等）は通常通り緑/赤のバーと差分バッジが表示されること
- [x] 値が 0 の場合に最小値ラベルが負にならないこと

Closes #147