### PR TITLE
fix: お気に入りフィルター設定後にソートボタンを押すとフィルターがリセットされるバグを修正

### DIFF
--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -288,13 +288,13 @@
               <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
             <% else %>
               <%= link_to label,
-                    matches_path(sort: value, per: @per_page, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], mobile_suits: params[:mobile_suits], costs: params[:costs], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]),
+                    matches_path(_all.merge(sort: value)),
                     class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
             <% end %>
           <% end %>
         </div>
       </div>
-      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], mobile_suits: params[:mobile_suits], costs: params[:costs], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
+      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(_all.merge(per: n)) } %>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -381,7 +381,7 @@
     <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
       <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
         <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
-        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(sort: @sort, per: n, events: params[:events], users: params[:users], users_mode: params[:users_mode], streaming_users: params[:streaming_users], streaming_users_mode: params[:streaming_users_mode], mobile_suits: params[:mobile_suits], costs: params[:costs], stat_player_id: params[:stat_player_id], ol_filter: params[:ol_filter], stat_filters: params[:stat_filters], damage_dealt_val: params[:damage_dealt_val], damage_dealt_dir: params[:damage_dealt_dir], damage_received_val: params[:damage_received_val], damage_received_dir: params[:damage_received_dir]) } %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(_all.merge(per: n)) } %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Summary
- ソートボタン（最新順/リアクション順）クリック後もお気に入り機体フィルターの状態が維持されるよう修正

## 原因
`app/views/matches/index.html.erb` のソートボタンおよび per_page_selector のリンク生成で明示的にパラメータを列挙していたが、`my_mobile_suits` パラメータが含まれていなかった。お気に入りボタンのアクティブ状態は `@filter_my_mobile_suits` が `true` であることを要求するため、ソート後に `nil` になると見た目上リセットされた。

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| ソートボタンのリンク | 全パラメータを明示列挙（`my_mobile_suits` 欠落） | `_all.merge(sort: value)` |
| per_page_selector（上部） | 全パラメータを明示列挙（`my_mobile_suits` 欠落） | `_all.merge(per: n)` |
| per_page_selector（下部） | 全パラメータを明示列挙（`my_mobile_suits` 欠落） | `_all.merge(per: n)` |

## Test plan
- [x] お気に入り機体フィルターを有効にした状態で「最新順」ボタンを押し、ボタンが点灯したままになることを確認
- [x] お気に入り機体フィルターを有効にした状態で「リアクション順」ボタンを押し、ボタンが点灯したままになることを確認
- [x] per_page 変更後もフィルター状態が維持されることを確認

Closes #181