### PR TITLE
feat: 機体詳細画面の実装と統計連携

### DIFF
--- a/app/controllers/admin/mobile_suits_controller.rb
+++ b/app/controllers/admin/mobile_suits_controller.rb
@@ -44,7 +44,7 @@ module Admin
     end
 
     def mobile_suit_params
-      params.require(:mobile_suit).permit(:name, :series, :cost, :wiki_url)
+      params.require(:mobile_suit).permit(:name, :series, :cost, :wiki_url, :durability, :bd_count, :red_lock_range)
     end
   end
 end

--- a/app/controllers/mobile_suits_controller.rb
+++ b/app/controllers/mobile_suits_controller.rb
@@ -9,4 +9,199 @@ class MobileSuitsController < ApplicationController
     @suits = @selected_cost ? MobileSuit.where(cost: @selected_cost).order(:position) : MobileSuit.all.order(:position)
     @search_query = params[:q].to_s.strip
   end
+
+  def show
+    @suit = MobileSuit.find(params[:id])
+    calculate_global_stats
+  end
+
+  private
+
+  def calculate_global_stats
+    suit_mps = MatchPlayer.where(mobile_suit_id: @suit.id)
+                          .joins(:match)
+                          .includes(:user, match: { match_players: :mobile_suit })
+
+    @total_uses = suit_mps.count
+    wins        = suit_mps.count { |mp| mp.match.winning_team == mp.team_number }
+    @win_rate   = @total_uses > 0 ? (wins.to_f / @total_uses * 100).round(1) : 0.0
+    @dominance  = (@win_rate * @total_uses).round(1)
+
+    # ランキング用: SQLで全機体の使用回数・勝利数を一括取得
+    all_suit_counts = MatchPlayer.joins(:match).group(:mobile_suit_id).count
+    all_suit_wins   = MatchPlayer.joins(:match)
+                                 .where("matches.winning_team = match_players.team_number")
+                                 .group(:mobile_suit_id)
+                                 .count
+
+    all_ids      = MobileSuit.pluck(:id)
+    @total_suits = all_ids.size  # 全登録機体数（未使用含む）
+
+    # 使用回数ランキング: 全機体対象（未使用 = 0）
+    counts_for_rank = all_ids.index_with { |id| all_suit_counts[id] || 0 }
+    @rank_uses = value_rank(counts_for_rank, @suit.id, :desc)
+
+    # 環境支配度ランキング: 全機体対象（未使用 = 0）
+    dominance_for_rank = all_ids.index_with do |id|
+      total  = all_suit_counts[id] || 0
+      wins_n = all_suit_wins[id] || 0
+      wr     = total > 0 ? (wins_n.to_f / total * 100) : 0.0
+      (wr * total).round(1)
+    end
+    @rank_dominance = value_rank(dominance_for_rank, @suit.id, :desc)
+
+    # 勝率ランキング: 使用実績のある機体のみ対象（未使用機体を含めると不公平なため）
+    win_rates_for_rank = all_suit_counts.each_with_object({}) do |(sid, total), h|
+      wins_n = all_suit_wins[sid] || 0
+      h[sid] = (wins_n.to_f / total * 100).round(1)
+    end
+    @rank_win_rate        = value_rank(win_rates_for_rank, @suit.id, :desc)
+    @total_suits_with_uses = win_rates_for_rank.size
+
+    # プレイヤーランキング TOP5
+    @player_ranking = suit_mps.group_by(&:user_id).map do |_, mps|
+      wins_n  = mps.count { |mp| mp.match.winning_team == mp.team_number }
+      total_n = mps.count
+      {
+        user:     mps.first.user,
+        uses:     total_n,
+        win_rate: total_n > 0 ? (wins_n.to_f / total_n * 100).round(1) : 0.0
+      }
+    end.sort_by { |d| -d[:uses] }.first(5)
+
+    # 相方機体別分析
+    partner_suit_data = Hash.new { |h, k| h[k] = { mobile_suit: nil, wins: 0, total: 0 } }
+    suit_mps.each do |my_mp|
+      partner_mp = my_mp.match.match_players.find do |mp|
+        mp.team_number == my_mp.team_number && mp.mobile_suit_id != @suit.id
+      end
+      next unless partner_mp
+
+      pid = partner_mp.mobile_suit_id
+      partner_suit_data[pid][:mobile_suit] = partner_mp.mobile_suit
+      partner_suit_data[pid][:total] += 1
+      partner_suit_data[pid][:wins] += 1 if my_mp.match.winning_team == my_mp.team_number
+    end
+
+    @partner_suits = partner_suit_data.map do |_, d|
+      total = d[:total]
+      {
+        mobile_suit: d[:mobile_suit],
+        total:       total,
+        ratio:       @total_uses > 0 ? (total.to_f / @total_uses * 100).round(1) : 0.0,
+        win_rate:    total > 0 ? (d[:wins].to_f / total * 100).round(1) : 0.0
+      }
+    end.sort_by { |d| -d[:total] }
+
+    # 相方コスト別分析
+    partner_cost_data = Hash.new { |h, k| h[k] = { wins: 0, total: 0 } }
+    suit_mps.each do |my_mp|
+      partner_mp = my_mp.match.match_players.find do |mp|
+        mp.team_number == my_mp.team_number && mp.mobile_suit_id != @suit.id
+      end
+      next unless partner_mp
+
+      cost = partner_mp.mobile_suit.cost
+      partner_cost_data[cost][:total] += 1
+      partner_cost_data[cost][:wins] += 1 if my_mp.match.winning_team == my_mp.team_number
+    end
+
+    @partner_costs = partner_cost_data.map do |cost, d|
+      total = d[:total]
+      {
+        cost:     cost,
+        total:    total,
+        ratio:    @total_uses > 0 ? (total.to_f / @total_uses * 100).round(1) : 0.0,
+        win_rate: total > 0 ? (d[:wins].to_f / total * 100).round(1) : 0.0
+      }
+    end.sort_by { |d| -d[:total] }
+
+    # パフォーマンス統計（has_stats? の試合のみ）
+    stats_mps   = suit_mps.select(&:has_stats?)
+    @global_perf = build_perf(stats_mps)
+
+    # プレイヤー別パフォーマンス（stats持ち試合があるプレイヤーのみ）
+    @player_perf = stats_mps.group_by(&:user_id).filter_map do |_, mps|
+      build_perf(mps)&.merge(user: mps.first.user)
+    end.sort_by { |d| -d[:stats_count] }
+  end
+
+  # 同率考慮ランキング: 自分より strict に上位の件数 + 1
+  def value_rank(hash, target_id, direction)
+    target_val = hash[target_id]
+    return nil if target_val.nil?
+
+    better_count = if direction == :desc
+      hash.count { |_, v| v > target_val }
+    else
+      hash.count { |_, v| v < target_val }
+    end
+    better_count + 1
+  end
+
+  def build_perf(mps)
+    return nil if mps.empty?
+
+    deaths_total         = mps.sum { |mp| mp.deaths.to_i }
+    exburst_deaths_total = mps.sum { |mp| mp.exburst_deaths.to_i }
+
+    {
+      stats_count:         mps.size,
+      avg_score:           avg_stat(mps, :score),
+      avg_kills:           avg_stat(mps, :kills),
+      avg_deaths:          avg_stat(mps, :deaths),
+      avg_damage_dealt:    avg_stat(mps, :damage_dealt),
+      avg_damage_recv:     avg_stat(mps, :damage_received),
+      avg_exburst_count:   avg_stat(mps, :exburst_count),
+      avg_exburst_damage:  avg_stat(mps, :exburst_damage),
+      avg_exburst_deaths:  avg_stat(mps, :exburst_deaths),
+      exburst_death_ratio: deaths_total > 0 ? (exburst_deaths_total.to_f / deaths_total * 100).round(1) : nil,
+      ol_rate:             bool_rate(mps, :ex_overlimit_activated),
+      survival_stats:      calc_survival_stats(mps)
+    }
+  end
+
+  def avg_stat(mps, attr)
+    values = mps.map(&attr).compact
+    values.any? ? (values.sum.to_f / values.size).round(1) : nil
+  end
+
+  def bool_rate(mps, attr)
+    values = mps.map(&attr).compact
+    return nil if values.empty?
+
+    (values.count(&:itself) * 100.0 / values.size).round(1)
+  end
+
+  def calc_survival_stats(mps)
+    mps_with_st = mps.select { |mp| (mp.survival_times || []).any? }
+    return [] if mps_with_st.empty?
+
+    max_lives = mps_with_st.map { |mp| mp.survival_times.size }.max
+
+    max_lives.times.map do |i|
+      mps_with_life = mps_with_st.select { |mp| mp.survival_times.size > i }
+
+      # survival_times.size > deaths.to_i のとき最終ライフが生存で終わった
+      survived = mps_with_life.select do |mp|
+        mp.survival_times.size == i + 1 && mp.survival_times.size > mp.deaths.to_i
+      end
+      died = mps_with_life - survived
+
+      {
+        life:           i + 1,
+        survived_cs:    avg_cs_value(survived, i),
+        survived_count: survived.size,
+        died_cs:        avg_cs_value(died, i),
+        died_count:     died.size
+      }
+    end
+  end
+
+  def avg_cs_value(mps, life_index)
+    values = mps.filter_map { |mp| mp.survival_times[life_index] }
+    return nil if values.empty?
+
+    (values.sum.to_f / values.size).round(0).to_i
+  end
 end

--- a/app/helpers/mobile_suits_helper.rb
+++ b/app/helpers/mobile_suits_helper.rb
@@ -13,4 +13,31 @@ module MobileSuitsHelper
   def cost_bar_classes(cost)
     COST_STYLES.dig(cost, :bar) || "bg-gray-400"
   end
+
+  # "フルアーマー：7強化型：8" のような連結スペック文字列を
+  # [{label: "フルアーマー", value: "7"}, {label: "強化型", value: "8"}] に分解する。
+  # ラベルなし単純値（"8", "A"）は [{label: nil, value: "8"}] を返す。
+  def parse_spec_field(str)
+    return [] if str.blank?
+    return [ { label: nil, value: str } ] unless str.include?("：")
+
+    parts  = str.split("：")
+    result = [ { label: parts[0], value: nil } ]
+
+    parts[1..].each do |part|
+      # 値は数字列 or 大文字1文字（ランクS/A/B/C/D）。
+      # 値の直後に続く文字が次の形態名の先頭。
+      if (m = part.match(/\A(\d+)(.+)\z/))
+        result.last[:value] = m[1]
+        result << { label: m[2], value: nil }
+      elsif (m = part.match(/\A([A-Z])(.+)\z/))
+        result.last[:value] = m[1]
+        result << { label: m[2], value: nil }
+      else
+        result.last[:value] = part
+      end
+    end
+
+    result
+  end
 end

--- a/app/helpers/mobile_suits_helper.rb
+++ b/app/helpers/mobile_suits_helper.rb
@@ -14,6 +14,13 @@ module MobileSuitsHelper
     COST_STYLES.dig(cost, :bar) || "bg-gray-400"
   end
 
+  def safe_external_url(url)
+    uri = URI.parse(url.to_s)
+    %w[http https].include?(uri.scheme) ? url : "#"
+  rescue URI::InvalidURIError
+    "#"
+  end
+
   # "フルアーマー：7強化型：8" のような連結スペック文字列を
   # [{label: "フルアーマー", value: "7"}, {label: "強化型", value: "8"}] に分解する。
   # ラベルなし単純値（"8", "A"）は [{label: nil, value: "8"}] を返す。

--- a/app/helpers/mobile_suits_helper.rb
+++ b/app/helpers/mobile_suits_helper.rb
@@ -1,2 +1,16 @@
 module MobileSuitsHelper
+  COST_STYLES = {
+    3000 => { badge: "bg-red-100 text-red-700",    tab_active: "bg-red-500 text-white shadow-sm",       tab_inactive: "text-red-500 hover:bg-red-100/80",     bar: "bg-red-400" },
+    2500 => { badge: "bg-orange-100 text-orange-700", tab_active: "bg-orange-500 text-white shadow-sm", tab_inactive: "text-orange-500 hover:bg-orange-100/80", bar: "bg-orange-400" },
+    2000 => { badge: "bg-yellow-100 text-yellow-700", tab_active: "bg-yellow-400 text-gray-900 shadow-sm", tab_inactive: "text-yellow-600 hover:bg-yellow-100/80", bar: "bg-yellow-400" },
+    1500 => { badge: "bg-green-100 text-green-700",  tab_active: "bg-green-500 text-white shadow-sm",   tab_inactive: "text-green-600 hover:bg-green-100/80",    bar: "bg-green-400" }
+  }.freeze
+
+  def cost_badge_classes(cost)
+    COST_STYLES.dig(cost, :badge) || "bg-gray-100 text-gray-700"
+  end
+
+  def cost_bar_classes(cost)
+    COST_STYLES.dig(cost, :bar) || "bg-gray-400"
+  end
 end

--- a/app/views/admin/mobile_suits/_form.html.erb
+++ b/app/views/admin/mobile_suits/_form.html.erb
@@ -40,11 +40,11 @@
     </div>
     <div>
       <%= form.label :bd_count, "BD回数", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= form.number_field :bd_count, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 6" %>
+      <%= form.text_field :bd_count, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 8" %>
     </div>
     <div>
       <%= form.label :red_lock_range, "赤ロック距離", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= form.number_field :red_lock_range, step: 0.01, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 200.00" %>
+      <%= form.text_field :red_lock_range, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: A" %>
     </div>
   </div>
 

--- a/app/views/admin/mobile_suits/_form.html.erb
+++ b/app/views/admin/mobile_suits/_form.html.erb
@@ -30,6 +30,24 @@
     <%= form.url_field :wiki_url, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "https://w.atwiki.jp/..." %>
   </div>
 
+  <hr class="border-gray-200">
+  <p class="text-sm font-semibold text-gray-600">スペック情報</p>
+
+  <div class="grid grid-cols-3 gap-4">
+    <div>
+      <%= form.label :durability, "耐久値", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.number_field :durability, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 620" %>
+    </div>
+    <div>
+      <%= form.label :bd_count, "BD回数", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.number_field :bd_count, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 6" %>
+    </div>
+    <div>
+      <%= form.label :red_lock_range, "赤ロック距離", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.number_field :red_lock_range, step: 0.01, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: 200.00" %>
+    </div>
+  </div>
+
   <div class="flex justify-end space-x-3">
     <%= link_to "キャンセル", admin_mobile_suits_path, class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
     <%= form.submit mobile_suit.new_record? ? "登録" : "更新", class: "px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700" %>

--- a/app/views/mobile_suits/index.html.erb
+++ b/app/views/mobile_suits/index.html.erb
@@ -59,50 +59,54 @@
   <%# 機体グリッド %>
   <div id="suit-grid" class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3">
     <% @suits.each do |suit| %>
-      <div class="suit-card group relative flex flex-col rounded-xl overflow-hidden bg-white border border-gray-200 shadow-sm hover:shadow-md hover:-translate-y-0.5 hover:border-indigo-300 transition-all duration-150"
+      <div class="suit-card group flex flex-col rounded-xl overflow-hidden bg-white border border-gray-200 shadow-sm hover:shadow-md hover:-translate-y-0.5 hover:border-indigo-300 transition-all duration-150"
            data-name="<%= suit.name %>">
 
-        <%# 画像エリア %>
-        <div class="bg-gradient-to-b from-gray-50 to-gray-100 flex items-center justify-center p-1">
-          <% if suit.wiki_url.present? %>
-            <%= link_to suit.wiki_url, target: "_blank", rel: "noopener noreferrer", title: "#{suit.name} — Wiki", class: "block" do %>
-              <% if suit.image_filename.present? %>
-                <%= image_tag "/mobile_suits/#{suit.image_filename}", alt: suit.name,
-                    class: "w-[120px] h-[120px] object-contain group-hover:scale-105 transition-transform duration-150",
-                    loading: "lazy" %>
-              <% else %>
-                <div class="w-[120px] h-[120px] flex items-center justify-center text-gray-300">
-                  <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-                  </svg>
-                </div>
-              <% end %>
-            <% end %>
-          <% elsif suit.image_filename.present? %>
+        <%# 画像エリア → 機体詳細へ %>
+        <%= link_to mobile_suit_path(suit), class: "relative block bg-gradient-to-b from-gray-50 to-gray-100" do %>
+          <% if suit.image_filename.present? %>
             <%= image_tag "/mobile_suits/#{suit.image_filename}", alt: suit.name,
-                class: "w-[120px] h-[120px] object-contain",
+                class: "w-full h-[100px] object-contain px-2 pt-2 group-hover:scale-105 transition-transform duration-150",
                 loading: "lazy" %>
+          <% else %>
+            <div class="w-full h-[100px] flex items-center justify-center text-gray-300">
+              <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+              </svg>
+            </div>
           <% end %>
-        </div>
+          <%# ホバーで「詳細を見る」 %>
+          <div class="absolute bottom-1.5 inset-x-0 flex justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+            <span class="text-[10px] font-bold text-indigo-700 bg-white/95 rounded-full px-2 py-0.5 shadow-sm border border-indigo-100">詳細を見る</span>
+          </div>
+        <% end %>
 
         <%# テキストエリア %>
-        <div class="px-2 py-2 flex-1 flex flex-col gap-0.5">
-          <p class="text-xs font-semibold text-gray-800 leading-tight line-clamp-2 group-hover:text-indigo-700 transition-colors">
-            <%= suit.name %>
-          </p>
+        <div class="px-2 pt-1.5 pb-1 flex-1 flex flex-col gap-0.5">
+          <%= link_to mobile_suit_path(suit), class: "block" do %>
+            <p class="text-xs font-semibold text-gray-800 leading-tight line-clamp-2 group-hover:text-indigo-700 transition-colors">
+              <%= suit.name %>
+            </p>
+          <% end %>
           <p class="text-[10px] text-gray-400 leading-tight line-clamp-1">
             <%= suit.series %>
           </p>
         </div>
 
-        <%# Wikiリンクアイコン（右上オーバーレイ） %>
+        <%# Wiki リンク（常時表示） %>
         <% if suit.wiki_url.present? %>
-          <%= link_to suit.wiki_url, target: "_blank", rel: "noopener noreferrer",
-              class: "absolute top-1.5 right-1.5 opacity-0 group-hover:opacity-100 transition-opacity duration-150 bg-white/90 rounded-md p-0.5 shadow-sm" do %>
-            <svg class="w-3.5 h-3.5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
-            </svg>
-          <% end %>
+          <div class="border-t border-gray-100 px-2 py-1 flex justify-center">
+            <%= link_to suit.wiki_url, target: "_blank", rel: "noopener noreferrer",
+                class: "inline-flex items-center gap-0.5 text-[10px] font-semibold text-indigo-500 hover:text-indigo-700 transition-colors" do %>
+              <svg class="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+              </svg>
+              Wiki
+              <svg class="w-2 h-2 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+              </svg>
+            <% end %>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/mobile_suits/show.html.erb
+++ b/app/views/mobile_suits/show.html.erb
@@ -70,9 +70,23 @@
             %>
             <dl class="divide-y divide-gray-100">
               <% specs.each do |spec| %>
-                <div class="flex items-center justify-between gap-8 px-4 py-2.5">
-                  <dt class="text-xs font-medium text-gray-400 whitespace-nowrap"><%= spec[:label] %></dt>
-                  <dd class="text-base font-bold text-gray-800 tabular-nums"><%= spec[:value] %></dd>
+                <% parsed = parse_spec_field(spec[:value].to_s) %>
+                <div class="px-4 py-2.5">
+                  <dt class="text-xs font-medium text-gray-400 whitespace-nowrap mb-1"><%= spec[:label] %></dt>
+                  <% if parsed.size == 1 && parsed[0][:label].nil? %>
+                    <%# 単純値 %>
+                    <dd class="text-base font-bold text-gray-800 tabular-nums"><%= parsed[0][:value] %></dd>
+                  <% else %>
+                    <%# 形態別リスト %>
+                    <dd class="space-y-0.5">
+                      <% parsed.each do |item| %>
+                        <div class="flex items-center justify-between gap-6">
+                          <span class="text-xs text-gray-400 whitespace-nowrap"><%= item[:label] %></span>
+                          <span class="text-sm font-bold text-gray-800 tabular-nums"><%= item[:value] %></span>
+                        </div>
+                      <% end %>
+                    </dd>
+                  <% end %>
                 </div>
               <% end %>
             </dl>

--- a/app/views/mobile_suits/show.html.erb
+++ b/app/views/mobile_suits/show.html.erb
@@ -71,19 +71,14 @@
             <dl class="divide-y divide-gray-100">
               <% specs.each do |spec| %>
                 <% parsed = parse_spec_field(spec[:value].to_s) %>
-                <div class="px-4 py-2.5">
-                  <dt class="text-xs font-medium text-gray-400 whitespace-nowrap mb-1"><%= spec[:label] %></dt>
+                <div class="flex items-center justify-between gap-8 px-4 py-2.5">
+                  <dt class="text-xs font-medium text-gray-400 whitespace-nowrap"><%= spec[:label] %></dt>
                   <% if parsed.size == 1 && parsed[0][:label].nil? %>
-                    <%# 単純値 %>
                     <dd class="text-base font-bold text-gray-800 tabular-nums"><%= parsed[0][:value] %></dd>
                   <% else %>
-                    <%# 形態別リスト %>
-                    <dd class="space-y-0.5">
-                      <% parsed.each do |item| %>
-                        <div class="flex items-center justify-between gap-6">
-                          <span class="text-xs text-gray-400 whitespace-nowrap"><%= item[:label] %></span>
-                          <span class="text-sm font-bold text-gray-800 tabular-nums"><%= item[:value] %></span>
-                        </div>
+                    <dd class="text-right text-xs font-bold text-gray-800 leading-snug">
+                      <% parsed.each_with_index do |item, idx| %>
+                        <span class="tabular-nums"><%= item[:value] %></span><span class="font-normal text-gray-400 ml-0.5"><%= item[:label] %></span><% unless idx == parsed.size - 1 %><span class="text-gray-200 mx-1">/</span><% end %>
                       <% end %>
                     </dd>
                   <% end %>

--- a/app/views/mobile_suits/show.html.erb
+++ b/app/views/mobile_suits/show.html.erb
@@ -1,0 +1,386 @@
+<div class="max-w-5xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+
+  <%# ── 戻るリンク（上） %>
+  <%= link_to mobile_suits_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 transition-colors" do %>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+    </svg>
+    機体一覧に戻る
+  <% end %>
+
+  <%# ── 機体カード（白） %>
+  <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+    <div class="flex flex-col sm:flex-row items-center sm:items-start gap-0">
+
+      <%# 画像 %>
+      <div class="flex-shrink-0 flex items-center justify-center bg-gray-50 sm:w-48 w-full py-8 px-6 border-b sm:border-b-0 sm:border-r border-gray-100">
+        <% if @suit.image_filename.present? %>
+          <%= image_tag "/mobile_suits/#{@suit.image_filename}", alt: @suit.name,
+              class: "w-36 h-36 object-contain" %>
+        <% else %>
+          <div class="w-36 h-36 flex items-center justify-center bg-gray-100 rounded-xl">
+            <svg class="w-12 h-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+            </svg>
+          </div>
+        <% end %>
+      </div>
+
+      <%# テキスト情報 %>
+      <div class="flex-1 min-w-0 p-6 sm:p-8 flex flex-col gap-4">
+
+        <%# コスト・シリーズ %>
+        <div class="flex flex-wrap items-center gap-2">
+          <span class="text-xs font-bold px-3 py-1 rounded-full <%= cost_badge_classes(@suit.cost) %>">
+            Cost <%= @suit.cost %>
+          </span>
+          <span class="text-sm text-gray-500"><%= @suit.series %></span>
+        </div>
+
+        <%# 機体名 %>
+        <h1 class="text-2xl sm:text-3xl font-black text-gray-900 leading-tight"><%= @suit.name %></h1>
+
+        <%# スペック %>
+        <% if @suit.durability.present? || @suit.bd_count.present? || @suit.red_lock_range.present? %>
+          <div class="flex flex-wrap gap-4 text-sm">
+            <% if @suit.durability.present? %>
+              <div>
+                <span class="text-gray-400 text-sm font-medium block mb-0.5">耐久値</span>
+                <span class="font-bold text-gray-800 text-lg"><%= @suit.durability %></span>
+              </div>
+            <% end %>
+            <% if @suit.bd_count.present? %>
+              <div>
+                <span class="text-gray-400 text-sm font-medium block mb-0.5">BD回数</span>
+                <span class="font-bold text-gray-800 text-lg"><%= @suit.bd_count %></span>
+              </div>
+            <% end %>
+            <% if @suit.red_lock_range.present? %>
+              <div>
+                <span class="text-gray-400 text-sm font-medium block mb-0.5">赤ロック距離</span>
+                <span class="font-bold text-gray-800 text-lg"><%= @suit.red_lock_range %></span>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+
+        <%# Wiki リンク %>
+        <% if @suit.wiki_url.present? %>
+          <%= link_to @suit.wiki_url, target: "_blank", rel: "noopener noreferrer",
+              class: "self-start inline-flex items-center gap-1.5 text-sm font-semibold text-indigo-600 hover:text-indigo-800 hover:underline transition-colors" do %>
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+            </svg>
+            Wiki を開く
+            <svg class="w-3.5 h-3.5 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+            </svg>
+          <% end %>
+        <% end %>
+
+      </div>
+    </div>
+  </div>
+
+  <% if @total_uses > 0 %>
+
+    <%# ── 統計サマリー %>
+    <div class="grid grid-cols-3 gap-3 sm:gap-4">
+
+      <%# 使用回数 %>
+      <div class="relative overflow-hidden bg-gradient-to-br from-indigo-500 to-indigo-600 rounded-2xl p-5 text-white shadow-md flex flex-col">
+        <div class="absolute -right-4 -top-4 w-24 h-24 bg-white/10 rounded-full"></div>
+        <div class="absolute -right-2 -bottom-6 w-16 h-16 bg-white/5 rounded-full"></div>
+        <p class="relative text-indigo-100 text-sm font-medium">使用回数</p>
+        <p class="relative mt-1 text-5xl font-black tabular-nums leading-none"><%= @total_uses %><span class="text-xl font-semibold ml-1 text-indigo-200">回</span></p>
+        <div class="relative mt-auto pt-3">
+          <% if @rank_uses %>
+            <span class="inline-block text-xs font-bold bg-white/20 px-2.5 py-1 rounded-full">#<%= @rank_uses %> / <%= @total_suits %></span>
+          <% end %>
+        </div>
+      </div>
+
+      <%# 勝率 %>
+      <div class="relative overflow-hidden bg-gradient-to-br from-violet-500 to-purple-600 rounded-2xl p-5 text-white shadow-md flex flex-col">
+        <div class="absolute -right-4 -top-4 w-24 h-24 bg-white/10 rounded-full"></div>
+        <div class="absolute -right-2 -bottom-6 w-16 h-16 bg-white/5 rounded-full"></div>
+        <p class="relative text-purple-100 text-sm font-medium">勝率</p>
+        <p class="relative mt-1 text-5xl font-black tabular-nums leading-none"><%= @win_rate %><span class="text-xl font-semibold ml-0.5 text-purple-200">%</span></p>
+        <div class="relative mt-auto pt-3">
+          <p class="text-xs text-purple-200 mb-1.5">使用実績あり機体内</p>
+          <% if @rank_win_rate %>
+            <span class="inline-block text-xs font-bold bg-white/20 px-2.5 py-1 rounded-full">#<%= @rank_win_rate %> / <%= @total_suits_with_uses %></span>
+          <% end %>
+        </div>
+      </div>
+
+      <%# 環境支配度 %>
+      <div class="relative overflow-hidden bg-gradient-to-br from-amber-500 to-orange-600 rounded-2xl p-5 text-white shadow-md flex flex-col">
+        <div class="absolute -right-4 -top-4 w-24 h-24 bg-white/10 rounded-full"></div>
+        <div class="absolute -right-2 -bottom-6 w-16 h-16 bg-white/5 rounded-full"></div>
+        <div class="relative flex items-baseline gap-2">
+          <p class="text-amber-100 text-sm font-medium">環境支配度</p>
+          <p class="text-amber-200 text-xs">勝率 × 使用回数</p>
+        </div>
+        <p class="relative mt-1 text-5xl font-black tabular-nums leading-none"><%= @dominance %></p>
+        <div class="relative mt-auto pt-3">
+          <% if @rank_dominance %>
+            <span class="inline-block text-xs font-bold bg-white/20 px-2.5 py-1 rounded-full">#<%= @rank_dominance %> / <%= @total_suits %></span>
+          <% end %>
+        </div>
+      </div>
+
+    </div>
+
+    <%# ── プレイヤーランキング %>
+    <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+      <div class="px-6 py-4 border-b border-gray-100">
+        <h2 class="text-base font-bold text-gray-700">使用プレイヤー TOP5</h2>
+      </div>
+      <% if @player_ranking.any? %>
+        <ul class="divide-y divide-gray-100">
+          <% @player_ranking.each_with_index do |d, i| %>
+            <li class="flex items-center gap-4 px-6 py-4">
+              <span class="w-7 text-center text-sm font-black <%= i == 0 ? 'text-yellow-500' : i == 1 ? 'text-gray-400' : i == 2 ? 'text-orange-400' : 'text-gray-300' %>">
+                <%= i + 1 %>
+              </span>
+              <span class="flex-1 font-semibold text-gray-800 truncate"><%= d[:user].nickname %></span>
+              <span class="text-xl font-black text-gray-900 tabular-nums">
+                <%= d[:uses] %><span class="text-sm font-normal text-gray-400 ml-0.5">回</span>
+              </span>
+              <span class="w-14 text-right text-sm font-bold tabular-nums text-purple-600">
+                <%= d[:win_rate] %>%
+              </span>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="px-6 py-8 text-sm text-gray-400 text-center">データがありません</p>
+      <% end %>
+    </div>
+
+    <%# ── 相方コスト別 %>
+    <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+      <div class="px-6 py-4 border-b border-gray-100">
+        <h2 class="text-base font-bold text-gray-700">相方コスト別</h2>
+      </div>
+      <% if @partner_costs.any? %>
+        <div class="divide-y divide-gray-100">
+          <% @partner_costs.each do |d| %>
+            <div class="px-6 py-4">
+              <%# コストバッジ + 数値 %>
+              <div class="flex items-center gap-4 mb-3">
+                <span class="text-sm font-bold px-3 py-1 rounded-lg <%= cost_badge_classes(d[:cost]) %>">Cost <%= d[:cost] %></span>
+                <span class="text-sm font-semibold text-gray-700"><%= d[:total] %><span class="text-xs font-normal text-gray-400 ml-0.5">回</span></span>
+              </div>
+              <%# 使用割合バー %>
+              <div class="mb-2">
+                <div class="flex justify-between text-sm text-gray-400 mb-1">
+                  <span>使用割合</span>
+                  <span class="font-medium text-gray-600"><%= d[:ratio] %>%</span>
+                </div>
+                <div class="h-2 rounded-full bg-gray-100 overflow-hidden">
+                  <div class="h-2 rounded-full transition-all duration-500 <%= cost_bar_classes(d[:cost]) %>" style="width: <%= d[:ratio] %>%"></div>
+                </div>
+              </div>
+              <%# 勝率バー %>
+              <div>
+                <div class="flex justify-between text-sm text-gray-400 mb-1">
+                  <span>勝率</span>
+                  <span class="font-bold text-purple-600"><%= d[:win_rate] %>%</span>
+                </div>
+                <div class="h-2 rounded-full bg-gray-100 overflow-hidden">
+                  <div class="h-2 rounded-full transition-all duration-500 bg-purple-400" style="width: <%= d[:win_rate] %>%"></div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="px-6 py-8 text-sm text-gray-400 text-center">データがありません</p>
+      <% end %>
+    </div>
+
+    <%# ── 相方機体ランキング %>
+    <% if @partner_suits.any? %>
+      <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+          <h2 class="text-base font-bold text-gray-700">相方機体ランキング</h2>
+          <span class="text-xs text-gray-400">使用回数順 · 上位10件</span>
+        </div>
+        <ul class="divide-y divide-gray-100">
+          <% @partner_suits.first(10).each_with_index do |d, i| %>
+            <li class="flex items-center gap-4 px-6 py-4">
+              <span class="w-5 flex-shrink-0 text-sm font-black text-center <%= i == 0 ? 'text-yellow-500' : 'text-gray-300' %>"><%= i + 1 %></span>
+              <div class="flex-shrink-0 w-32 h-16 flex items-center justify-center">
+                <% if d[:mobile_suit].image_filename.present? %>
+                  <%= image_tag "/mobile_suits/#{d[:mobile_suit].image_filename}", alt: d[:mobile_suit].name, class: "w-32 h-16 object-contain" %>
+                <% else %>
+                  <div class="w-32 h-16 flex items-center justify-center bg-gray-100 rounded-xl">
+                    <svg class="w-9 h-9 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                    </svg>
+                  </div>
+                <% end %>
+              </div>
+              <div class="flex-1 min-w-0">
+                <p class="text-base font-semibold text-gray-800 leading-snug line-clamp-2"><%= d[:mobile_suit].name %></p>
+                <span class="inline-block mt-0.5 text-[11px] font-bold px-1.5 py-0.5 rounded <%= cost_badge_classes(d[:mobile_suit].cost) %>"><%= d[:mobile_suit].cost %></span>
+              </div>
+              <div class="flex-shrink-0 text-right">
+                <p class="text-lg font-black text-gray-900 tabular-nums leading-tight"><%= d[:total] %><span class="text-xs font-normal text-gray-400 ml-0.5">回</span></p>
+                <p class="text-xs text-gray-400 tabular-nums"><%= d[:ratio] %>%</p>
+                <p class="text-sm font-bold tabular-nums text-purple-600"><%= d[:win_rate] %>%</p>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+  <% else %>
+    <div class="bg-white rounded-2xl border border-gray-200 shadow-sm py-16 text-center">
+      <svg class="mx-auto w-10 h-10 text-gray-300 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+      </svg>
+      <p class="text-sm font-medium text-gray-500">まだ試合データがありません</p>
+    </div>
+  <% end %>
+
+  <%# ── パフォーマンス統計 %>
+  <% if @global_perf %>
+    <%
+      perf_groups = [
+        { label: "基本戦績", rows: [
+          { key: :avg_score,  label: "スコア"   },
+          { key: :avg_kills,  label: "撃墜数"   },
+          { key: :avg_deaths, label: "被撃墜数" },
+        ]},
+        { label: "ダメージ", rows: [
+          { key: :avg_damage_dealt,   label: "与ダメージ"         },
+          { key: :avg_damage_recv,    label: "被ダメージ"         },
+          { key: :avg_exburst_damage, label: "EXバーストダメージ" },
+        ]},
+        { label: "EXバースト", rows: [
+          { key: :avg_exburst_count,   label: "EXバースト発動回数"   },
+          { key: :avg_exburst_deaths,  label: "EXバースト中被撃墜数" },
+          { key: :exburst_death_ratio, label: "EXバースト中被撃墜率", unit: "%" },
+        ]},
+        { label: "EXオーバーリミット", rows: [
+          { key: :ol_rate, label: "EXオーバーリミット発動率", unit: "%" },
+        ]},
+      ]
+      all_players = @player_perf
+      col_count   = 2 + all_players.size
+
+      global_st = @global_perf[:survival_stats]
+      st_max_n  = [ global_st.size, all_players.map { |d| d[:survival_stats].size }.max.to_i ].max
+    %>
+    <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+      <div class="px-6 py-4 border-b border-gray-100 flex flex-wrap items-baseline gap-2">
+        <h2 class="text-base font-bold text-gray-700">基本パフォーマンス統計</h2>
+        <span class="text-xs text-gray-400">統計あり試合 <%= @global_perf[:stats_count] %> 件の平均値</span>
+      </div>
+      <div class="overflow-x-auto">
+        <table class="w-full text-base">
+          <thead>
+            <tr class="bg-gray-50 border-b border-gray-200">
+              <th class="sticky left-0 bg-gray-50 text-left px-5 py-3 text-sm font-semibold text-gray-500 tracking-wide whitespace-nowrap w-52">指標</th>
+              <th class="text-right px-4 py-3 text-sm font-semibold text-indigo-600 whitespace-nowrap">全体平均</th>
+              <% all_players.each do |d| %>
+                <th class="text-right px-4 py-3 text-sm font-semibold text-gray-500 whitespace-nowrap">
+                  <%= d[:user].nickname %><span class="font-normal text-gray-400 ml-1">(<%= d[:stats_count] %>)</span>
+                </th>
+              <% end %>
+            </tr>
+          </thead>
+          <tbody>
+            <%# 通常グループ %>
+            <% perf_groups.each do |group| %>
+              <tr class="bg-gray-50/70 border-t border-gray-200">
+                <td colspan="<%= col_count %>" class="sticky left-0 px-5 py-1.5 text-xs font-bold text-gray-400 uppercase tracking-widest">
+                  <%= group[:label] %>
+                </td>
+              </tr>
+              <% group[:rows].each do |row| %>
+                <tr class="border-t border-gray-100 hover:bg-gray-50/50 transition-colors">
+                  <td class="sticky left-0 bg-white hover:bg-gray-50/50 px-5 py-3 text-sm font-medium text-gray-600 whitespace-nowrap">
+                    <%= row[:label] %>
+                  </td>
+                  <% val = @global_perf[row[:key]] %>
+                  <td class="px-4 py-3 text-right font-bold text-indigo-700 tabular-nums whitespace-nowrap">
+                    <%= val ? "#{val}#{row[:unit]}" : "—" %>
+                  </td>
+                  <% all_players.each do |d| %>
+                    <% pval = d[row[:key]] %>
+                    <td class="px-4 py-3 text-right text-gray-700 tabular-nums whitespace-nowrap">
+                      <%= pval ? "#{pval}#{row[:unit]}" : "—" %>
+                    </td>
+                  <% end %>
+                </tr>
+              <% end %>
+            <% end %>
+
+            <%# 生存時間グループ（ライフ数が動的） %>
+            <% if st_max_n > 0 %>
+              <tr class="bg-gray-50/70 border-t border-gray-200">
+                <td colspan="<%= col_count %>" class="sticky left-0 px-5 py-1.5 text-xs font-bold text-gray-400 uppercase tracking-widest">
+                  生存時間
+                </td>
+              </tr>
+              <% st_max_n.times do |i| %>
+                <%# N機体目ラベル行 %>
+                <tr class="bg-gray-50/40 border-t border-gray-100">
+                  <td colspan="<%= col_count %>" class="px-5 py-1 text-xs font-medium text-gray-400 pl-8">
+                    <%= i + 1 %>機体目
+                  </td>
+                </tr>
+                <%# 生存・被撃破の2行 %>
+                <% [ { key: :survived_cs, count_key: :survived_count, label: "生存",   label_color: "text-green-600" },
+                     { key: :died_cs,     count_key: :died_count,     label: "被撃破", label_color: "text-rose-600"  } ].each do |outcome| %>
+                  <%
+                    g_st  = global_st[i]
+                    g_cs  = g_st&.dig(outcome[:key])
+                    g_cnt = g_st&.dig(outcome[:count_key]).to_i
+                    next if g_cs.nil? && all_players.all? { |d| d[:survival_stats][i]&.dig(outcome[:key]).nil? }
+                  %>
+                  <tr class="border-t border-gray-100 hover:bg-gray-50/50 transition-colors">
+                    <td class="sticky left-0 bg-white hover:bg-gray-50/50 pl-10 pr-5 py-3 text-sm font-semibold whitespace-nowrap <%= outcome[:label_color] %>">
+                      <%= outcome[:label] %>
+                    </td>
+                    <td class="px-4 py-3 text-right font-bold text-indigo-700 tabular-nums whitespace-nowrap">
+                      <% if g_cs %>
+                        <%= format_survival_cs(g_cs) %>
+                        <span class="text-xs font-normal text-gray-400 ml-0.5"><%= g_cnt %>試合</span>
+                      <% else %>—<% end %>
+                    </td>
+                    <% all_players.each do |d| %>
+                      <% p_st  = d[:survival_stats][i]
+                         p_cs  = p_st&.dig(outcome[:key])
+                         p_cnt = p_st&.dig(outcome[:count_key]).to_i %>
+                      <td class="px-4 py-3 text-right text-gray-700 tabular-nums whitespace-nowrap">
+                        <% if p_cs %>
+                          <%= format_survival_cs(p_cs) %>
+                          <span class="text-xs text-gray-400 ml-0.5"><%= p_cnt %>試合</span>
+                        <% else %>—<% end %>
+                      </td>
+                    <% end %>
+                  </tr>
+                <% end %>
+              <% end %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
+
+  <%# ── 戻るリンク（下） %>
+  <%= link_to mobile_suits_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 transition-colors" do %>
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+    </svg>
+    機体一覧に戻る
+  <% end %>
+
+</div>

--- a/app/views/mobile_suits/show.html.erb
+++ b/app/views/mobile_suits/show.html.erb
@@ -45,7 +45,7 @@
 
           <%# Wiki リンク %>
           <% if @suit.wiki_url.present? %>
-            <%= link_to @suit.wiki_url, target: "_blank", rel: "noopener noreferrer",
+            <%= link_to safe_external_url(@suit.wiki_url), target: "_blank", rel: "noopener noreferrer",
                 class: "self-start inline-flex items-center gap-1.5 text-xs font-semibold text-indigo-600 bg-indigo-50 hover:bg-indigo-100 px-3 py-1.5 rounded-lg transition-colors" do %>
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>

--- a/app/views/mobile_suits/show.html.erb
+++ b/app/views/mobile_suits/show.html.erb
@@ -10,7 +10,7 @@
 
   <%# ── 機体カード（白） %>
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
-    <div class="flex flex-col sm:flex-row items-center sm:items-start gap-0">
+    <div class="flex flex-col sm:flex-row items-center gap-0">
 
       <%# 画像 %>
       <div class="flex-shrink-0 flex items-center justify-center bg-gray-50 sm:w-48 w-full py-8 px-6 border-b sm:border-b-0 sm:border-r border-gray-100">
@@ -27,7 +27,7 @@
       </div>
 
       <%# テキスト情報 %>
-      <div class="flex-1 min-w-0 p-6 sm:p-8 flex items-start gap-6">
+      <div class="flex-1 min-w-0 p-6 sm:p-8 flex items-center gap-6">
 
         <%# 左: コスト・名前・Wiki %>
         <div class="flex-1 min-w-0 flex flex-col gap-4">
@@ -46,12 +46,12 @@
           <%# Wiki リンク %>
           <% if @suit.wiki_url.present? %>
             <%= link_to @suit.wiki_url, target: "_blank", rel: "noopener noreferrer",
-                class: "self-start inline-flex items-center gap-1.5 text-sm font-semibold text-indigo-600 hover:text-indigo-800 hover:underline transition-colors" do %>
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                class: "self-start inline-flex items-center gap-1.5 text-xs font-semibold text-indigo-600 bg-indigo-50 hover:bg-indigo-100 px-3 py-1.5 rounded-lg transition-colors" do %>
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
               </svg>
               Wiki を開く
-              <svg class="w-3.5 h-3.5 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-3 h-3 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
               </svg>
             <% end %>
@@ -72,13 +72,13 @@
               <% specs.each do |spec| %>
                 <% parsed = parse_spec_field(spec[:value].to_s) %>
                 <div class="flex items-center justify-between gap-8 px-4 py-2.5">
-                  <dt class="text-xs font-medium text-gray-400 whitespace-nowrap"><%= spec[:label] %></dt>
+                  <dt class="text-sm font-medium text-gray-400 whitespace-nowrap"><%= spec[:label] %></dt>
                   <% if parsed.size == 1 && parsed[0][:label].nil? %>
                     <dd class="text-base font-bold text-gray-800 tabular-nums"><%= parsed[0][:value] %></dd>
                   <% else %>
-                    <dd class="text-right text-xs font-bold text-gray-800 leading-snug">
+                    <dd class="text-right text-base leading-snug">
                       <% parsed.each_with_index do |item, idx| %>
-                        <span class="tabular-nums"><%= item[:value] %></span><span class="font-normal text-gray-400 ml-0.5"><%= item[:label] %></span><% unless idx == parsed.size - 1 %><span class="text-gray-200 mx-1">/</span><% end %>
+                        <span class="font-normal text-gray-400"><%= item[:label] %>:</span> <span class="font-bold text-gray-800 tabular-nums"><%= item[:value] %></span><% unless idx == parsed.size - 1 %><span class="text-gray-200 mx-1.5">/</span><% end %>
                       <% end %>
                     </dd>
                   <% end %>

--- a/app/views/mobile_suits/show.html.erb
+++ b/app/views/mobile_suits/show.html.erb
@@ -27,55 +27,56 @@
       </div>
 
       <%# テキスト情報 %>
-      <div class="flex-1 min-w-0 p-6 sm:p-8 flex flex-col gap-4">
+      <div class="flex-1 min-w-0 p-6 sm:p-8 flex items-start gap-6">
 
-        <%# コスト・シリーズ %>
-        <div class="flex flex-wrap items-center gap-2">
-          <span class="text-xs font-bold px-3 py-1 rounded-full <%= cost_badge_classes(@suit.cost) %>">
-            Cost <%= @suit.cost %>
-          </span>
-          <span class="text-sm text-gray-500"><%= @suit.series %></span>
+        <%# 左: コスト・名前・Wiki %>
+        <div class="flex-1 min-w-0 flex flex-col gap-4">
+
+          <%# コスト・シリーズ %>
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="text-xs font-bold px-3 py-1 rounded-full <%= cost_badge_classes(@suit.cost) %>">
+              Cost <%= @suit.cost %>
+            </span>
+            <span class="text-sm text-gray-500"><%= @suit.series %></span>
+          </div>
+
+          <%# 機体名 %>
+          <h1 class="text-2xl sm:text-3xl font-black text-gray-900 leading-tight"><%= @suit.name %></h1>
+
+          <%# Wiki リンク %>
+          <% if @suit.wiki_url.present? %>
+            <%= link_to @suit.wiki_url, target: "_blank", rel: "noopener noreferrer",
+                class: "self-start inline-flex items-center gap-1.5 text-sm font-semibold text-indigo-600 hover:text-indigo-800 hover:underline transition-colors" do %>
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
+              </svg>
+              Wiki を開く
+              <svg class="w-3.5 h-3.5 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+              </svg>
+            <% end %>
+          <% end %>
+
         </div>
 
-        <%# 機体名 %>
-        <h1 class="text-2xl sm:text-3xl font-black text-gray-900 leading-tight"><%= @suit.name %></h1>
-
-        <%# スペック %>
+        <%# 右: スペックパネル %>
         <% if @suit.durability.present? || @suit.bd_count.present? || @suit.red_lock_range.present? %>
-          <div class="flex flex-wrap gap-4 text-sm">
-            <% if @suit.durability.present? %>
-              <div>
-                <span class="text-gray-400 text-sm font-medium block mb-0.5">耐久値</span>
-                <span class="font-bold text-gray-800 text-lg"><%= @suit.durability %></span>
-              </div>
-            <% end %>
-            <% if @suit.bd_count.present? %>
-              <div>
-                <span class="text-gray-400 text-sm font-medium block mb-0.5">BD回数</span>
-                <span class="font-bold text-gray-800 text-lg"><%= @suit.bd_count %></span>
-              </div>
-            <% end %>
-            <% if @suit.red_lock_range.present? %>
-              <div>
-                <span class="text-gray-400 text-sm font-medium block mb-0.5">赤ロック距離</span>
-                <span class="font-bold text-gray-800 text-lg"><%= @suit.red_lock_range %></span>
-              </div>
-            <% end %>
+          <div class="flex-shrink-0 self-start bg-gray-50 rounded-xl border border-gray-100 overflow-hidden">
+            <%
+              specs = []
+              specs << { label: "耐久値",      value: @suit.durability      } if @suit.durability.present?
+              specs << { label: "BD回数",       value: @suit.bd_count        } if @suit.bd_count.present?
+              specs << { label: "赤ロック距離", value: @suit.red_lock_range  } if @suit.red_lock_range.present?
+            %>
+            <dl class="divide-y divide-gray-100">
+              <% specs.each do |spec| %>
+                <div class="flex items-center justify-between gap-8 px-4 py-2.5">
+                  <dt class="text-xs font-medium text-gray-400 whitespace-nowrap"><%= spec[:label] %></dt>
+                  <dd class="text-base font-bold text-gray-800 tabular-nums"><%= spec[:value] %></dd>
+                </div>
+              <% end %>
+            </dl>
           </div>
-        <% end %>
-
-        <%# Wiki リンク %>
-        <% if @suit.wiki_url.present? %>
-          <%= link_to @suit.wiki_url, target: "_blank", rel: "noopener noreferrer",
-              class: "self-start inline-flex items-center gap-1.5 text-sm font-semibold text-indigo-600 hover:text-indigo-800 hover:underline transition-colors" do %>
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/>
-            </svg>
-            Wiki を開く
-            <svg class="w-3.5 h-3.5 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
-            </svg>
-          <% end %>
         <% end %>
 
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
   get "statistics", to: "statistics#index", as: :statistics
 
   # Mobile Suits (public)
-  resources :mobile_suits, only: [ :index ]
+  resources :mobile_suits, only: [ :index, :show ]
 
   # API
   namespace :api do

--- a/db/migrate/20260310120712_add_spec_columns_to_mobile_suits.rb
+++ b/db/migrate/20260310120712_add_spec_columns_to_mobile_suits.rb
@@ -1,0 +1,7 @@
+class AddSpecColumnsToMobileSuits < ActiveRecord::Migration[8.1]
+  def change
+    add_column :mobile_suits, :durability, :integer
+    add_column :mobile_suits, :bd_count, :integer
+    add_column :mobile_suits, :red_lock_range, :decimal, precision: 5, scale: 2
+  end
+end

--- a/db/migrate/20260311143008_change_spec_columns_string_in_mobile_suits.rb
+++ b/db/migrate/20260311143008_change_spec_columns_string_in_mobile_suits.rb
@@ -1,0 +1,6 @@
+class ChangeSpecColumnsStringInMobileSuits < ActiveRecord::Migration[8.1]
+  def change
+    change_column :mobile_suits, :bd_count, :string
+    change_column :mobile_suits, :red_lock_range, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_09_150445) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_10_120712) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -101,11 +101,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_09_150445) do
   end
 
   create_table "mobile_suits", force: :cascade do |t|
+    t.integer "bd_count"
     t.integer "cost", null: false
     t.datetime "created_at", null: false
+    t.integer "durability"
     t.string "image_filename"
     t.string "name", null: false
     t.integer "position"
+    t.decimal "red_lock_range", precision: 5, scale: 2
     t.string "series", null: false
     t.datetime "updated_at", null: false
     t.string "wiki_url"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_10_120712) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_11_143008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -101,14 +101,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_10_120712) do
   end
 
   create_table "mobile_suits", force: :cascade do |t|
-    t.integer "bd_count"
+    t.string "bd_count"
     t.integer "cost", null: false
     t.datetime "created_at", null: false
     t.integer "durability"
     t.string "image_filename"
     t.string "name", null: false
     t.integer "position"
-    t.decimal "red_lock_range", precision: 5, scale: 2
+    t.string "red_lock_range"
     t.string "series", null: false
     t.datetime "updated_at", null: false
     t.string "wiki_url"

--- a/lib/tasks/vsmobile.rake
+++ b/lib/tasks/vsmobile.rake
@@ -25,7 +25,14 @@ namespace :vsmobile do
       end
 
       image_filename = File.basename(unit["imageLocalPath"])
-      suit.update!(wiki_url: unit["wikiUrl"], image_filename: image_filename)
+      metadata = unit["metadata"] || {}
+      suit.update!(
+        wiki_url:       unit["wikiUrl"],
+        image_filename: image_filename,
+        durability:     metadata["durability"]&.to_i.presence,
+        bd_count:       metadata["bdCount"].presence,
+        red_lock_range: metadata["redLockRange"].presence
+      )
       updated += 1
     end
 


### PR DESCRIPTION
## Summary
- `mobile_suits` テーブルにスペックカラム（耐久値・BD回数・赤ロック距離）を追加
- BD回数・赤ロック距離のカラム型を string に変更（換装機の複数形態値に対応）
- 管理画面の機体編集フォームにスペック入力フィールドを追加
- `vsmobile:import_mobile_suit_data` タスクでスペックデータを一括インポート
- 機体詳細ページ（`/mobile_suits/:id`）を新設
  - 機体名・コスト・シリーズ・画像・スペック情報（耐久値・BD回数・赤ロック距離）・Wikiリンクを表示
  - スペック値は全角コロン区切りで形態別に分解して表示（例: フルアーマー: 7 / 強化型: 8）
  - 使用回数・勝率・環境支配度（グラデーションカード＋全機体内順位）
  - 使用プレイヤー TOP5
  - 相方コスト別分析（使用割合・勝率の2本バー）
  - 相方機体ランキング TOP10
  - 基本パフォーマンス統計テーブル（スコア・ダメージ・EXバースト・OL発動率・生存時間）を統計ページと同じグループ・列順で表示
- 機体一覧のグリッドカードから詳細ページへリンクを追加
- 機体カードのレイアウト調整（縦中央揃え・WikiリンクをピルボタンUI）

## Test plan
- [x] 機体一覧 → 機体詳細へ遷移できる
- [x] 試合データがある機体で統計サマリー・各セクションが正しく表示される
- [x] 試合データがない機体で「まだ試合データがありません」が表示される
- [x] 管理画面で耐久値・BD回数・赤ロック距離を入力・保存できる
- [x] スペック情報が詳細ページに反映される（単純値・複数形態値どちらも）
- [x] `bin/rails db:migrate` が正常に完了する

Closes #11