### PR TITLE
fix: 機体一覧の並び順をpositionカラム基準に修正 + seeds同期方式改善

### DIFF
--- a/app/controllers/mobile_suits_controller.rb
+++ b/app/controllers/mobile_suits_controller.rb
@@ -6,7 +6,7 @@ class MobileSuitsController < ApplicationController
   def index
     @counts_by_cost = MobileSuit.group(:cost).count
     @selected_cost = params[:cost].to_i.in?(COSTS) ? params[:cost].to_i : nil
-    @suits = @selected_cost ? MobileSuit.where(cost: @selected_cost).order(:id) : MobileSuit.all.order(:id)
+    @suits = @selected_cost ? MobileSuit.where(cost: @selected_cost).order(:position) : MobileSuit.all.order(:position)
     @search_query = params[:q].to_s.strip
   end
 end

--- a/db/migrate/20260309150445_fix_mobile_suit_positions_for_seravee.rb
+++ b/db/migrate/20260309150445_fix_mobile_suit_positions_for_seravee.rb
@@ -1,0 +1,20 @@
+class FixMobileSuitPositionsForSeravee < ActiveRecord::Migration[8.1]
+  def up
+    # セラヴィーガンダム（id=247）は position=101 が正しい位置。
+    # しかし既存のラファエルガンダム以降も position=101 から始まっており重複している。
+    # seeds.rb の定義通り、セラヴィーガンダム以外の position >= 101 を +1 シフトする。
+    execute <<~SQL
+      UPDATE mobile_suits
+      SET position = position + 1
+      WHERE position >= 101 AND id != 247
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE mobile_suits
+      SET position = position - 1
+      WHERE position >= 102 AND id != 247
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_08_140859) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_150445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -280,14 +280,12 @@ mobile_suits_data = [
   { name: 'N-EXTREMEガンダム スプレマシー', series: 'Project N-EXTREME', cost: 1500, position: 246 }
 ]
 
-mobile_suits_data.each do |suit_data|
-  suit = MobileSuit.find_or_create_by!(name: suit_data[:name]) do |suit|
-    suit.series = suit_data[:series]
-    suit.cost = suit_data[:cost]
-    suit.position = suit_data[:position]
-  end
-  puts "  Created mobile suit: #{suit.name} (#{suit.cost}コスト)"
-end
+MobileSuit.upsert_all(
+  mobile_suits_data,
+  unique_by: :name,
+  update_only: [ :series, :cost, :position ]
+)
+puts "  Upserted #{mobile_suits_data.size} mobile suits"
 
 puts "\nCreating master emojis..."
 


### PR DESCRIPTION
## Summary
- 機体一覧でセラヴィーガンダムが末尾に表示されていた問題を修正
- seeds.rb を `upsert_all` 方式に変更し、今後の機体追加・位置変更を migration なしで行えるようにした

## 原因
`MobileSuitsController` が `order(:id)` で並べていたため、後から追加されたセラヴィーガンダム（id=247）が末尾に表示されていた。また seeds.rb が `find_or_create_by!` を使っており既存レコードの position を更新できなかったため、ラファエルガンダム以降の position が seeds.rb の定義と1つずれた状態になっていた。

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| 機体一覧の並び順 | `order(:id)` | `order(:position)` |
| seeds.rb の同期方式 | `find_or_create_by!`（作成のみ） | `upsert_all`（作成 + position 更新） |
| データ migration | ラファエルガンダム以降（position >= 101）を +1 シフト | — |

## 今後の運用
新機体追加・位置変更は seeds.rb を編集して `rails db:seed` を実行するだけでよくなった。migration は不要。

## Test plan
- [ ] 機体一覧（全コスト）を開き、セラヴィーガンダムがスサノオの次に表示されることを確認
- [ ] 2500コストでフィルタリングし、同様に確認
- [ ] position の重複がないことを確認（`MobileSuit.group(:position).having('count(*) > 1').count` が空）

Closes #163