### PR TITLE
feat: 対戦履歴のイベント選択時に参加プレイヤーフィルターを絞り込む

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -171,11 +171,20 @@ class MatchesController < ApplicationController
 
     # フィルター用のデータ
     @all_events = Event.order(held_on: :desc)
-    @all_users = User.regular_users.order(:nickname)
     @all_mobile_suits = MobileSuit.all.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
 
     # 選択されたフィルター値
     @filter_events = params[:events].present? ? params[:events].reject(&:blank?).map(&:to_i) : []
+
+    all_users = User.regular_users.order(:nickname)
+    if @filter_events.any?
+      user_ids_in_events = MatchPlayer.joins(:match)
+                                      .where(matches: { event_id: @filter_events })
+                                      .distinct
+                                      .pluck(:user_id)
+      all_users = all_users.where(id: user_ids_in_events)
+    end
+    @all_users = all_users
     @filter_users = params[:users].present? ? params[:users].reject(&:blank?).map(&:to_i) : []
     @filter_users_mode = params[:users_mode].presence_in(%w[or and]) || "or"
     @filter_streaming_users = params[:streaming_users].present? ? params[:streaming_users].reject(&:blank?).map(&:to_i) : []


### PR DESCRIPTION
## Summary
- 対戦履歴画面でイベントを選択した際、「参加プレイヤー」フィルターにそのイベントの参加者のみが表示されるようにした
- 統計ページ（`StatisticsController`）に既にある同等実装と同じパターンで `MatchesController#index` に追加
- 「配信台ユーザー」フィルターも `@all_users` 派生のため自動的に連動する

## Test plan
- [x] イベントを選択しない場合、参加プレイヤーフィルターに全ユーザーが表示される
- [x] イベントを1件選択した場合、そのイベントに参加したプレイヤーのみがフィルターに表示される
- [x] イベントを複数選択した場合、いずれかのイベントに参加したプレイヤーが表示される
- [x] 配信台ユーザーフィルターも同様に絞り込まれる

## 関連Issue・PR
#159