### PR TITLE
feat: 管理者の view-as 中のマイページ閲覧・お気に入り機体登録を正しく動作させる

### DIFF
--- a/app/controllers/my_page_controller.rb
+++ b/app/controllers/my_page_controller.rb
@@ -4,7 +4,7 @@ class MyPageController < ApplicationController
   COSTS = [ 3000, 2500, 2000, 1500 ].freeze
 
   def show
-    @favorites_by_slot = current_user.user_favorite_suits
+    @favorites_by_slot = viewing_as_user.user_favorite_suits
                                      .includes(:mobile_suit)
                                      .index_by(&:slot)
     @selected_suit_ids = (0..11).filter_map { |s| @favorites_by_slot[s]&.mobile_suit_id }

--- a/app/controllers/user_favorite_suits_controller.rb
+++ b/app/controllers/user_favorite_suits_controller.rb
@@ -7,9 +7,9 @@ class UserFavoriteSuitsController < ApplicationController
     ordered_ids = ids.select { |id| valid_ids.include?(id) }
 
     ActiveRecord::Base.transaction do
-      current_user.user_favorite_suits.delete_all
+      viewing_as_user.user_favorite_suits.delete_all
       ordered_ids.each_with_index do |suit_id, slot|
-        current_user.user_favorite_suits.create!(mobile_suit_id: suit_id, slot: slot)
+        viewing_as_user.user_favorite_suits.create!(mobile_suit_id: suit_id, slot: slot)
       end
     end
 

--- a/app/views/my_page/show.html.erb
+++ b/app/views/my_page/show.html.erb
@@ -5,6 +5,16 @@
 
   <div class="max-w-4xl mx-auto px-4 py-8">
 
+    <%# ── view-as バナー ── %>
+    <% if viewing_as_someone_else? %>
+      <div class="mb-6 flex items-center gap-2 px-4 py-3 rounded-xl bg-amber-50 border border-amber-200 text-amber-800 text-sm font-medium">
+        <svg class="w-4 h-4 shrink-0 text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+        </svg>
+        <span>管理者として <span class="font-bold"><%= viewing_as_user.nickname %></span> さんのマイページを編集中</span>
+      </div>
+    <% end %>
+
     <%# ── プロフィールヘッダー ── %>
     <div class="mb-8 flex items-center gap-4">
       <div class="w-14 h-14 rounded-2xl bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center shadow-lg select-none">


### PR DESCRIPTION
## Summary
- `MyPageController#show` および `UserFavoriteSuitsController#bulk_update` で `current_user` の代わりに `viewing_as_user` を使用
- view-as 中はそのユーザーのお気に入りを表示・保存するよう修正
- view-as 中のマイページ上部に「管理者として〇〇さんのマイページを編集中」バナーを表示

## Test plan
- [ ] 管理者が view-as でユーザー切り替え → マイページを開くと切り替え先ユーザーのお気に入りが表示される
- [ ] お気に入りを登録 → 切り替え先ユーザーのお気に入りとして保存される（管理者のお気に入りは変わらない）
- [ ] view-as 中はページ上部に amber バナーが表示される
- [ ] 通常ユーザー（view-as なし）でマイページを開いても自分のお気に入りが正しく表示・保存される

Closes #154