### PR TITLE
fix: プッシュ通知タップ時にローテーションページへ遷移する

### DIFF
--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -11,7 +11,7 @@ class PushNotificationService
         user_id: user.id,
         title: title,
         body: body,
-        path: "/dashboard"
+        path: "/rotations/#{rotation.id}"
       )
     end
 
@@ -25,7 +25,7 @@ class PushNotificationService
         user_id: user.id,
         title: title,
         body: body,
-        path: "/dashboard"
+        path: "/rotations/#{rotation.id}"
       )
     end
 
@@ -66,7 +66,7 @@ class PushNotificationService
           user_id: user.id,
           title: "ローテーションが開始されました",
           body: "#{rotation.display_name}が開始されました",
-          path: "/dashboard"
+          path: "/rotations/#{rotation.id}"
         )
       end
     end


### PR DESCRIPTION
## Summary
- プッシュ通知タップ時の遷移先を `/dashboard` から該当ローテーションのページ (`/rotations/:id`) に変更した

## 原因
`PushNotificationService` の各通知メソッドで `path: "/dashboard"` をハードコードしていたため、通知をタップしてもダッシュボードにしか遷移しなかった。各メソッドはすでに `rotation:` を引数として受け取っており、`rotation.id` を使うだけでよかった。

## 変更内容
| メソッド | 変更前 | 変更後 |
|---|---|---|
| `notify_match_upcoming` | `/dashboard` | `/rotations/#{rotation.id}` |
| `notify_match_now` | `/dashboard` | `/rotations/#{rotation.id}` |
| `notify_rotation_activated` | `/dashboard` | `/rotations/#{rotation.id}` |

## Test plan
- [x] ローテーションを activate して通知を受信し、タップするとそのローテーションページに遷移することを確認
- [x] 「あと〇試合」「出番です」通知をタップしてローテーションページに遷移することを確認

## 関連Issue・PR
#59