### PR TITLE
feat: 機体・コストフィルターにお気に入り機体のクイックフィルターボタンを追加

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -55,7 +55,13 @@ class MatchesController < ApplicationController
     if params[:mobile_suits].present?
       mobile_suit_ids = params[:mobile_suits].reject(&:blank?).map(&:to_i)
       if mobile_suit_ids.any?
-        @matches = @matches.joins(:match_players).where(match_players: { mobile_suit_id: mobile_suit_ids }).distinct
+        if params[:my_mobile_suits] == "1"
+          @matches = @matches.joins(:match_players).where(
+            match_players: { mobile_suit_id: mobile_suit_ids, user_id: viewing_as_user.id }
+          ).distinct
+        else
+          @matches = @matches.joins(:match_players).where(match_players: { mobile_suit_id: mobile_suit_ids }).distinct
+        end
       end
     end
 
@@ -176,6 +182,7 @@ class MatchesController < ApplicationController
     @filter_streaming_users_mode = params[:streaming_users_mode].presence_in(%w[or and]) || "or"
     @filter_mobile_suits = params[:mobile_suits].present? ? params[:mobile_suits].reject(&:blank?).map(&:to_i) : []
     @filter_costs = params[:costs].present? ? params[:costs].reject(&:blank?).map(&:to_i) : []
+    @filter_my_mobile_suits = params[:my_mobile_suits] == "1"
     @filter_stat_player_id = stat_player_id
     @filter_ol_filter = ol_filter
     @filter_stat_filters = stat_filters

--- a/app/javascript/controllers/suit_select_controller.js
+++ b/app/javascript/controllers/suit_select_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
       onChange: (value) => {
         const url = new URL(window.location.href)
         url.searchParams.delete('mobile_suits[]')
+        url.searchParams.delete('my_mobile_suits')
         if (value) url.searchParams.set('mobile_suits[]', value)
         window.location.href = url.toString()
       }

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -23,7 +23,8 @@
             damage_dealt_val: @filter_damage_dealt_val, damage_dealt_dir: @filter_damage_dealt_dir,
             damage_received_val: @filter_damage_received_val, damage_received_dir: @filter_damage_received_dir }
     _cur = { events: @filter_events, users: @filter_users, users_mode: @filter_users_mode,
-             streaming_users: @filter_streaming_users, mobile_suits: @filter_mobile_suits, costs: @filter_costs }
+             streaming_users: @filter_streaming_users, mobile_suits: @filter_mobile_suits, costs: @filter_costs,
+             my_mobile_suits: @filter_my_mobile_suits ? "1" : nil }
     _all = _bp.merge(_cur)
 
     _btn_on  = "px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-indigo-600 text-white"
@@ -73,14 +74,14 @@
     <div class="flex flex-wrap items-center gap-3">
       <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">機体・コスト</span>
       <div class="flex rounded-xl bg-gray-100 p-1 gap-0.5 shrink-0">
-        <%= link_to "全体", matches_path(_all.merge(costs: [], mobile_suits: [])),
+        <%= link_to "全体", matches_path(_all.merge(costs: [], mobile_suits: [], my_mobile_suits: nil)),
             class: "px-3 py-1.5 rounded-lg text-sm font-semibold transition-all whitespace-nowrap #{@filter_costs.empty? && @filter_mobile_suits.empty? ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}" %>
         <% [[3000, 'bg-red-500 text-white shadow-sm', 'text-red-500 hover:bg-red-100/80'],
             [2500, 'bg-orange-500 text-white shadow-sm', 'text-orange-500 hover:bg-orange-100/80'],
             [2000, 'bg-yellow-400 text-gray-900 shadow-sm', 'text-yellow-600 hover:bg-yellow-100/80'],
             [1500, 'bg-green-500 text-white shadow-sm', 'text-green-600 hover:bg-green-100/80']].each do |cost, active_cls, inactive_cls| %>
           <% is_cost_active = @filter_costs == [cost] && @filter_mobile_suits.empty? %>
-          <% cost_url = is_cost_active ? matches_path(_all.merge(costs: [], mobile_suits: [])) : matches_path(_all.merge(costs: [cost], mobile_suits: [])) %>
+          <% cost_url = is_cost_active ? matches_path(_all.merge(costs: [], mobile_suits: [], my_mobile_suits: nil)) : matches_path(_all.merge(costs: [cost], mobile_suits: [], my_mobile_suits: nil)) %>
           <%= link_to cost.to_s, cost_url,
               class: "px-3 py-1.5 rounded-lg text-sm font-semibold transition-all whitespace-nowrap #{is_cost_active ? active_cls : inactive_cls}" %>
         <% end %>
@@ -93,7 +94,7 @@
         </select>
       </div>
       <% unless @filter_costs.empty? && @filter_mobile_suits.empty? %>
-        <%= link_to matches_path(_all.merge(costs: [], mobile_suits: [])),
+        <%= link_to matches_path(_all.merge(costs: [], mobile_suits: [], my_mobile_suits: nil)),
             class: "flex items-center gap-1 text-xs text-gray-400 hover:text-red-500 transition-colors shrink-0" do %>
           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -102,6 +103,25 @@
         <% end %>
       <% end %>
     </div>
+
+    <!-- お気に入り機体 -->
+    <% _fav_suits = viewing_as_user&.user_favorite_suits&.order(:slot)&.includes(:mobile_suit)&.to_a || [] %>
+    <% if _fav_suits.any? %>
+      <%
+        _fav_toggle = ->(suit_id) {
+          new_arr = @filter_mobile_suits.include?(suit_id) ? @filter_mobile_suits - [suit_id] : @filter_mobile_suits + [suit_id]
+          matches_path(_all.merge(mobile_suits: new_arr, my_mobile_suits: new_arr.any? ? "1" : nil))
+        }
+      %>
+      <div class="flex items-center flex-wrap gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">お気に入り</span>
+        <% _fav_suits.each do |fav| %>
+          <%= link_to fav.mobile_suit.name, _fav_toggle.call(fav.mobile_suit.id),
+              class: (@filter_mobile_suits.include?(fav.mobile_suit.id) && @filter_my_mobile_suits) ? _btn_on : _btn_off %>
+        <% end %>
+        <span class="text-xs text-gray-400 ml-1">自分が使用した試合のみ</span>
+      </div>
+    <% end %>
 
     <!-- 詳細条件（折りたたみ） -->
     <% stat_section_active = @filter_ol_filter.present? || @filter_stat_filters.any? || @filter_stat_player_id.present? || @filter_damage_dealt_val.present? || @filter_damage_received_val.present? %>
@@ -130,6 +150,7 @@
           <% @filter_streaming_users.each do |id| %><input type="hidden" name="streaming_users[]" value="<%= id %>"><% end %>
           <% @filter_mobile_suits.each do |id| %><input type="hidden" name="mobile_suits[]" value="<%= id %>"><% end %>
           <% @filter_costs.each do |c| %><input type="hidden" name="costs[]" value="<%= c %>"><% end %>
+          <% if @filter_my_mobile_suits %><input type="hidden" name="my_mobile_suits" value="1"><% end %>
           <input type="hidden" name="sort" value="<%= @sort %>">
           <input type="hidden" name="per" value="<%= @per_page %>">
 

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -198,6 +198,19 @@
         <% end %>
       <% end %>
     </div>
+
+    <!-- お気に入り機体 -->
+    <% _fav_suits = viewing_as_user&.user_favorite_suits&.order(:slot)&.includes(:mobile_suit)&.to_a || [] %>
+    <% if _fav_suits.any? %>
+      <div class="flex items-center flex-wrap gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">お気に入り</span>
+        <% _fav_suits.each do |fav| %>
+          <% _new_suits = @filter_mobile_suits.include?(fav.mobile_suit.id) ? @filter_mobile_suits - [fav.mobile_suit.id] : @filter_mobile_suits + [fav.mobile_suit.id] %>
+          <%= link_to fav.mobile_suit.name, statistics_path(suit_base.merge(mobile_suits: _new_suits)),
+              class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_mobile_suits.include?(fav.mobile_suit.id) ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 
   <% end %>


### PR DESCRIPTION
## Summary
- 対戦履歴・統計（個人タブ）のフィルターカードに「お気に入り」行を追加し、お気に入り機体をボタンで選択してフィルタリングできるようにした
- 対戦履歴では `my_mobile_suits=1` パラメータを導入し、お気に入りボタン経由の絞り込みは `viewing_as_user` が使用した試合のみに限定（機体selectドロップダウンは従来通り全員対象）
- 管理者の view-as 中は表示ユーザーのお気に入りが表示される
- ボタン行末尾に「自分が使用した試合のみ」と常時表示し、挙動を明示
- お気に入りが0件のユーザーにはボタン行を非表示

## Test plan
- [ ] お気に入り機体を登録済みのユーザーで対戦履歴を開き、「お気に入り」行が表示される
- [ ] お気に入りボタンをクリックすると、自分がその機体を使った試合のみが表示される
- [ ] 複数ボタンをトグルして複数機体フィルターが機能する
- [ ] 機体selectドロップダウンで選択すると、全員対象のフィルターになる（`my_mobile_suits` がクリアされる）
- [ ] 全体・コスト・クリアボタンをクリックするとお気に入りフィルターが解除される
- [ ] 統計ページ（個人タブ）でお気に入りボタンが表示され、機体フィルターが機能する
- [ ] お気に入りが0件のユーザーにはボタン行が表示されない
- [ ] 管理者が view-as 中、表示ユーザーのお気に入りが表示される

## 関連Issue・PR
#157

Closes #157