### PR TITLE
feat: Discord自動リマインド - イベント前日・7日前に投稿

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -207,6 +207,6 @@ class EventsController < ApplicationController
   end
 
   def event_params
-    params.require(:event).permit(:name, :held_on, :description, :broadcast_url)
+    params.require(:event).permit(:name, :held_on, :description, :broadcast_url, :discord_thread_url)
   end
 end

--- a/app/jobs/event_reminder_job.rb
+++ b/app/jobs/event_reminder_job.rb
@@ -1,0 +1,30 @@
+class EventReminderJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    today = Date.current
+
+    { 1 => "明日", 7 => "1週間後に" }.each do |days, label|
+      target_date = today + days
+      events = Event.where(held_on: target_date)
+      next if events.none?
+
+      events.each do |event|
+        message = build_message(event, label)
+        DiscordWebhookService.post(purpose: :reminder, message: message)
+      end
+    end
+  end
+
+  private
+
+  def build_message(event, label)
+    lines = []
+    lines << "@everyone"
+    lines << "【リマインド】"
+    lines << "こちら、#{label}開催です！！"
+    lines << "参加したい方はフォーラムまで連絡下さい！！"
+    lines << event.discord_thread_url if event.discord_thread_url.present?
+    lines.join("\n")
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,7 @@ class Event < ApplicationRecord
   validates :name, presence: true
   validates :held_on, presence: true
   validates :broadcast_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
+  validates :discord_thread_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
 
   # Associations
   has_many :matches, dependent: :destroy

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -31,6 +31,12 @@
     <p class="mt-1 text-sm text-gray-500">YouTubeなどの配信アーカイブURLを入力すると、詳細画面にリンクが表示されます</p>
   </div>
 
+  <div>
+    <%= form.label :discord_thread_url, "DiscordフォーラムスレッドURL（任意）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.url_field :discord_thread_url, placeholder: "https://discord.com/channels/...", class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    <p class="mt-1 text-sm text-gray-500">設定するとDiscordリマインドメッセージにスレッドリンクが含まれます</p>
+  </div>
+
   <div class="flex justify-end space-x-3">
     <%= link_to "キャンセル", events_path, class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
     <%= form.submit event.new_record? ? "作成" : "更新", class: "px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700" %>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,8 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+
+  event_reminder:
+    class: EventReminderJob
+    queue: default
+    schedule: every day at 12pm

--- a/db/migrate/20260314002422_add_discord_thread_url_to_events.rb
+++ b/db/migrate/20260314002422_add_discord_thread_url_to_events.rb
@@ -1,0 +1,5 @@
+class AddDiscordThreadUrlToEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :events, :discord_thread_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_13_124720) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_14_002422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -37,6 +37,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_13_124720) do
     t.string "broadcast_url"
     t.datetime "created_at", null: false
     t.text "description"
+    t.string "discord_thread_url"
     t.date "held_on", null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## Summary
- `events` テーブルに `discord_thread_url` カラムを追加し、イベント作成・編集フォームから設定可能にした
- `EventReminderJob` を実装。毎日12時（JST）に実行され、翌日・7日後のイベントを `reminder` チャンネルへ自動投稿する
- メッセージ形式は手動投稿に合わせた（`@everyone` / `【リマインド】` / フォーラムスレッドリンク）
- `discord_thread_url` 未設定の場合はスレッドリンク行を省略、`reminder` チャンネルWebhook未設定の場合は何もしない

## Test plan
- [x] イベント編集画面で `discord_thread_url` を入力・保存できる
- [x] `bin/rails runner` でジョブを手動実行し、対象イベントがある日付に正しく投稿される
- [x] `discord_thread_url` 未設定のイベントでもエラーなく投稿される
- [x] `reminder` チャンネル未設定時はスキップされる

## 関連Issue・PR
#174