### PR TITLE
feat: 管理者視点切り替えUIのモダン化（select廃止・ユーザー情報エリアをクリッカブルに）

### DIFF
--- a/app/javascript/controllers/user_switcher_controller.js
+++ b/app/javascript/controllers/user_switcher_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["dropdown"]
+
+  connect() {
+    this._outsideClickHandler = this._onOutsideClick.bind(this)
+  }
+
+  toggle() {
+    const dropdown = this.dropdownTarget
+    const isHidden = dropdown.classList.contains("hidden")
+    if (isHidden) {
+      dropdown.classList.remove("hidden")
+      document.addEventListener("click", this._outsideClickHandler)
+    } else {
+      this._close()
+    }
+  }
+
+  switchView(event) {
+    const userId = event.currentTarget.dataset.userId
+    this._submitSwitchForm(userId)
+  }
+
+  clearView() {
+    this._submitSwitchForm("clear")
+  }
+
+  _close() {
+    this.dropdownTarget.classList.add("hidden")
+    document.removeEventListener("click", this._outsideClickHandler)
+  }
+
+  _onOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this._close()
+    }
+  }
+
+  _submitSwitchForm(userId) {
+    const form = document.createElement("form")
+    form.method = "POST"
+    form.action = userId === "clear"
+      ? "/admin/users/clear_view"
+      : `/admin/users/${userId}/switch_view`
+
+    const token = document.querySelector('meta[name="csrf-token"]').content
+    const csrfInput = document.createElement("input")
+    csrfInput.type = "hidden"
+    csrfInput.name = "authenticity_token"
+    csrfInput.value = token
+
+    form.appendChild(csrfInput)
+    document.body.appendChild(form)
+    form.submit()
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this._outsideClickHandler)
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,35 +72,74 @@
 
         <!-- 下部セクション（固定・インディゴ背景） -->
         <div class="flex-shrink-0 border-t border-indigo-400 p-4 bg-[#4F39F6]">
-          <!-- ユーザー情報 -->
-          <div class="flex items-center mb-3">
-            <div class="flex-shrink-0">
-              <div class="h-10 w-10 rounded-full bg-white/20 flex items-center justify-center">
-                <span class="text-white font-medium text-sm"><%= current_user.nickname[0] %></span>
+          <!-- ユーザー情報（管理者はクリックで視点切り替えドロップダウン） -->
+          <% if current_user.is_admin? %>
+            <div class="relative mb-3" data-controller="user-switcher">
+              <button type="button" data-action="click->user-switcher#toggle" class="w-full flex items-center rounded-lg px-2 py-2 transition-colors <%= viewing_as_someone_else? ? 'bg-white/20 hover:bg-white/25 ring-1 ring-white/50' : 'hover:bg-white/10' %>">
+                <div class="flex-shrink-0">
+                  <div class="h-9 w-9 rounded-full flex items-center justify-center <%= viewing_as_someone_else? ? 'bg-white/35' : 'bg-white/20' %>">
+                    <span class="text-white font-medium text-sm"><%= viewing_as_user.nickname[0] %></span>
+                  </div>
+                </div>
+                <div class="ml-3 flex-1 text-left min-w-0">
+                  <div class="text-sm font-medium text-white truncate">
+                    <% if viewing_as_someone_else? %>
+                      <span class="text-indigo-100 text-xs font-normal">視点切り替え中</span><br>
+                      <%= viewing_as_user.nickname %>
+                    <% else %>
+                      <%= current_user.nickname %>
+                    <% end %>
+                  </div>
+                  <div class="text-xs text-indigo-200 truncate">
+                    <% if viewing_as_someone_else? %>
+                      <%= viewing_as_user.username %>
+                    <% else %>
+                      <%= current_user.username %>
+                    <% end %>
+                  </div>
+                </div>
+                <div class="flex-shrink-0 ml-2">
+                  <svg class="w-4 h-4 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
+                  </svg>
+                </div>
+              </button>
+
+              <!-- ドロップダウン（上方向に展開） -->
+              <div data-user-switcher-target="dropdown" class="hidden absolute bottom-full left-0 right-0 mb-2 bg-white rounded-lg shadow-xl border border-gray-200 overflow-hidden z-50">
+                <% if viewing_as_someone_else? %>
+                  <button type="button" data-action="click->user-switcher#clearView" class="w-full flex items-center px-4 py-3 text-sm font-medium text-indigo-700 hover:bg-indigo-50 border-b border-gray-100 transition-colors">
+                    <svg class="w-4 h-4 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
+                    </svg>
+                    管理者視点に戻す
+                  </button>
+                <% end %>
+                <div class="max-h-48 overflow-y-auto py-1">
+                  <% User.where(is_admin: false).order(:nickname).each do |user| %>
+                    <% next if viewing_as_someone_else? && user.id == viewing_as_user.id %>
+                    <button type="button" data-action="click->user-switcher#switchView" data-user-id="<%= user.id %>" class="w-full flex items-center px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                      <div class="h-7 w-7 rounded-full bg-indigo-100 flex items-center justify-center mr-3 flex-shrink-0">
+                        <span class="text-indigo-600 font-medium text-xs"><%= user.nickname[0] %></span>
+                      </div>
+                      <span class="truncate"><%= user.nickname %></span>
+                    </button>
+                  <% end %>
+                </div>
               </div>
             </div>
-            <div class="ml-3">
-              <div class="text-sm font-medium text-white"><%= current_user.nickname %></div>
-              <div class="text-xs text-indigo-200"><%= current_user.username %></div>
-            </div>
-          </div>
-
-          <!-- 管理者用: 視点切り替え -->
-          <% if current_user.is_admin? %>
-            <div class="mb-3">
-              <select onchange="if(this.value) switchUserView(this.value);" class="w-full text-sm border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-white <%= viewing_as_someone_else? ? 'bg-orange-50 border-orange-300 text-gray-800' : 'bg-white/90 border-indigo-300 text-gray-800' %>">
-                <% if viewing_as_someone_else? %>
-                  <option value=""><%= viewing_as_user.nickname %>の視点 ▼</option>
-                  <option value="clear">--- 管理者視点に戻す ---</option>
-                <% else %>
-                  <option value="">視点切り替え...</option>
-                <% end %>
-                <% User.where(is_admin: false).order(:nickname).each do |user| %>
-                  <% unless viewing_as_someone_else? && user.id == viewing_as_user.id %>
-                    <option value="<%= user.id %>"><%= user.nickname %></option>
-                  <% end %>
-                <% end %>
-              </select>
+          <% else %>
+            <!-- 一般ユーザー: 通常のユーザー情報表示 -->
+            <div class="flex items-center mb-3 px-2">
+              <div class="flex-shrink-0">
+                <div class="h-9 w-9 rounded-full bg-white/20 flex items-center justify-center">
+                  <span class="text-white font-medium text-sm"><%= current_user.nickname[0] %></span>
+                </div>
+              </div>
+              <div class="ml-3 min-w-0">
+                <div class="text-sm font-medium text-white truncate"><%= current_user.nickname %></div>
+                <div class="text-xs text-indigo-200 truncate"><%= current_user.username %></div>
+              </div>
             </div>
           <% end %>
 
@@ -154,7 +193,7 @@
                 <!-- 管理者用: ユーザー視点切り替え -->
                 <% if current_user.is_admin? %>
                   <div class="flex items-center space-x-2">
-                    <select onchange="if(this.value) switchUserView(this.value);" class="text-sm border border-gray-300 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 <%= viewing_as_someone_else? ? 'bg-orange-50 border-orange-300' : '' %>">
+                    <select onchange="if(this.value) switchUserView(this.value);" class="text-sm border border-gray-300 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 <%= viewing_as_someone_else? ? 'bg-indigo-50 border-indigo-300' : '' %>">
                       <% if viewing_as_someone_else? %>
                         <option value=""><%= viewing_as_user.nickname %>の視点 ▼</option>
                         <option value="clear">--- 管理者視点に戻す ---</option>
@@ -341,36 +380,73 @@
           </div>
           <!-- ユーザー情報セクション（インディゴ背景） -->
           <div class="pt-4 pb-3 border-t border-indigo-400 bg-[#4F39F6] px-4">
-            <div class="flex items-center px-4">
-              <div class="flex-shrink-0">
-                <div class="h-10 w-10 rounded-full bg-white/20 flex items-center justify-center">
-                  <span class="text-white font-medium text-sm"><%= current_user.nickname[0] %></span>
-                </div>
-              </div>
-              <div class="ml-3">
-                <div class="text-base font-medium text-white"><%= current_user.nickname %></div>
-                <div class="text-sm text-indigo-200"><%= current_user.username %></div>
-              </div>
-            </div>
-            <div class="mt-3 space-y-1">
-              <% if current_user.is_admin? %>
-                <!-- 視点切り替え -->
-                <div class="px-4 py-2">
-                  <select onchange="if(this.value) switchUserView(this.value);" class="w-full text-sm border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-white <%= viewing_as_someone_else? ? 'bg-orange-50 border-orange-300 text-gray-800' : 'bg-white/90 border-indigo-300 text-gray-800' %>">
-                    <% if viewing_as_someone_else? %>
-                      <option value=""><%= viewing_as_user.nickname %>の視点 ▼</option>
-                      <option value="clear">--- 管理者視点に戻す ---</option>
-                    <% else %>
-                      <option value="">視点切り替え...</option>
-                    <% end %>
-                    <% User.where(is_admin: false).order(:nickname).each do |user| %>
-                      <% unless viewing_as_someone_else? && user.id == viewing_as_user.id %>
-                        <option value="<%= user.id %>"><%= user.nickname %></option>
+            <!-- ユーザー情報（管理者はクリックで視点切り替えドロップダウン） -->
+            <% if current_user.is_admin? %>
+              <div class="relative" data-controller="user-switcher">
+                <button type="button" data-action="click->user-switcher#toggle" class="w-full flex items-center rounded-lg px-3 py-2 transition-colors <%= viewing_as_someone_else? ? 'bg-white/20 hover:bg-white/25 ring-1 ring-white/50' : 'hover:bg-white/10' %>">
+                  <div class="flex-shrink-0">
+                    <div class="h-10 w-10 rounded-full flex items-center justify-center <%= viewing_as_someone_else? ? 'bg-white/35' : 'bg-white/20' %>">
+                      <span class="text-white font-medium text-sm"><%= viewing_as_user.nickname[0] %></span>
+                    </div>
+                  </div>
+                  <div class="ml-3 flex-1 text-left min-w-0">
+                    <div class="text-base font-medium text-white truncate">
+                      <% if viewing_as_someone_else? %>
+                        <span class="text-indigo-100 text-xs font-normal">視点切り替え中</span><br>
+                        <%= viewing_as_user.nickname %>
+                      <% else %>
+                        <%= current_user.nickname %>
                       <% end %>
+                    </div>
+                    <div class="text-sm text-indigo-200 truncate">
+                      <%= viewing_as_someone_else? ? viewing_as_user.username : current_user.username %>
+                    </div>
+                  </div>
+                  <div class="flex-shrink-0 ml-2">
+                    <svg class="w-4 h-4 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
+                    </svg>
+                  </div>
+                </button>
+
+                <!-- ドロップダウン（下方向に展開） -->
+                <div data-user-switcher-target="dropdown" class="hidden absolute top-full left-0 right-0 mt-2 bg-white rounded-lg shadow-xl border border-gray-200 overflow-hidden z-50">
+                  <% if viewing_as_someone_else? %>
+                    <button type="button" data-action="click->user-switcher#clearView" class="w-full flex items-center px-4 py-3 text-sm font-medium text-indigo-700 hover:bg-indigo-50 border-b border-gray-100 transition-colors">
+                      <svg class="w-4 h-4 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
+                      </svg>
+                      管理者視点に戻す
+                    </button>
+                  <% end %>
+                  <div class="max-h-48 overflow-y-auto py-1">
+                    <% User.where(is_admin: false).order(:nickname).each do |user| %>
+                      <% next if viewing_as_someone_else? && user.id == viewing_as_user.id %>
+                      <button type="button" data-action="click->user-switcher#switchView" data-user-id="<%= user.id %>" class="w-full flex items-center px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                        <div class="h-7 w-7 rounded-full bg-indigo-100 flex items-center justify-center mr-3 flex-shrink-0">
+                          <span class="text-indigo-600 font-medium text-xs"><%= user.nickname[0] %></span>
+                        </div>
+                        <span class="truncate"><%= user.nickname %></span>
+                      </button>
                     <% end %>
-                  </select>
+                  </div>
                 </div>
-              <% end %>
+              </div>
+            <% else %>
+              <div class="flex items-center px-3">
+                <div class="flex-shrink-0">
+                  <div class="h-10 w-10 rounded-full bg-white/20 flex items-center justify-center">
+                    <span class="text-white font-medium text-sm"><%= current_user.nickname[0] %></span>
+                  </div>
+                </div>
+                <div class="ml-3">
+                  <div class="text-base font-medium text-white"><%= current_user.nickname %></div>
+                  <div class="text-sm text-indigo-200"><%= current_user.username %></div>
+                </div>
+              </div>
+            <% end %>
+
+            <div class="mt-3 space-y-1">
               <% unless current_user.is_guest? %>
                 <%= link_to "マイページ", my_page_path, class: "mobile-menu-item-small #{current_page?(my_page_path) ? 'active' : ''}" %>
               <% end %>
@@ -398,27 +474,6 @@
             iconOpen.classList.remove('hidden');
             iconClose.classList.add('hidden');
           }
-        }
-
-        function switchUserView(userId) {
-          const form = document.createElement('form');
-          form.method = 'POST';
-
-          if (userId === 'clear') {
-            form.action = '/admin/users/clear_view';
-          } else {
-            form.action = '/admin/users/' + userId + '/switch_view';
-          }
-
-          const token = document.querySelector('meta[name="csrf-token"]').content;
-          const csrfInput = document.createElement('input');
-          csrfInput.type = 'hidden';
-          csrfInput.name = 'authenticity_token';
-          csrfInput.value = token;
-
-          form.appendChild(csrfInput);
-          document.body.appendChild(form);
-          form.submit();
         }
       </script>
     </nav>


### PR DESCRIPTION
## Summary
- 管理者用視点切り替え（view-as）のUIを刷新
- サイドバー下部の `<select>` プルダウンを廃止し、ユーザー情報エリア（アバター＋名前）をクリックするとカスタムドロップダウンが開くモダンなUIに変更
- Stimulus コントローラ（`user_switcher_controller.js`）を新規作成し、ドロップダウンの開閉・クリックアウト自動クローズ・ユーザー切り替えフォーム送信を管理
- 視点切り替え中はユーザー情報エリアが `bg-white/20 ring-1 ring-white/50` でハイライト表示され、「視点切り替え中」ラベルを表示
- モバイルメニューも同様のUIに統一
- インライン JS の `switchUserView()` を廃止し Stimulus に移植

## Test plan
- [x] 管理者でログインし、ユーザー情報エリアをクリックするとドロップダウンが開くことを確認
- [x] ドロップダウンからユーザーを選択すると視点が切り替わることを確認
- [x] 視点切り替え中にユーザー情報エリアがハイライト表示（白リング＋「視点切り替え中」ラベル）されることを確認
- [x] ドロップダウン内「管理者視点に戻す」ボタンで元の視点に戻ることを確認
- [x] ドロップダウン外をクリックすると閉じることを確認
- [x] モバイルメニュー（ハンバーガー）でも同様に動作することを確認
- [x] 一般ユーザーではドロップダウンなし（通常のユーザー情報表示のみ）であることを確認

## 関連Issue
#165

Closes #165