### PR TITLE
feat: 対戦履歴に「自チームを左に」表示オプションを追加

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -192,6 +192,7 @@ class MatchesController < ApplicationController
     @filter_mobile_suits = params[:mobile_suits].present? ? params[:mobile_suits].reject(&:blank?).map(&:to_i) : []
     @filter_costs = params[:costs].present? ? params[:costs].reject(&:blank?).map(&:to_i) : []
     @filter_my_mobile_suits = params[:my_mobile_suits] == "1"
+    @flip_team = params[:flip_team] == "1"
     @filter_stat_player_id = stat_player_id
     @filter_ol_filter = ol_filter
     @filter_stat_filters = stat_filters

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -17,7 +17,7 @@
 
   <!-- フィルターセクション -->
   <%
-    _bp = { sort: @sort, per: @per_page,
+    _bp = { sort: @sort, per: @per_page, flip_team: @flip_team ? "1" : nil,
             stat_player_id: @filter_stat_player_id, ol_filter: @filter_ol_filter,
             stat_filters: @filter_stat_filters,
             damage_dealt_val: @filter_damage_dealt_val, damage_dealt_dir: @filter_damage_dealt_dir,
@@ -151,6 +151,7 @@
           <% @filter_mobile_suits.each do |id| %><input type="hidden" name="mobile_suits[]" value="<%= id %>"><% end %>
           <% @filter_costs.each do |c| %><input type="hidden" name="costs[]" value="<%= c %>"><% end %>
           <% if @filter_my_mobile_suits %><input type="hidden" name="my_mobile_suits" value="1"><% end %>
+          <% if @flip_team %><input type="hidden" name="flip_team" value="1"><% end %>
           <input type="hidden" name="sort" value="<%= @sort %>">
           <input type="hidden" name="per" value="<%= @per_page %>">
 
@@ -294,7 +295,19 @@
           <% end %>
         </div>
       </div>
-      <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(_all.merge(per: n)) } %>
+      <div class="flex items-center gap-3">
+        <% if viewing_as_user&.regular_user? %>
+          <%= link_to matches_path(_all.merge(flip_team: @flip_team ? nil : "1", page: nil)),
+                title: "自分が参加した試合で、自チームを左側に表示します",
+                class: "flex items-center gap-1.5 px-3 py-1 text-sm font-medium rounded-lg border transition whitespace-nowrap #{@flip_team ? 'bg-indigo-600 text-white border-indigo-600' : 'text-gray-500 bg-white border-gray-300 hover:border-indigo-300 hover:text-indigo-600'}" do %>
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
+            </svg>
+            自チームを左に
+          <% end %>
+        <% end %>
+        <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(_all.merge(per: n)) } %>
+      </div>
     </div>
     <ul class="divide-y divide-gray-200">
       <% @matches.each do |match| %>
@@ -322,24 +335,46 @@
               </div>
             </div>
 
+            <%
+              _all_mp      = match.match_players.sort_by { |mp| [mp.team_number, mp.position] }
+              _team1       = _all_mp.select { |mp| mp.team_number == 1 }
+              _team2       = _all_mp.select { |mp| mp.team_number == 2 }
+              _streaming_id = _team1.first&.id
+
+              if @flip_team && viewing_as_user
+                _user_team = _all_mp.find { |mp| mp.user_id == viewing_as_user.id }&.team_number
+                if _user_team == 2
+                  _left_players, _right_players = _team2, _team1
+                  _left_wins = match.winning_team == 2
+                else
+                  _left_players, _right_players = _team1, _team2
+                  _left_wins = match.winning_team == 1
+                end
+                _left_label  = "自チーム"
+                _right_label = "相手チーム"
+              else
+                _left_players, _right_players = _team1, _team2
+                _left_wins    = match.winning_team == 1
+                _left_label   = "チーム1"
+                _right_label  = "チーム2"
+              end
+            %>
             <%= link_to match_path(match), class: "block", data: { turbo_frame: "_top" } do %>
               <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
-                <% team1_players = match.match_players.where(team_number: 1).order(:position) %>
-                <% team2_players = match.match_players.where(team_number: 2).order(:position) %>
 
-                <!-- Team 1 -->
-                <div class="<%= match.winning_team == 1 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">
+                <!-- 左チーム -->
+                <div class="<%= _left_wins ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">
                   <div class="text-xs font-semibold text-gray-500 mb-2 flex items-center justify-between">
-                    <span>チーム1</span>
-                    <span class="px-2 py-0.5 rounded text-xs font-bold <%= match.winning_team == 1 ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
-                      <%= match.winning_team == 1 ? 'WIN' : 'LOSE' %>
+                    <span><%= _left_label %></span>
+                    <span class="px-2 py-0.5 rounded text-xs font-bold <%= _left_wins ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
+                      <%= _left_wins ? 'WIN' : 'LOSE' %>
                     </span>
                   </div>
-                  <% team1_players.each_with_index do |player, index| %>
+                  <% _left_players.each do |player| %>
                     <div class="mb-1">
-                      <span class="<%= index == 0 ? 'text-red-600 font-bold' : 'text-gray-700' %>">
+                      <span class="<%= player.id == _streaming_id ? 'text-red-600 font-bold' : 'text-gray-700' %>">
                         <%= player.user.nickname %>
-                        <% if index == 0 %>
+                        <% if player.id == _streaming_id %>
                           <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
                         <% end %>
                       </span>
@@ -353,17 +388,22 @@
                   VS
                 </div>
 
-                <!-- Team 2 -->
-                <div class="<%= match.winning_team == 2 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">
+                <!-- 右チーム -->
+                <div class="<%= _left_wins ? 'bg-red-50 border-2 border-red-400 rounded p-2' : 'bg-blue-50 border-2 border-blue-400 rounded p-2' %>">
                   <div class="text-xs font-semibold text-gray-500 mb-2 flex items-center justify-between">
-                    <span>チーム2</span>
-                    <span class="px-2 py-0.5 rounded text-xs font-bold <%= match.winning_team == 2 ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
-                      <%= match.winning_team == 2 ? 'WIN' : 'LOSE' %>
+                    <span><%= _right_label %></span>
+                    <span class="px-2 py-0.5 rounded text-xs font-bold <%= _left_wins ? 'bg-red-600 text-white' : 'bg-blue-600 text-white' %>">
+                      <%= _left_wins ? 'LOSE' : 'WIN' %>
                     </span>
                   </div>
-                  <% team2_players.each do |player| %>
+                  <% _right_players.each do |player| %>
                     <div class="mb-1">
-                      <span class="text-gray-700"><%= player.user.nickname %></span>
+                      <span class="<%= player.id == _streaming_id ? 'text-red-600 font-bold' : 'text-gray-700' %>">
+                        <%= player.user.nickname %>
+                        <% if player.id == _streaming_id %>
+                          <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
+                        <% end %>
+                      </span>
                       <div class="text-gray-500"><%= player.mobile_suit.name %></div>
                     </div>
                   <% end %>


### PR DESCRIPTION
## Summary
- 対戦履歴の結果ヘッダー右側に「自チームを左に」トグルボタンを追加
- ONにすると、自分が参加している試合でチーム表示が左右入れ替わり、自チームが常に左側に表示される
- チームラベルも「チーム1/チーム2」から「自チーム/相手チーム」に変わる
- 配信台マーカーは入れ替え後も正しく表示される（player ID で判定）
- 一般ユーザーのみ表示（管理者・ゲストは非表示）
- `flip_team` パラメータはフィルター・ソート・ページネーション間で引き継がれる

## Test plan
- [x] 一般ユーザーでログインし、「自チームを左に」ボタンが表示されることを確認
- [x] ボタンをONにすると、自分が参加した試合の自チームが左側に表示されることを確認
- [x] 自分が参加していない試合はチーム1/チーム2の通常表示のままであることを確認
- [x] ボタンON時、配信台マーカーが正しいプレイヤーに表示されることを確認
- [x] フィルター・ソート・ページ移動後も `flip_team` 状態が維持されることを確認
- [x] 管理者・ゲストユーザーではボタンが表示されないことを確認

Closes #188