### PR TITLE
chore: units.json を最新データに更新（2026-03-11）

### DIFF
--- a/db/data/units.json
+++ b/db/data/units.json
@@ -214,7 +214,7 @@
         "機動戦士ガンダムUC"
       ],
       "metadata": {
-        "durability": "680",
+        "durability": "720",
         "formChange": "ユニコーンデストロイ",
         "moveType": "通常BD",
         "bdCount": "ユニコーン：7デストロイ：8",
@@ -1564,7 +1564,8 @@
         "コスト3000",
         "ガンダム",
         "カウンター",
-        "機動戦士ガンダム 鉄血のオルフェンズ"
+        "機動戦士ガンダム 鉄血のオルフェンズ",
+        "特殊移動派生"
       ],
       "metadata": {
         "durability": "760",
@@ -2784,7 +2785,7 @@
         "SEED発現"
       ],
       "metadata": {
-        "durability": "640",
+        "durability": "660",
         "formChange": "SEED発現",
         "moveType": "通常BD",
         "bdCount": "通常時：7SEED発現中：8",
@@ -6940,7 +6941,8 @@
         "コスト2000",
         "ガンダム",
         "無限赤ロック",
-        "機動戦士ガンダム 鉄血のオルフェンズ"
+        "機動戦士ガンダム 鉄血のオルフェンズ",
+        "機体スキン"
       ],
       "metadata": {
         "durability": "620",
@@ -8133,7 +8135,7 @@
     }
   ],
   "metadata": {
-    "scrapedAt": "2026-02-23T12:31:40.510069+00:00",
+    "scrapedAt": "2026-03-11T23:50:41.376244+00:00",
     "sourceUrl": "https://w.atwiki.jp/exvs2infiniteboost/pages/123.html",
     "totalUnits": 247,
     "scraperVersion": "0.1.0",


### PR DESCRIPTION
## Summary
- exvs2ib-wiki-scraper で再取得した最新データに units.json を更新

## 変更内容
| 機体 | 変更前 | 変更後 |
|------|--------|--------|
| ユニコーンガンダム | 耐久 680 | 耐久 720 |
| ストライクフリーダムガンダム | 耐久 640 | 耐久 660 |
| ガンダムバルバトス | タグなし | 「特殊移動派生」タグ追加 |
| ガンダムグシオンリベイク | タグなし | 「機体スキン」タグ追加 |
| メタデータ | scrapedAt: 2026-02-23 | scrapedAt: 2026-03-11 |

## Test plan
- [ ] マージ後に `kamal app exec 'bin/rails mobile_suits:import_data'` を実行して機体詳細画面のスペックに反映されることを確認