### PR TITLE
feat: マイページ新設とお気に入り機体設定機能の追加

### DIFF
--- a/app/controllers/my_page_controller.rb
+++ b/app/controllers/my_page_controller.rb
@@ -1,0 +1,16 @@
+class MyPageController < ApplicationController
+  before_action :authenticate_user!
+
+  COSTS = [ 3000, 2500, 2000, 1500 ].freeze
+
+  def show
+    @favorites_by_slot = current_user.user_favorite_suits
+                                     .includes(:mobile_suit)
+                                     .index_by(&:slot)
+    @selected_suit_ids = (0..11).filter_map { |s| @favorites_by_slot[s]&.mobile_suit_id }
+
+    @all_suits      = MobileSuit.all.order(:id)
+    @costs          = COSTS
+    @counts_by_cost = MobileSuit.group(:cost).count
+  end
+end

--- a/app/controllers/user_favorite_suits_controller.rb
+++ b/app/controllers/user_favorite_suits_controller.rb
@@ -1,0 +1,18 @@
+class UserFavoriteSuitsController < ApplicationController
+  before_action :authenticate_user!
+
+  def bulk_update
+    ids = Array(params[:mobile_suit_ids]).map(&:to_i).first(UserFavoriteSuit::MAX_SLOTS)
+    valid_ids = MobileSuit.where(id: ids).pluck(:id)
+    ordered_ids = ids.select { |id| valid_ids.include?(id) }
+
+    ActiveRecord::Base.transaction do
+      current_user.user_favorite_suits.delete_all
+      ordered_ids.each_with_index do |suit_id, slot|
+        current_user.user_favorite_suits.create!(mobile_suit_id: suit_id, slot: slot)
+      end
+    end
+
+    redirect_to my_page_path, notice: "お気に入り機体を更新しました"
+  end
+end

--- a/app/javascript/controllers/favorite_picker_controller.js
+++ b/app/javascript/controllers/favorite_picker_controller.js
@@ -1,0 +1,270 @@
+import { Controller } from "@hotwired/stimulus"
+
+const SLOT_LABELS = ["M", "S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8", "S9", "S10", "S11"]
+const MAX_SLOTS = 12
+
+const COST_STYLES = {
+  "":     { active: "bg-white shadow text-gray-900",         inactive: "text-gray-500 hover:text-gray-700" },
+  "3000": { active: "bg-red-500 text-white shadow-sm",       inactive: "text-red-500 hover:bg-red-100/80" },
+  "2500": { active: "bg-orange-500 text-white shadow-sm",    inactive: "text-orange-500 hover:bg-orange-100/80" },
+  "2000": { active: "bg-yellow-400 text-gray-900 shadow-sm", inactive: "text-yellow-600 hover:bg-yellow-100/80" },
+  "1500": { active: "bg-green-500 text-white shadow-sm",     inactive: "text-green-600 hover:bg-green-100/80" },
+}
+const COST_TAB_BASE = "flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-semibold text-sm transition-all whitespace-nowrap"
+
+export default class extends Controller {
+  static targets = ["modal", "form", "tray", "countBadge", "saveBtn", "searchInput"]
+  static values  = { initial: Array }
+
+  connect() {
+    this.selected     = [...this.initialValue]
+    this._currentCost = ""
+    this._sortable    = null
+    this._trayHandler = this._onTrayClick.bind(this)
+    this.trayTarget.addEventListener("click", this._trayHandler)
+  }
+
+  disconnect() {
+    this.trayTarget.removeEventListener("click", this._trayHandler)
+    if (this._sortable) this._sortable.destroy()
+  }
+
+  // ── 開閉 ──────────────────────────────────────────
+
+  open() {
+    this.selected = [...this.initialValue]
+    this.modalTarget.classList.remove("hidden")
+    document.body.style.overflow = "hidden"
+    this._resetFilters()
+    this._renderAll()
+  }
+
+  close() {
+    this.modalTarget.classList.add("hidden")
+    document.body.style.overflow = ""
+  }
+
+  // ── 機体選択トグル ────────────────────────────────
+
+  toggleSuit(event) {
+    const card = event.currentTarget
+    const id   = parseInt(card.dataset.suitId)
+    const idx  = this.selected.indexOf(id)
+
+    if (idx >= 0) {
+      this.selected.splice(idx, 1)
+    } else if (this.selected.length < MAX_SLOTS) {
+      this.selected.push(id)
+    }
+    this._renderAll()
+  }
+
+  clearAll() {
+    this.selected = []
+    this._renderAll()
+  }
+
+  // ── 保存 ──────────────────────────────────────────
+
+  save() {
+    const form = this.formTarget
+    form.querySelectorAll("input[name='mobile_suit_ids[]']").forEach(el => el.remove())
+    this.selected.forEach(id => {
+      const input   = document.createElement("input")
+      input.type    = "hidden"
+      input.name    = "mobile_suit_ids[]"
+      input.value   = id
+      form.appendChild(input)
+    })
+    form.requestSubmit()
+    this.close()
+  }
+
+  // ── フィルター ────────────────────────────────────
+
+  search(event) {
+    const q = event.target.value.trim().toLowerCase()
+    this.element.querySelectorAll("[data-suit-wrapper]").forEach(wrapper => {
+      const nameMatch = !q || wrapper.dataset.suitName.toLowerCase().includes(q)
+      const costMatch = !this._currentCost || wrapper.dataset.suitCost === this._currentCost
+      wrapper.style.display = (nameMatch && costMatch) ? "" : "none"
+    })
+  }
+
+  filterCost(event) {
+    const cost        = event.currentTarget.dataset.cost
+    this._currentCost = cost
+
+    this.element.querySelectorAll("[data-cost-btn]").forEach(btn => {
+      const isActive     = btn.dataset.cost === cost
+      btn.dataset.active = isActive ? "true" : "false"
+      const s            = COST_STYLES[btn.dataset.cost] || COST_STYLES[""]
+      btn.className      = `${COST_TAB_BASE} ${isActive ? s.active : s.inactive}`
+    })
+
+    const q = this.hasSearchInputTarget ? this.searchInputTarget.value.trim().toLowerCase() : ""
+    this.element.querySelectorAll("[data-suit-wrapper]").forEach(wrapper => {
+      const nameMatch = !q || wrapper.dataset.suitName.toLowerCase().includes(q)
+      const costMatch = !cost || wrapper.dataset.suitCost === cost
+      wrapper.style.display = (nameMatch && costMatch) ? "" : "none"
+    })
+  }
+
+  // ── プライベート ──────────────────────────────────
+
+  _resetFilters() {
+    this._currentCost = ""
+    this.element.querySelectorAll("[data-suit-wrapper]").forEach(w => w.style.display = "")
+    this.element.querySelectorAll("[data-cost-btn]").forEach(btn => {
+      const isActive     = btn.dataset.cost === ""
+      btn.dataset.active = isActive ? "true" : "false"
+      const s            = COST_STYLES[btn.dataset.cost] || COST_STYLES[""]
+      btn.className      = `${COST_TAB_BASE} ${isActive ? s.active : s.inactive}`
+    })
+    if (this.hasSearchInputTarget) this.searchInputTarget.value = ""
+  }
+
+  _renderAll() {
+    this._updateCards()
+    this._renderTray()
+    this._updateCounter()
+  }
+
+  _updateCards() {
+    this.element.querySelectorAll("[data-suit-id]").forEach(card => {
+      const id      = parseInt(card.dataset.suitId)
+      const slotIdx = this.selected.indexOf(id)
+      const badge   = card.querySelector("[data-slot-badge]")
+
+      if (slotIdx >= 0) {
+        card.classList.add("ring-2", "ring-indigo-500", "border-indigo-400")
+        card.classList.remove("border-gray-200", "hover:border-indigo-300")
+        let overlay = card.querySelector("[data-picker-overlay]")
+        if (!overlay) {
+          overlay = document.createElement("div")
+          overlay.dataset.pickerOverlay = ""
+          overlay.className = "absolute inset-0 bg-indigo-500/8 pointer-events-none rounded-xl"
+          card.appendChild(overlay)
+        }
+        if (badge) {
+          badge.textContent = SLOT_LABELS[slotIdx]
+          badge.classList.remove("hidden")
+          badge.classList.add("flex")
+        }
+      } else {
+        card.classList.remove("ring-2", "ring-indigo-500", "border-indigo-400")
+        card.classList.add("border-gray-200", "hover:border-indigo-300")
+        const overlay = card.querySelector("[data-picker-overlay]")
+        if (overlay) overlay.remove()
+        if (badge) {
+          badge.classList.add("hidden")
+          badge.classList.remove("flex")
+        }
+      }
+    })
+  }
+
+  _renderTray() {
+    if (this._sortable) {
+      this._sortable.destroy()
+      this._sortable = null
+    }
+
+    if (this.selected.length === 0) {
+      this.trayTarget.innerHTML = `<p class="col-span-6 text-sm text-gray-400 italic py-4 text-center">機体をクリックして追加…</p>`
+      return
+    }
+
+    const suitMap = this._buildSuitMap()
+    this.trayTarget.innerHTML = this.selected.map((id, idx) => {
+      const s          = suitMap[id] || {}
+      const label      = SLOT_LABELS[idx]
+      const isMain     = idx === 0
+      const badgeColor = isMain ? "bg-indigo-600" : "bg-indigo-400"
+      const img        = s.image
+        ? `<img src="/mobile_suits/${s.image}" alt="${s.name || ""}" class="w-full h-full object-contain pointer-events-none p-1">`
+        : `<div class="w-full h-full flex items-center justify-center text-gray-300 text-xs">?</div>`
+      return `
+        <div class="tray-item flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none"
+             data-tray-suit-id="${id}">
+          <div class="relative w-full h-14 rounded-xl overflow-hidden bg-gradient-to-b from-gray-50 to-gray-100
+                      border-2 border-indigo-300 transition-all duration-150 shadow-sm">
+            ${img}
+            <span class="absolute top-1 left-1 px-1.5 h-5 min-w-[20px] ${badgeColor} text-white
+                         text-[10px] font-bold rounded-md flex items-center justify-center
+                         pointer-events-none shadow-sm">${label}</span>
+            <button type="button"
+                    class="delete-btn absolute top-1 right-1 w-5 h-5 bg-red-500 hover:bg-red-600 text-white
+                           text-[11px] font-bold rounded-full flex items-center justify-center shadow-md
+                           pointer-events-auto z-10 leading-none"
+                    data-delete-suit-id="${id}">×</button>
+          </div>
+          <span class="text-xs text-gray-600 font-medium leading-tight text-center w-full line-clamp-2 px-0.5
+                       pointer-events-none">${s.name || ""}</span>
+        </div>`
+    }).join("")
+
+    // Sortable を dynamic import で初期化（読み込み失敗でも他機能は壊れない）
+    import("sortablejs").then(({ default: Sortable }) => {
+      if (this._sortable) this._sortable.destroy()
+      this._sortable = new Sortable(this.trayTarget, {
+        animation:   180,
+        easing:      "cubic-bezier(0.25, 1, 0.5, 1)",
+        ghostClass:  "tray-ghost",
+        chosenClass: "tray-chosen",
+        dragClass:   "tray-dragging",
+        onEnd: () => {
+          // DOM の順序から selected を同期
+          const items = this.trayTarget.querySelectorAll("[data-tray-suit-id]")
+          this.selected = Array.from(items).map(el => parseInt(el.dataset.traySuitId))
+          this._updateTrayBadges()
+          this._updateCards()
+          this._updateCounter()
+        },
+      })
+    }).catch(() => {
+      // Sortable が使えない場合はドラッグなしで動作継続
+    })
+  }
+
+  // ドラッグ後にトレイ内バッジのテキストと色だけ更新（DOM再構築なし）
+  _updateTrayBadges() {
+    const items = this.trayTarget.querySelectorAll("[data-tray-suit-id]")
+    items.forEach((item, idx) => {
+      const badge = item.querySelector("span[class*='rounded-md']")
+      if (!badge) return
+      badge.textContent = SLOT_LABELS[idx]
+      // メインとサブで色を切り替え
+      badge.classList.toggle("bg-indigo-600", idx === 0)
+      badge.classList.toggle("bg-indigo-400", idx !== 0)
+    })
+  }
+
+  _onTrayClick(e) {
+    // 削除ボタンのクリック
+    const deleteBtn = e.target.closest("[data-delete-suit-id]")
+    if (deleteBtn) {
+      const id  = parseInt(deleteBtn.dataset.deleteSuitId)
+      this.selected = this.selected.filter(s => s !== id)
+      this._renderAll()
+      return
+    }
+  }
+
+  _updateCounter() {
+    this.countBadgeTarget.textContent = `${this.selected.length} / ${MAX_SLOTS}`
+    this.saveBtnTarget.textContent =
+      this.selected.length > 0 ? `保存（${this.selected.length}機体）` : "保存"
+  }
+
+  _buildSuitMap() {
+    const map = {}
+    this.element.querySelectorAll("[data-suit-id]").forEach(card => {
+      map[parseInt(card.dataset.suitId)] = {
+        name:  card.dataset.suitName  || "",
+        image: card.dataset.suitImage || "",
+      }
+    })
+    return map
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   # Associations
   has_many :match_players, dependent: :destroy
+  has_many :user_favorite_suits, dependent: :destroy
   has_many :push_subscriptions, dependent: :destroy
   has_many :reactions, dependent: :destroy
   has_many :user_announcement_reads, dependent: :destroy

--- a/app/models/user_favorite_suit.rb
+++ b/app/models/user_favorite_suit.rb
@@ -1,0 +1,12 @@
+class UserFavoriteSuit < ApplicationRecord
+  belongs_to :user
+  belongs_to :mobile_suit
+
+  MAX_SLOTS = 12
+  SLOTS = (0..11).freeze
+  SLOT_LABELS = { 0 => "メイン" }.merge((1..11).index_with { |i| "サブ#{i}" }).freeze
+
+  validates :slot, inclusion: { in: SLOTS }
+  validates :slot, uniqueness: { scope: :user_id }
+  validates :mobile_suit_id, uniqueness: { scope: :user_id, message: "はすでに別のスロットに設定されています" }
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -104,8 +104,11 @@
             </div>
           <% end %>
 
-          <!-- 設定・ログアウト -->
+          <!-- マイページ・設定・ログアウト -->
           <div class="space-y-1">
+            <% unless current_user.is_guest? %>
+              <%= link_to "マイページ", my_page_path, class: "sidebar-nav-item-small #{current_page?(my_page_path) ? 'active' : ''}" %>
+            <% end %>
             <% unless current_user.username == 'guest' %>
               <%= link_to "設定", edit_profile_path, class: "sidebar-nav-item-small" %>
             <% end %>
@@ -347,6 +350,9 @@
                     <% end %>
                   </select>
                 </div>
+              <% end %>
+              <% unless current_user.is_guest? %>
+                <%= link_to "マイページ", my_page_path, class: "mobile-menu-item-small #{current_page?(my_page_path) ? 'active' : ''}" %>
               <% end %>
               <% unless current_user.username == 'guest' %>
                 <%= link_to "設定", edit_profile_path, class: "mobile-menu-item-small" %>

--- a/app/views/my_page/_picker_modal.html.erb
+++ b/app/views/my_page/_picker_modal.html.erb
@@ -1,0 +1,168 @@
+<%#
+  locals:
+    suits:          MobileSuit collection
+    costs:          Array of cost integers
+    counts_by_cost: Hash { cost => count }
+%>
+<style>
+  /* SortableJS ドラッグスタイル */
+  .tray-ghost   { opacity: 0.3; }
+  .tray-chosen  { cursor: grabbing !important; }
+  .tray-dragging { opacity: 0.95; transform: scale(1.05); box-shadow: 0 8px 24px rgba(0,0,0,0.18); }
+  /* ドラッグ中は削除ボタンを非表示 */
+  .tray-chosen .delete-btn { opacity: 0 !important; }
+</style>
+<%
+  cost_styles = {
+    ""     => { active: "bg-white shadow text-gray-900",          inactive: "text-gray-500 hover:text-gray-700" },
+    "3000" => { active: "bg-red-500 text-white shadow-sm",        inactive: "text-red-500 hover:bg-red-100/80" },
+    "2500" => { active: "bg-orange-500 text-white shadow-sm",     inactive: "text-orange-500 hover:bg-orange-100/80" },
+    "2000" => { active: "bg-yellow-400 text-gray-900 shadow-sm",  inactive: "text-yellow-600 hover:bg-yellow-100/80" },
+    "1500" => { active: "bg-green-500 text-white shadow-sm",      inactive: "text-green-600 hover:bg-green-100/80" },
+  }
+  cost_tabs = [["", "すべて", counts_by_cost.values.sum]] + costs.map { |c| [c.to_s, c.to_s, counts_by_cost[c] || 0] }
+%>
+
+<div class="fixed inset-0 z-50 hidden"
+     data-favorite-picker-target="modal">
+
+  <%# バックドロップ %>
+  <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+       data-action="click->favorite-picker#close"></div>
+
+  <%# パネル: モバイルは下から、デスクトップは中央 %>
+  <div class="absolute inset-x-0 bottom-0 sm:inset-6 md:inset-10 flex flex-col bg-white rounded-t-3xl sm:rounded-2xl shadow-2xl overflow-hidden max-h-[95vh] sm:max-h-full">
+
+    <%# ── ヘッダー ── %>
+    <div class="flex-shrink-0 flex items-center justify-between px-5 py-4 border-b border-gray-100">
+      <div class="flex items-center gap-3">
+        <h2 class="text-base font-bold text-gray-900">お気に入り機体を選択</h2>
+        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold tabular-nums"
+              data-favorite-picker-target="countBadge">0 / 9</span>
+      </div>
+      <button type="button"
+              class="w-8 h-8 rounded-full flex items-center justify-center text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+              data-action="click->favorite-picker#close">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+        </svg>
+      </button>
+    </div>
+
+    <%# ── 選択中トレイ ── %>
+    <div class="flex-shrink-0 bg-gray-50/80 border-b border-gray-100 px-4 pt-3 pb-2">
+      <div class="flex items-start gap-2">
+        <div class="flex-1 grid grid-cols-6 gap-2"
+             data-favorite-picker-target="tray">
+          <p class="col-span-6 text-sm text-gray-400 italic py-4 text-center self-center">機体をクリックして追加…</p>
+        </div>
+        <button type="button"
+                class="flex-shrink-0 text-xs text-gray-400 hover:text-red-500 font-medium transition-colors px-2 py-1 rounded-lg hover:bg-red-50 mt-1"
+                data-action="click->favorite-picker#clearAll">
+          クリア
+        </button>
+      </div>
+      <p class="mt-1.5 text-[11px] text-indigo-400/80 flex items-center gap-1.5">
+        <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M7 16V4m0 0L3 8m4-4l4 4M17 8v12m0 0l4-4m-4 4l-4-4"/>
+        </svg>
+        ドラッグで順番を変えられます　　× で削除
+      </p>
+    </div>
+
+    <%# ── フィルターバー ── %>
+    <div class="flex-shrink-0 flex flex-wrap items-center gap-2 px-4 py-3 border-b border-gray-100 bg-white">
+      <div class="flex gap-0.5 flex-wrap p-1 bg-gray-100 rounded-xl">
+        <% cost_tabs.each do |val, label, count| %>
+          <% is_all = val.empty? %>
+          <% s = cost_styles[val] %>
+          <button type="button"
+                  class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg font-semibold text-sm transition-all whitespace-nowrap <%= is_all ? s[:active] : s[:inactive] %>"
+                  data-cost-btn
+                  data-cost="<%= val %>"
+                  data-active="<%= is_all ? 'true' : 'false' %>"
+                  data-action="click->favorite-picker#filterCost">
+            <%= label %>
+            <span class="text-xs font-medium"><%= count %></span>
+          </button>
+        <% end %>
+      </div>
+
+      <div class="relative flex-1 min-w-36">
+        <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+          <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"/>
+          </svg>
+        </div>
+        <input type="text"
+               placeholder="機体名で検索…"
+               class="w-full rounded-xl border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm text-gray-800 placeholder-gray-400 shadow-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 transition"
+               data-favorite-picker-target="searchInput"
+               data-action="input->favorite-picker#search">
+      </div>
+    </div>
+
+    <%# ── 機体グリッド ── %>
+    <div class="flex-1 overflow-y-auto px-3 py-3">
+      <div class="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-7 gap-1.5">
+        <% suits.each do |suit| %>
+          <div data-suit-wrapper
+               data-suit-name="<%= suit.name %>"
+               data-suit-cost="<%= suit.cost %>">
+            <div class="suit-picker-card relative flex flex-col rounded-lg overflow-hidden bg-white border border-gray-200 cursor-pointer select-none transition-all duration-150 hover:border-indigo-300 hover:shadow-sm active:scale-95"
+                 data-suit-id="<%= suit.id %>"
+                 data-suit-name="<%= suit.name %>"
+                 data-suit-image="<%= suit.image_filename.to_s %>"
+                 data-action="click->favorite-picker#toggleSuit">
+
+              <%# スロットバッジ（選択時に JS で表示） %>
+              <span class="absolute top-1 left-1 z-10 min-w-[20px] h-5 px-1 bg-indigo-600 text-white text-[9px] font-bold rounded items-center justify-center shadow hidden"
+                    data-slot-badge></span>
+
+              <%# 機体画像 %>
+              <div class="bg-gradient-to-b from-gray-50 to-gray-100 flex items-center justify-center h-14 pointer-events-none">
+                <% if suit.image_filename.present? %>
+                  <%= image_tag "/mobile_suits/#{suit.image_filename}", alt: suit.name,
+                      class: "h-full w-full object-contain p-0.5",
+                      loading: "lazy" %>
+                <% else %>
+                  <svg class="w-6 h-6 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                  </svg>
+                <% end %>
+              </div>
+
+              <%# 機体名 %>
+              <p class="text-[12px] font-medium text-gray-600 leading-tight truncate text-center px-1 py-1 pointer-events-none">
+                <%= suit.name %>
+              </p>
+
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <%# ── フッター ── %>
+    <div class="flex-shrink-0 flex items-center justify-end gap-3 px-5 py-4 border-t border-gray-100 bg-white">
+      <button type="button"
+              class="px-5 py-2.5 rounded-xl border border-gray-200 text-sm font-semibold text-gray-600 hover:bg-gray-50 transition-colors"
+              data-action="click->favorite-picker#close">
+        キャンセル
+      </button>
+      <button type="button"
+              class="px-6 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-bold shadow-sm transition-all duration-150 active:scale-95"
+              data-favorite-picker-target="saveBtn"
+              data-action="click->favorite-picker#save">
+        保存
+      </button>
+    </div>
+
+    <%# 非表示フォーム %>
+    <%= form_with url: bulk_update_user_favorite_suits_path, method: :post,
+                  data: { favorite_picker_target: "form" } do |f| %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/my_page/show.html.erb
+++ b/app/views/my_page/show.html.erb
@@ -1,0 +1,106 @@
+<% content_for :title, "マイページ" %>
+
+<div data-controller="favorite-picker"
+     data-favorite-picker-initial-value="<%= @selected_suit_ids.to_json %>">
+
+  <div class="max-w-4xl mx-auto px-4 py-8">
+
+    <%# ── プロフィールヘッダー ── %>
+    <div class="mb-8 flex items-center gap-4">
+      <div class="w-14 h-14 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center shadow-lg select-none">
+        <span class="text-white font-bold text-2xl"><%= viewing_as_user.nickname[0] %></span>
+      </div>
+      <div>
+        <h1 class="text-xl font-bold text-gray-900 leading-tight"><%= viewing_as_user.nickname %></h1>
+        <p class="text-sm text-gray-400 mt-0.5">@<%= viewing_as_user.username %></p>
+      </div>
+    </div>
+
+    <%# ── お気に入り機体カード ── %>
+    <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+
+      <%# カードヘッダー %>
+      <div class="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+        <div class="flex items-center gap-2.5">
+          <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-indigo-100 to-purple-100 flex items-center justify-center">
+            <svg class="w-4 h-4 text-indigo-600" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+            </svg>
+          </div>
+          <h2 class="text-sm font-bold text-gray-900">お気に入り機体</h2>
+          <% if @favorites_by_slot.any? %>
+            <span class="px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600 text-xs font-semibold">
+              <%= @favorites_by_slot.size %>/12
+            </span>
+          <% end %>
+        </div>
+        <% unless current_user.is_guest? %>
+          <button type="button"
+                  class="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold shadow-sm transition-all duration-150 active:scale-95"
+                  data-action="click->favorite-picker#open">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+            </svg>
+            <%= @favorites_by_slot.empty? ? "設定する" : "編集する" %>
+          </button>
+        <% end %>
+      </div>
+
+      <%# カードボディ %>
+      <div class="p-6">
+        <% if @favorites_by_slot.empty? %>
+          <%# 空状態 %>
+          <div class="flex flex-col items-center justify-center py-12 text-center">
+            <div class="w-16 h-16 rounded-2xl bg-gray-100 flex items-center justify-center mb-4">
+              <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+              </svg>
+            </div>
+            <p class="text-sm font-semibold text-gray-500">まだ設定されていません</p>
+            <p class="text-xs text-gray-400 mt-1">好きな機体を最大12機体まで登録できます</p>
+          </div>
+        <% else %>
+          <%# 設定済みスロット一覧: レスポンシブグリッド %>
+          <div class="grid grid-cols-4 sm:grid-cols-6 gap-3">
+            <% (0..11).each do |slot| %>
+              <% fav = @favorites_by_slot[slot] %>
+              <% next unless fav %>
+              <div class="flex flex-col items-center gap-1.5 min-w-0">
+                <div class="relative w-full">
+                  <%# 画像カード %>
+                  <div class="relative w-full aspect-square rounded-xl overflow-hidden bg-gradient-to-b from-gray-50 to-gray-100 border border-gray-200 shadow-sm flex items-center justify-center">
+                    <% if fav.mobile_suit.image_filename.present? %>
+                      <%= image_tag "/mobile_suits/#{fav.mobile_suit.image_filename}",
+                          alt: fav.mobile_suit.name,
+                          class: "w-full h-full object-contain p-1" %>
+                    <% else %>
+                      <svg class="w-1/2 h-1/2 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                      </svg>
+                    <% end %>
+                  </div>
+                  <%# スロットバッジ %>
+                  <span class="absolute -top-1.5 -left-1.5 px-1.5 min-w-[22px] h-[22px] <%= slot == 0 ? 'bg-indigo-600' : 'bg-indigo-400' %> text-white text-[10px] font-bold rounded-full flex items-center justify-center shadow-md ring-2 ring-white leading-none">
+                    <%= slot == 0 ? "M" : "S#{slot}" %>
+                  </span>
+                </div>
+                <%# 機体名 %>
+                <p class="text-[11px] text-gray-600 font-medium text-center leading-tight line-clamp-2 w-full px-0.5">
+                  <%= fav.mobile_suit.name %>
+                </p>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
+
+  <%# 機体ピッカーモーダル（コントローラー内に配置） %>
+  <%= render "my_page/picker_modal",
+             suits: @all_suits,
+             costs: @costs,
+             counts_by_cost: @counts_by_cost %>
+
+</div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,4 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "sortablejs", to: "https://cdn.jsdelivr.net/npm/sortablejs@1.15.4/+esm"
 pin "@rails/actioncable", to: "@rails--actioncable.js" # @8.1.100

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,14 @@ Rails.application.routes.draw do
   # Dashboard
   get "dashboard", to: "dashboard#index", as: :dashboard
 
+  # My Page
+  get "my_page", to: "my_page#show", as: :my_page
+  resources :user_favorite_suits, only: [] do
+    collection do
+      post :bulk_update
+    end
+  end
+
   # Profile (User settings)
   resource :profile, only: [ :edit, :update ]
 

--- a/db/migrate/20260308140859_create_user_favorite_suits.rb
+++ b/db/migrate/20260308140859_create_user_favorite_suits.rb
@@ -1,0 +1,13 @@
+class CreateUserFavoriteSuits < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_favorite_suits do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :mobile_suit, null: false, foreign_key: true
+      t.integer :slot, null: false
+
+      t.timestamps
+    end
+
+    add_index :user_favorite_suits, [ :user_id, :slot ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_08_083502) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_08_140859) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -178,6 +178,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_08_083502) do
     t.index ["user_id"], name: "index_user_announcement_reads_on_user_id"
   end
 
+  create_table "user_favorite_suits", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "mobile_suit_id", null: false
+    t.integer "slot", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["mobile_suit_id"], name: "index_user_favorite_suits_on_mobile_suit_id"
+    t.index ["user_id", "slot"], name: "index_user_favorite_suits_on_user_id_and_slot", unique: true
+    t.index ["user_id"], name: "index_user_favorite_suits_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "encrypted_password", default: "", null: false
@@ -211,4 +222,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_08_083502) do
   add_foreign_key "rotations", "rotations", column: "base_rotation_id"
   add_foreign_key "user_announcement_reads", "announcements"
   add_foreign_key "user_announcement_reads", "users"
+  add_foreign_key "user_favorite_suits", "mobile_suits"
+  add_foreign_key "user_favorite_suits", "users"
 end


### PR DESCRIPTION
## Summary

- `/my_page` にマイページを新設し、サイドバー・モバイルメニューにナビリンクを追加
- `user_favorite_suits` テーブルを新設（slot 順序保証、最大12機体）
- 機体ピッカーモーダルで複数機体を一括選択して保存（コストタブ・検索フィルター付き）
- 選択済み機体のドラッグ&ドロップによる順番入れ替え（SortableJS）
- メイン（M）＋サブ1〜11のスロット順に自動割り当て（空きスロットなし）

## Test plan

- [ ] サイドバー「マイページ」リンクから遷移できる
- [ ] 「設定する」ボタンでピッカーモーダルが開く
- [ ] コストタブ・検索で機体を絞り込める
- [ ] 機体をクリックしてトレイに追加・×で削除できる
- [ ] トレイ内をドラッグして順番を変えられる
- [ ] 「保存」後にマイページに機体一覧が反映される
- [ ] 「編集する」で既存の選択状態が復元された状態でモーダルが開く
- [ ] ゲストユーザーにはマイページリンクが表示されない

Closes #150