### PR TITLE
feat: 各ページの機体名リンクと機体画像の追加

### DIFF
--- a/app/javascript/controllers/card_link_controller.js
+++ b/app/javascript/controllers/card_link_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+import { Turbo } from "@hotwired/turbo-rails"
+
+export default class extends Controller {
+  static values = { url: String }
+
+  navigate(event) {
+    if (!event.target.closest("a, button")) {
+      Turbo.visit(this.urlValue)
+    }
+  }
+}

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -352,7 +352,10 @@
                 # ログインユーザーのチームを特定
                 my_player = match.match_players.find { |mp| mp.user_id == viewing_as_user.id }
               %>
-              <%= link_to match_path(match), class: "block hover:bg-gray-50 px-6 py-4" do %>
+              <div class="block hover:bg-gray-50 px-6 py-4 cursor-pointer"
+                   data-controller="card-link"
+                   data-card-link-url-value="<%= match_path(match) %>"
+                   data-action="click->card-link#navigate">
                 <div class="flex items-center justify-between mb-2">
                   <span class="text-xs text-gray-500"><%= match.played_at.strftime('%Y年%m月%d日') %></span>
                   <% if my_player %>
@@ -386,7 +389,9 @@
                       <div class="font-semibold text-gray-700 mb-1">自チーム</div>
                       <% my_team_players.each_with_index do |player, index| %>
                         <div class="<%= (my_team == 1 && player.position == 1) ? 'text-red-600 font-bold' : 'text-gray-600' %>">
-                          <%= player.user.nickname %> / <%= player.mobile_suit.name %>
+                          <%= player.user.nickname %> /
+                          <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                              class: "hover:text-indigo-600 hover:underline transition-colors" %>
                         </div>
                       <% end %>
                     </div>
@@ -403,13 +408,15 @@
                       <div class="font-semibold text-gray-700 mb-1">相手チーム</div>
                       <% opponent_players.each_with_index do |player, index| %>
                         <div class="<%= (opponent_team == 1 && player.position == 1) ? 'text-red-600 font-bold' : 'text-gray-600' %>">
-                          <%= player.user.nickname %> / <%= player.mobile_suit.name %>
+                          <%= player.user.nickname %> /
+                          <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                              class: "hover:text-indigo-600 hover:underline transition-colors" %>
                         </div>
                       <% end %>
                     </div>
                   </div>
                 <% end %>
-              <% end %>
+              </div>
             <% end %>
           <% else %>
             <div class="px-6 py-8 text-center">
@@ -439,14 +446,16 @@
             <% @matchup_matrix.each do |matrix| %>
               <div class="border rounded p-4">
                 <div class="font-semibold text-gray-900 mb-3 flex items-center gap-2">
-                  <%= matrix[:my_suit].name %>
+                  <%= link_to matrix[:my_suit].name, mobile_suit_path(matrix[:my_suit]),
+                      class: "hover:text-indigo-600 hover:underline transition-colors" %>
                   <%= cost_badge(matrix[:my_suit].cost) %>
                 </div>
                 <div class="space-y-2">
                   <% matrix[:matchups].each do |matchup| %>
                     <div class="flex items-center justify-between text-sm bg-gray-50 rounded p-2">
                       <div class="flex-1">
-                        <span class="text-gray-700"><%= matchup[:opponent_suit].name %></span>
+                        <%= link_to matchup[:opponent_suit].name, mobile_suit_path(matchup[:opponent_suit]),
+                            class: "text-gray-700 hover:text-indigo-600 hover:underline transition-colors" %>
                         <span class="text-xs text-gray-500 ml-2"><%= matchup[:wins] %>勝<%= matchup[:losses] %>敗</span>
                       </div>
                       <div class="flex items-center space-x-2">
@@ -606,7 +615,10 @@
             <% @event_suit_trend.each do |trend| %>
               <div class="px-6 py-4">
                 <div class="flex items-center justify-between mb-1">
-                  <div class="font-medium text-gray-900"><%= trend[:mobile_suit].name %></div>
+                  <div class="font-medium text-gray-900">
+                    <%= link_to trend[:mobile_suit].name, mobile_suit_path(trend[:mobile_suit]),
+                        class: "hover:text-indigo-600 hover:underline transition-colors" %>
+                  </div>
                   <div class="text-sm font-semibold <%= trend[:win_rate] >= 60 ? 'text-blue-600' : 'text-gray-600' %>">
                     <%= trend[:win_rate] %>%
                   </div>
@@ -697,7 +709,11 @@
                 <div class="flex items-center">
                   <span class="text-lg font-bold text-gray-400 mr-3"><%= index + 1 %></span>
                   <div>
-                    <div class="text-sm font-medium text-gray-900 flex items-center gap-2"><%= suit.name %> <%= cost_badge(suit.cost) %></div>
+                    <div class="text-sm font-medium text-gray-900 flex items-center gap-2">
+                      <%= link_to suit.name, mobile_suit_path(suit),
+                          class: "hover:text-indigo-600 hover:underline transition-colors" %>
+                      <%= cost_badge(suit.cost) %>
+                    </div>
                     <div class="text-xs text-gray-500"><%= suit.series %></div>
                   </div>
                 </div>
@@ -758,7 +774,10 @@
                   <span class="text-xl sm:text-2xl font-bold text-gray-300"><%= index + 1 %></span>
                   <span class="text-xs sm:text-sm text-blue-600 font-semibold"><%= suit.usage_count %>回</span>
                 </div>
-                <div class="text-xs sm:text-sm font-medium text-gray-900"><%= suit.name %></div>
+                <div class="text-xs sm:text-sm font-medium text-gray-900">
+                  <%= link_to suit.name, mobile_suit_path(suit),
+                      class: "hover:text-indigo-600 hover:underline transition-colors" %>
+                </div>
                 <div class="text-xs text-gray-500 mt-1 truncate"><%= suit.series %></div>
                 <div class="mt-1"><%= cost_badge(suit.cost) %></div>
               </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -122,8 +122,10 @@
           <ul class="divide-y divide-gray-200">
             <% @matches.each do |match| %>
               <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
-              <%= link_to match_path(match), class: "block hover:bg-gray-50" do %>
-                <li class="px-4 py-3">
+              <li class="px-4 py-3 hover:bg-gray-50 cursor-pointer"
+                  data-controller="card-link"
+                  data-card-link-url-value="<%= match_path(match) %>"
+                  data-action="click->card-link#navigate">
                   <div class="flex items-center gap-2 mb-2">
                     <span class="text-sm font-semibold text-gray-900">第<%= @match_numbers[match.id] %>試合</span>
                     <% if match.rotation_match&.started_at %>
@@ -160,7 +162,8 @@
                               <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
                             <% end %>
                           </span>
-                          <div class="text-gray-500"><%= player.mobile_suit.name %></div>
+                          <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                              class: "text-gray-500 hover:text-indigo-600 hover:underline transition-colors" %>
                         </div>
                       <% end %>
                     </div>
@@ -181,7 +184,8 @@
                       <% team2_players.each do |player| %>
                         <div class="mb-1">
                           <span class="text-gray-700"><%= player.user.nickname %></span>
-                          <div class="text-gray-500"><%= player.mobile_suit.name %></div>
+                          <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                              class: "text-gray-500 hover:text-indigo-600 hover:underline transition-colors" %>
                         </div>
                       <% end %>
                     </div>
@@ -190,7 +194,6 @@
                     <%= render "reactions/reaction_bar", match: match, compact: true, emojis: @emojis %>
                   </div>
                 </li>
-              <% end %>
             <% end %>
           </ul>
           <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -8,9 +8,9 @@
     <% if current_user.is_admin? %>
       <div class="flex flex-wrap gap-2">
         <% if @latest_event %>
-          <%= link_to "新規登録", new_event_match_path(@latest_event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
+          <%= link_to "新規登録", new_event_match_path(@latest_event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded", data: { turbo_frame: "_top" } %>
         <% end %>
-        <%= link_to "CSVインポート", new_admin_import_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
+        <%= link_to "CSVインポート", new_admin_import_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded", data: { turbo_frame: "_top" } %>
       </div>
     <% end %>
   </div>
@@ -359,7 +359,10 @@
                 _right_label  = "チーム2"
               end
             %>
-            <%= link_to match_path(match), class: "block", data: { turbo_frame: "_top" } do %>
+            <div class="block cursor-pointer"
+                 data-controller="card-link"
+                 data-card-link-url-value="<%= match_path(match) %>"
+                 data-action="click->card-link#navigate">
               <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
 
                 <!-- 左チーム -->
@@ -378,7 +381,9 @@
                           <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
                         <% end %>
                       </span>
-                      <div class="text-gray-500"><%= player.mobile_suit.name %></div>
+                      <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                          class: "text-gray-500 hover:text-indigo-600 hover:underline transition-colors",
+                          data: { turbo_frame: "_top" } %>
                     </div>
                   <% end %>
                 </div>
@@ -404,12 +409,14 @@
                           <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
                         <% end %>
                       </span>
-                      <div class="text-gray-500"><%= player.mobile_suit.name %></div>
+                      <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                          class: "text-gray-500 hover:text-indigo-600 hover:underline transition-colors",
+                          data: { turbo_frame: "_top" } %>
                     </div>
                   <% end %>
                 </div>
               </div>
-            <% end %>
+            </div>
 
             <!-- リアクションバー（リアルタイム更新対応） -->
             <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -67,12 +67,27 @@
                         <span class="px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
                       <% end %>
                     </div>
-                    <div class="mt-2">
-                      <p class="text-sm text-gray-500">使用機体</p>
-                      <p class="text-sm font-medium text-gray-900 flex items-center gap-2">
-                        <%= player.mobile_suit.name %>
-                        <%= cost_badge(player.mobile_suit.cost) %>
-                      </p>
+                    <div class="mt-3 flex items-center gap-3">
+                      <%= link_to mobile_suit_path(player.mobile_suit), class: "shrink-0 block" do %>
+                        <% if player.mobile_suit.image_filename.present? %>
+                          <%= image_tag "/mobile_suits/#{player.mobile_suit.image_filename}", alt: player.mobile_suit.name,
+                              class: "w-28 h-16 object-contain rounded-lg bg-gray-100 hover:opacity-80 transition-opacity" %>
+                        <% else %>
+                          <div class="w-28 h-16 flex items-center justify-center bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors">
+                            <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                            </svg>
+                          </div>
+                        <% end %>
+                      <% end %>
+                      <div>
+                        <p class="text-xs text-gray-500 mb-0.5">使用機体</p>
+                        <div class="flex items-center gap-2 flex-wrap">
+                          <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                              class: "text-sm font-medium text-gray-900 hover:text-indigo-600 hover:underline transition-colors" %>
+                          <%= cost_badge(player.mobile_suit.cost) %>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -101,12 +116,27 @@
                       <%= render "matches/rank_badge", rank: player.match_rank %>
                       <p class="text-lg font-semibold text-gray-900"><%= player.user.nickname %></p>
                     </div>
-                    <div class="mt-2">
-                      <p class="text-sm text-gray-500">使用機体</p>
-                      <p class="text-sm font-medium text-gray-900 flex items-center gap-2">
-                        <%= player.mobile_suit.name %>
-                        <%= cost_badge(player.mobile_suit.cost) %>
-                      </p>
+                    <div class="mt-3 flex items-center gap-3">
+                      <%= link_to mobile_suit_path(player.mobile_suit), class: "shrink-0 block" do %>
+                        <% if player.mobile_suit.image_filename.present? %>
+                          <%= image_tag "/mobile_suits/#{player.mobile_suit.image_filename}", alt: player.mobile_suit.name,
+                              class: "w-28 h-16 object-contain rounded-lg bg-gray-100 hover:opacity-80 transition-opacity" %>
+                        <% else %>
+                          <div class="w-28 h-16 flex items-center justify-center bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors">
+                            <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                            </svg>
+                          </div>
+                        <% end %>
+                      <% end %>
+                      <div>
+                        <p class="text-xs text-gray-500 mb-0.5">使用機体</p>
+                        <div class="flex items-center gap-2 flex-wrap">
+                          <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                              class: "text-sm font-medium text-gray-900 hover:text-indigo-600 hover:underline transition-colors" %>
+                          <%= cost_badge(player.mobile_suit.cost) %>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/app/views/statistics/_highlights_card.html.erb
+++ b/app/views/statistics/_highlights_card.html.erb
@@ -32,7 +32,8 @@
         <div class="flex items-center gap-2 flex-wrap">
           <span class="text-sm font-semibold text-gray-800"><%= mp.user.nickname %></span>
           <span class="text-gray-300 text-xs">·</span>
-          <span class="text-sm text-gray-600"><%= mp.mobile_suit.name %></span>
+          <%= link_to mp.mobile_suit.name, mobile_suit_path(mp.mobile_suit),
+              class: "text-sm text-gray-600 hover:text-indigo-600 hover:underline transition-colors" %>
           <%= cost_badge(mp.mobile_suit.cost) %>
         </div>
       <% end %>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -548,9 +548,24 @@
             <tbody class="bg-white divide-y divide-gray-200">
               <% @mobile_suits_list.each do |suit_stat| %>
                 <tr class="hover:bg-gray-50">
-                  <td class="px-6 py-4 whitespace-nowrap">
-                    <div class="text-sm font-medium text-gray-900">
-                      <%= suit_stat[:mobile_suit].name %>
+                  <td class="px-6 py-3 whitespace-nowrap">
+                    <div class="flex items-center gap-3">
+                      <%= link_to mobile_suit_path(suit_stat[:mobile_suit]), class: "shrink-0 block" do %>
+                        <% if suit_stat[:mobile_suit].image_filename.present? %>
+                          <%= image_tag "/mobile_suits/#{suit_stat[:mobile_suit].image_filename}", alt: suit_stat[:mobile_suit].name,
+                              class: "w-20 h-10 object-contain rounded bg-gray-100 hover:opacity-80 transition-opacity" %>
+                        <% else %>
+                          <div class="w-20 h-10 flex items-center justify-center bg-gray-100 rounded">
+                            <svg class="w-5 h-5 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                            </svg>
+                          </div>
+                        <% end %>
+                      <% end %>
+                      <div class="text-sm font-medium text-gray-900">
+                        <%= link_to suit_stat[:mobile_suit].name, mobile_suit_path(suit_stat[:mobile_suit]),
+                            class: "hover:text-indigo-600 hover:underline transition-colors" %>
+                      </div>
                     </div>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap">
@@ -628,9 +643,24 @@
             <tbody class="bg-white divide-y divide-gray-200">
               <% @opponent_suits_list.each do |suit_stat| %>
                 <tr class="hover:bg-gray-50">
-                  <td class="px-6 py-4 whitespace-nowrap">
-                    <div class="text-sm font-medium text-gray-900">
-                      <%= suit_stat[:mobile_suit].name %>
+                  <td class="px-6 py-3 whitespace-nowrap">
+                    <div class="flex items-center gap-3">
+                      <%= link_to mobile_suit_path(suit_stat[:mobile_suit]), class: "shrink-0 block" do %>
+                        <% if suit_stat[:mobile_suit].image_filename.present? %>
+                          <%= image_tag "/mobile_suits/#{suit_stat[:mobile_suit].image_filename}", alt: suit_stat[:mobile_suit].name,
+                              class: "w-20 h-10 object-contain rounded bg-gray-100 hover:opacity-80 transition-opacity" %>
+                        <% else %>
+                          <div class="w-20 h-10 flex items-center justify-center bg-gray-100 rounded">
+                            <svg class="w-5 h-5 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                            </svg>
+                          </div>
+                        <% end %>
+                      <% end %>
+                      <div class="text-sm font-medium text-gray-900">
+                        <%= link_to suit_stat[:mobile_suit].name, mobile_suit_path(suit_stat[:mobile_suit]),
+                            class: "hover:text-indigo-600 hover:underline transition-colors" %>
+                      </div>
                     </div>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap">
@@ -1017,11 +1047,24 @@
           <div class="divide-y divide-gray-200">
             <% @dominant_suits.each_with_index do |suit_stat, index| %>
               <div class="px-6 py-4 flex items-center justify-between">
-                <div class="flex items-center">
-                  <span class="text-lg font-bold text-gray-400 w-6"><%= index + 1 %></span>
-                  <div class="ml-3">
+                <div class="flex items-center gap-3">
+                  <span class="text-lg font-bold text-gray-400 w-6 shrink-0"><%= index + 1 %></span>
+                  <%= link_to mobile_suit_path(suit_stat[:mobile_suit]), class: "shrink-0 block" do %>
+                    <% if suit_stat[:mobile_suit].image_filename.present? %>
+                      <%= image_tag "/mobile_suits/#{suit_stat[:mobile_suit].image_filename}", alt: suit_stat[:mobile_suit].name,
+                          class: "w-32 h-16 object-contain rounded bg-gray-100 hover:opacity-80 transition-opacity" %>
+                    <% else %>
+                      <div class="w-32 h-16 flex items-center justify-center bg-gray-100 rounded">
+                        <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                        </svg>
+                      </div>
+                    <% end %>
+                  <% end %>
+                  <div>
                     <div class="text-sm font-medium text-gray-900 flex items-center gap-2">
-                      <%= suit_stat[:mobile_suit].name %>
+                      <%= link_to suit_stat[:mobile_suit].name, mobile_suit_path(suit_stat[:mobile_suit]),
+                          class: "hover:text-indigo-600 hover:underline transition-colors" %>
                       <%= cost_badge(suit_stat[:mobile_suit].cost) %>
                     </div>
                     <div class="text-xs text-gray-500">
@@ -1054,11 +1097,24 @@
             <div class="divide-y divide-gray-200">
               <% @popular_suits.each_with_index do |suit_stat, index| %>
                 <div class="px-6 py-4 flex items-center justify-between">
-                  <div class="flex items-center">
-                    <span class="text-lg font-bold text-gray-400 w-6"><%= index + 1 %></span>
-                    <div class="ml-3">
+                  <div class="flex items-center gap-3">
+                    <span class="text-lg font-bold text-gray-400 w-6 shrink-0"><%= index + 1 %></span>
+                    <%= link_to mobile_suit_path(suit_stat[:mobile_suit]), class: "shrink-0 block" do %>
+                      <% if suit_stat[:mobile_suit].image_filename.present? %>
+                        <%= image_tag "/mobile_suits/#{suit_stat[:mobile_suit].image_filename}", alt: suit_stat[:mobile_suit].name,
+                            class: "w-32 h-16 object-contain rounded bg-gray-100 hover:opacity-80 transition-opacity" %>
+                      <% else %>
+                        <div class="w-32 h-16 flex items-center justify-center bg-gray-100 rounded">
+                          <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                          </svg>
+                        </div>
+                      <% end %>
+                    <% end %>
+                    <div>
                       <div class="text-sm font-medium text-gray-900 flex items-center gap-2">
-                        <%= suit_stat[:mobile_suit].name %>
+                        <%= link_to suit_stat[:mobile_suit].name, mobile_suit_path(suit_stat[:mobile_suit]),
+                            class: "hover:text-indigo-600 hover:underline transition-colors" %>
                         <%= cost_badge(suit_stat[:mobile_suit].cost) %>
                       </div>
                       <div class="text-xs text-gray-500"><%= suit_stat[:mobile_suit].series %></div>
@@ -1088,11 +1144,24 @@
             <div class="divide-y divide-gray-200">
               <% @high_winrate_suits.each_with_index do |suit_stat, index| %>
                 <div class="px-6 py-4 flex items-center justify-between">
-                  <div class="flex items-center">
-                    <span class="text-lg font-bold text-gray-400 w-6"><%= index + 1 %></span>
-                    <div class="ml-3">
+                  <div class="flex items-center gap-3">
+                    <span class="text-lg font-bold text-gray-400 w-6 shrink-0"><%= index + 1 %></span>
+                    <%= link_to mobile_suit_path(suit_stat[:mobile_suit]), class: "shrink-0 block" do %>
+                      <% if suit_stat[:mobile_suit].image_filename.present? %>
+                        <%= image_tag "/mobile_suits/#{suit_stat[:mobile_suit].image_filename}", alt: suit_stat[:mobile_suit].name,
+                            class: "w-32 h-16 object-contain rounded bg-gray-100 hover:opacity-80 transition-opacity" %>
+                      <% else %>
+                        <div class="w-32 h-16 flex items-center justify-center bg-gray-100 rounded">
+                          <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                          </svg>
+                        </div>
+                      <% end %>
+                    <% end %>
+                    <div>
                       <div class="text-sm font-medium text-gray-900 flex items-center gap-2">
-                        <%= suit_stat[:mobile_suit].name %>
+                        <%= link_to suit_stat[:mobile_suit].name, mobile_suit_path(suit_stat[:mobile_suit]),
+                            class: "hover:text-indigo-600 hover:underline transition-colors" %>
                         <%= cost_badge(suit_stat[:mobile_suit].cost) %>
                       </div>
                       <div class="text-xs text-gray-500"><%= suit_stat[:wins] %>勝<%= suit_stat[:total] - suit_stat[:wins] %>敗</div>


### PR DESCRIPTION
## Summary
- 対戦履歴一覧・イベント詳細・ダッシュボードの機体名をクリックで機体詳細ページへ遷移するリンクに変更
- `card-link` Stimulus コントローラーを新規追加し、カード全体クリック（試合詳細へ）と機体名クリック（機体詳細へ）のダブルナビゲーション問題を解消
- 対戦履歴一覧は `turbo-frame` 内のリンクに `data-turbo-frame="_top"` を追加し「content missing」問題を修正
- 試合詳細の各プレイヤーカードに機体サムネイル画像（横長 `w-28 h-16`）を追加
- 統計ページ・全体統計タブの3つのランキングカードに機体サムネイル（`w-32 h-16`）を追加
- 統計ページ・ハイライトカードの機体名をリンク化
- 統計ページ・使用機体別／対戦機体別戦績テーブルの機体名列に機体サムネイル（`w-20 h-10`）を追加

## Test plan
- [x] 対戦履歴一覧：機体名クリック → 機体詳細ページへ遷移（試合詳細へは遷移しない）
- [x] 対戦履歴一覧：カード（機体名以外）クリック → 試合詳細ページへ遷移
- [x] 対戦履歴一覧：ソート・フィルターボタン → content missing が出ない
- [x] イベント詳細：機体名クリック → 機体詳細ページへ遷移
- [x] ダッシュボード：機体名クリック → 機体詳細ページへ遷移（試合詳細へは遷移しない）
- [x] 試合詳細：機体画像が表示され、クリックで機体詳細ページへ遷移
- [x] 統計・全体統計：ランキング各カードに機体画像が表示、環境支配ランキング含む
- [x] 統計・使用機体別戦績：テーブル機体名列に画像が表示
- [x] 統計・対戦機体別戦績：テーブル機体名列に画像が表示

Closes #190