### PR TITLE
fix: お気に入りピッカーのトレイ高さ固定とレイアウト詰め

### DIFF
--- a/app/javascript/controllers/favorite_picker_controller.js
+++ b/app/javascript/controllers/favorite_picker_controller.js
@@ -187,7 +187,7 @@ export default class extends Controller {
       return `
         <div class="tray-item flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none"
              data-tray-suit-id="${id}">
-          <div class="relative w-full h-14 rounded-xl overflow-hidden bg-gradient-to-b from-gray-50 to-gray-100
+          <div class="relative w-full h-12 rounded-xl overflow-hidden bg-gradient-to-b from-gray-50 to-gray-100
                       border-2 border-indigo-300 transition-all duration-150 shadow-sm">
             ${img}
             <span class="absolute top-1 left-1 px-1.5 h-5 min-w-[20px] ${badgeColor} text-white

--- a/app/views/my_page/_picker_modal.html.erb
+++ b/app/views/my_page/_picker_modal.html.erb
@@ -50,11 +50,11 @@
     </div>
 
     <%# ── 選択中トレイ ── %>
-    <div class="flex-shrink-0 bg-gray-50/80 border-b border-gray-100 px-4 pt-3 pb-2">
+    <div class="flex-shrink-0 bg-gray-50/80 border-b border-gray-100 px-4 pt-2 pb-1">
       <div class="flex items-start gap-2">
-        <div class="flex-1 grid grid-cols-6 gap-2"
+        <div class="flex-1 grid grid-cols-6 gap-2 content-start min-h-44"
              data-favorite-picker-target="tray">
-          <p class="col-span-6 text-sm text-gray-400 italic py-4 text-center self-center">機体をクリックして追加…</p>
+          <p class="col-span-6 text-sm text-gray-400 italic py-2 text-center self-center">機体をクリックして追加…</p>
         </div>
         <button type="button"
                 class="flex-shrink-0 text-xs text-gray-400 hover:text-red-500 font-medium transition-colors px-2 py-1 rounded-lg hover:bg-red-50 mt-1"
@@ -62,7 +62,7 @@
           クリア
         </button>
       </div>
-      <p class="mt-1.5 text-[11px] text-indigo-400/80 flex items-center gap-1.5">
+      <p class="mt-1 text-[11px] text-indigo-400/80 flex items-center gap-1.5">
         <svg class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                 d="M7 16V4m0 0L3 8m4-4l4 4M17 8v12m0 0l4-4m-4 4l-4-4"/>
@@ -72,7 +72,7 @@
     </div>
 
     <%# ── フィルターバー ── %>
-    <div class="flex-shrink-0 flex flex-wrap items-center gap-2 px-4 py-3 border-b border-gray-100 bg-white">
+    <div class="flex-shrink-0 flex flex-wrap items-center gap-2 px-4 py-2 border-b border-gray-100 bg-white">
       <div class="flex gap-0.5 flex-wrap p-1 bg-gray-100 rounded-xl">
         <% cost_tabs.each do |val, label, count| %>
           <% is_all = val.empty? %>
@@ -104,7 +104,7 @@
     </div>
 
     <%# ── 機体グリッド ── %>
-    <div class="flex-1 overflow-y-auto px-3 py-3">
+    <div class="flex-1 overflow-y-auto px-3 py-2">
       <div class="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-7 gap-1.5">
         <% suits.each do |suit| %>
           <div data-suit-wrapper
@@ -121,7 +121,7 @@
                     data-slot-badge></span>
 
               <%# 機体画像 %>
-              <div class="bg-gradient-to-b from-gray-50 to-gray-100 flex items-center justify-center h-14 pointer-events-none">
+              <div class="bg-gradient-to-b from-gray-50 to-gray-100 flex items-center justify-center h-12 pointer-events-none">
                 <% if suit.image_filename.present? %>
                   <%= image_tag "/mobile_suits/#{suit.image_filename}", alt: suit.name,
                       class: "h-full w-full object-contain p-0.5",


### PR DESCRIPTION
## Summary
- 登録機体数が6→7機体（1行→2行）に変わるとトレイ高さが増加し、機体選択グリッドがズレるバグを修正
- トレイグリッドに `content-start min-h-44` を追加し、常に2行分の高さを確保
- トレイ・フィルターバー・機体グリッドの余白を縮小し、機体選択リストの表示領域を拡大
- トレイアイテムおよび機体グリッドカードの画像高さを `h-14→h-12` に縮小

## Test plan
- [ ] ピッカーを開き、機体を6機体選択した状態から7機体目を追加しても機体選択グリッドの位置がズレないことを確認
- [ ] 7→6機体に減らしても同様にズレないことを確認
- [ ] 機体選択リストの表示領域が以前より広くなっていることを確認
- [ ] ドラッグ並べ替えが正常に動作することを確認

## 関連Issue
#167

Closes #167