### PR TITLE
feat: お気に入り機体をフィルター・試合記録プルダウンで上位表示する

### DIFF
--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -14,6 +14,14 @@ class RotationsController < ApplicationController
                                   .order(:match_index)
     @current_match = @rotation_matches[@rotation.current_match_index]
     @player_statistics = @rotation.player_statistics
+    @all_mobile_suits = MobileSuit.order(:name).to_a
+
+    # プレイヤーのお気に入り機体を N+1 を起こさずまとめてロード
+    if @current_match
+      players = [ @current_match.team1_player1, @current_match.team1_player2,
+                  @current_match.team2_player1, @current_match.team2_player2 ].compact
+      ActiveRecord::Associations::Preloader.new(records: players, associations: :user_favorite_suits).call
+    end
 
     # Check if we should show completion modal
     if session[:show_completion_modal] == @rotation.id

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,6 +42,33 @@ module ApplicationHelper
     "#{total_sec / 60}:#{format('%02d', total_sec % 60)}"
   end
 
+  # お気に入り機体を先頭にした <option> タグ群を返す
+  # お気に入りがある場合は favorites / others の2グループに分けて TomSelect に渡す
+  def mobile_suit_options_with_favorites(suits, user, selected_ids = [])
+    selected_ids = Array(selected_ids)
+    fav_ids = user&.user_favorite_suits&.order(:slot)&.pluck(:mobile_suit_id) || []
+
+    favorites = suits.select { |s| fav_ids.include?(s.id) }.sort_by { |s| fav_ids.index(s.id) }
+    others    = suits.reject { |s| fav_ids.include?(s.id) }
+
+    if favorites.any?
+      safe_join(favorites.map { |s|
+        content_tag(:option, "#{s.name} (#{s.cost})", value: s.id,
+                    data: { optgroup: "favorites" },
+                    selected: selected_ids.include?(s.id))
+      }) + safe_join(others.map { |s|
+        content_tag(:option, "#{s.name} (#{s.cost})", value: s.id,
+                    data: { optgroup: "others" },
+                    selected: selected_ids.include?(s.id))
+      })
+    else
+      safe_join(others.map { |s|
+        content_tag(:option, "#{s.name} (#{s.cost})", value: s.id,
+                    selected: selected_ids.include?(s.id))
+      })
+    end
+  end
+
   # コスト帯の組み合わせ（例："3000+2500"）を2つのバッジで表示
   def cost_combo_badges(cost_combo)
     costs = cost_combo.split("+").map(&:strip)

--- a/app/javascript/controllers/suit_select_controller.js
+++ b/app/javascript/controllers/suit_select_controller.js
@@ -3,10 +3,15 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     if (typeof TomSelect === 'undefined') return
+    const optgroups = this.element.dataset.hasFavorites === 'true'
+      ? [{ value: 'favorites', label: '★ お気に入り機体' }, { value: 'others', label: '── その他の機体 ──' }]
+      : []
     this.tomSelect = new TomSelect(this.element, {
       placeholder: '機体を検索...',
       maxOptions: null,
       dropdownParent: 'body',
+      optgroupField: 'optgroup',
+      optgroups: optgroups,
       onChange: (value) => {
         const url = new URL(window.location.href)
         url.searchParams.delete('mobile_suits[]')

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -86,14 +86,10 @@
         <% end %>
       </div>
       <div class="flex-1 min-w-[180px] max-w-xs">
-        <select id="match-suit-select" class="w-full" data-controller="suit-select">
+        <select id="match-suit-select" class="w-full" data-controller="suit-select" data-has-favorites="<%= viewing_as_user&.user_favorite_suits&.any? %>">
           <option value="">機体を検索...</option>
           <% _visible_suits = @filter_costs.any? ? @all_mobile_suits.select { |s| @filter_costs.include?(s.cost) } : @all_mobile_suits %>
-          <% _visible_suits.each do |suit| %>
-            <option value="<%= suit.id %>" <%= 'selected' if @filter_mobile_suits.include?(suit.id) %>>
-              <%= suit.name %> (<%= suit.cost %>)
-            </option>
-          <% end %>
+          <%= mobile_suit_options_with_favorites(_visible_suits, viewing_as_user, @filter_mobile_suits) %>
         </select>
       </div>
       <% unless @filter_costs.empty? && @filter_mobile_suits.empty? %>

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -225,20 +225,16 @@
                 <div class="space-y-3">
                   <div>
                     <label class="block text-sm text-gray-600 mb-1"><%= @current_match.team1_player1.nickname %> <span class="text-red-500">*</span></label>
-                    <select name="team1_player1_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+                    <select name="team1_player1_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" data-has-favorites="<%= @current_match.team1_player1.user_favorite_suits.any? %>">
                       <option value="">機体を選択...</option>
-                      <% MobileSuit.order(:name).each do |suit| %>
-                        <option value="<%= suit.id %>"><%= suit.name %> (<%= suit.cost %>)</option>
-                      <% end %>
+                      <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team1_player1) %>
                     </select>
                   </div>
                   <div>
                     <label class="block text-sm text-gray-600 mb-1"><%= @current_match.team1_player2.nickname %> <span class="text-red-500">*</span></label>
-                    <select name="team1_player2_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+                    <select name="team1_player2_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" data-has-favorites="<%= @current_match.team1_player2.user_favorite_suits.any? %>">
                       <option value="">機体を選択...</option>
-                      <% MobileSuit.order(:name).each do |suit| %>
-                        <option value="<%= suit.id %>"><%= suit.name %> (<%= suit.cost %>)</option>
-                      <% end %>
+                      <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team1_player2) %>
                     </select>
                   </div>
                 </div>
@@ -250,20 +246,16 @@
                 <div class="space-y-3">
                   <div>
                     <label class="block text-sm text-gray-600 mb-1"><%= @current_match.team2_player1.nickname %> <span class="text-red-500">*</span></label>
-                    <select name="team2_player1_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+                    <select name="team2_player1_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" data-has-favorites="<%= @current_match.team2_player1.user_favorite_suits.any? %>">
                       <option value="">機体を選択...</option>
-                      <% MobileSuit.order(:name).each do |suit| %>
-                        <option value="<%= suit.id %>"><%= suit.name %> (<%= suit.cost %>)</option>
-                      <% end %>
+                      <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team2_player1) %>
                     </select>
                   </div>
                   <div>
                     <label class="block text-sm text-gray-600 mb-1"><%= @current_match.team2_player2.nickname %> <span class="text-red-500">*</span></label>
-                    <select name="team2_player2_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500">
+                    <select name="team2_player2_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" data-has-favorites="<%= @current_match.team2_player2.user_favorite_suits.any? %>">
                       <option value="">機体を選択...</option>
-                      <% MobileSuit.order(:name).each do |suit| %>
-                        <option value="<%= suit.id %>"><%= suit.name %> (<%= suit.cost %>)</option>
-                      <% end %>
+                      <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team2_player2) %>
                     </select>
                   </div>
                 </div>
@@ -398,10 +390,15 @@
                   return;
                 }
 
+                const optgroups = select.dataset.hasFavorites === 'true'
+                  ? [{ value: 'favorites', label: '★ お気に入り機体' }, { value: 'others', label: '── その他の機体 ──' }]
+                  : [];
                 new TomSelect(select, {
                   placeholder: '機体を検索...',
                   allowEmptyOption: true,
                   plugins: ['clear_button'],
+                  optgroupField: 'optgroup',
+                  optgroups: optgroups,
                   render: {
                     no_results: function(data, escape) {
                       return '<div class="no-results">該当する機体が見つかりません</div>';

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -182,14 +182,10 @@
         <% end %>
       </div>
       <div class="flex-1 min-w-[180px] max-w-xs">
-        <select id="stat-suit-select" class="w-full">
+        <select id="stat-suit-select" class="w-full" data-has-favorites="<%= viewing_as_user&.user_favorite_suits&.any? %>">
           <option value="">機体を検索...</option>
           <% visible_suits = @filter_costs.any? ? @all_mobile_suits.select { |s| @filter_costs.include?(s.cost) } : @all_mobile_suits %>
-          <% visible_suits.each do |suit| %>
-            <option value="<%= suit.id %>" <%= 'selected' if @filter_mobile_suits.include?(suit.id) %>>
-              <%= suit.name %> (<%= suit.cost %>)
-            </option>
-          <% end %>
+          <%= mobile_suit_options_with_favorites(visible_suits, viewing_as_user, @filter_mobile_suits) %>
         </select>
       </div>
       <% unless no_suit_cost %>
@@ -2187,10 +2183,15 @@
     function initStatSuitSelect() {
       const el = document.querySelector('#stat-suit-select');
       if (!el || el.tomselect) return;
+      const statSuitOptgroups = el.dataset.hasFavorites === 'true'
+        ? [{ value: 'favorites', label: '★ お気に入り機体' }, { value: 'others', label: '── その他の機体 ──' }]
+        : [];
       new TomSelect('#stat-suit-select', {
         placeholder: '機体を検索...',
         maxOptions: null,
         dropdownParent: 'body',
+        optgroupField: 'optgroup',
+        optgroups: statSuitOptgroups,
         onChange: function(value) {
           navigateStatSuit(value);
         }


### PR DESCRIPTION
## Summary

- `mobile_suit_options_with_favorites` ヘルパーを追加し、お気に入り機体（スロット順）を先頭・その他を後続に並べた `<option>` 群を生成する
- 統計ページ・対戦履歴の使用機体フィルターに適用（`viewing_as_user` のお気に入りを基準）
- ローテーション詳細の試合記録フォームに適用（プレイヤーごとに異なるお気に入りを表示、N+1 を Preloader で回避）
- TomSelect の `optgroupField` / `optgroups` 設定で「★ お気に入り機体」「── その他の機体 ──」のグループヘッダーを表示

## Test plan

- [ ] お気に入り機体を登録済みのユーザーで統計ページを開き、機体フィルターのドロップダウンに「★ お気に入り機体」グループが先頭に表示されることを確認
- [ ] 対戦履歴ページの機体フィルターでも同様に確認
- [ ] ローテーション詳細の試合記録フォームで、各プレイヤーのセレクトに当該プレイヤーのお気に入りが先頭表示されることを確認
- [ ] お気に入り未登録のユーザーではグループヘッダーが表示されず、通常の一覧になることを確認

Closes #151

## 関連Issue・PR

#151