### PR TITLE
feat: ページタイトルを「VS.Mobile for KGY」に変更

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
   <div class="max-w-md w-full space-y-8">
     <div class="text-center">
-      <img src="/logo-login.png" alt="VS.モバイル for KGY" class="mx-auto max-h-48 sm:max-h-60 w-auto">
+      <img src="/logo-login.png" alt="VS.Mobile for KGY" class="mx-auto max-h-48 sm:max-h-60 w-auto">
     </div>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "mt-8 space-y-6" }) do |f| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html style="scrollbar-gutter: stable;">
   <head>
-    <title><%= content_for(:title) || "VS.モバイル for KGY" %></title>
+    <title><%= content_for(:title) || "VS.Mobile for KGY" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Vsmobile Kgy">
@@ -39,7 +39,7 @@
         <!-- ロゴ部分（白背景） -->
         <div class="flex-shrink-0 px-4 py-4 bg-white border-b border-gray-200">
           <%= link_to root_path do %>
-            <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.モバイル for KGY" class="h-12">
+            <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.Mobile for KGY" class="h-12">
           <% end %>
         </div>
 
@@ -166,7 +166,7 @@
           <div class="flex">
             <div class="flex-shrink-0 flex items-center">
               <%= link_to root_path do %>
-                <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.モバイル for KGY" class="h-12 sm:h-14">
+                <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.Mobile for KGY" class="h-12 sm:h-14">
               <% end %>
             </div>
             <% if user_signed_in? %>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "VS.モバイル for KGY",
+  "name": "VS.Mobile for KGY",
   "short_name": "VSM KGY",
   "icons": [
     {


### PR DESCRIPTION
## Summary
- ブラウザタブの `<title>` デフォルト値を「VS.モバイル for KGY」→「VS.Mobile for KGY」に変更
- PC・モバイルヘッダーのロゴ画像 `alt` 属性を変更（2箇所）
- ログインページのロゴ画像 `alt` 属性を変更（1箇所）
- PWA manifest の `name` フィールドを変更（1箇所）

## Test plan
- [x] ブラウザタブのタイトルが「VS.Mobile for KGY」になっていることを確認
- [x] PWA としてインストールした際のアプリ名が「VS.Mobile for KGY」になっていることを確認

Closes #179