### PR TITLE
feat: 試合履歴にお気に入り機能を追加する

### DIFF
--- a/app/controllers/favorite_matches_controller.rb
+++ b/app/controllers/favorite_matches_controller.rb
@@ -1,0 +1,35 @@
+class FavoriteMatchesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_match
+
+  def create
+    unless viewing_as_user&.regular_user?
+      head :forbidden
+      return
+    end
+
+    @match.favorite_matches.find_or_create_by!(user: viewing_as_user)
+    @is_favorited = true
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to match_path(@match) }
+    end
+  end
+
+  def destroy
+    @match.favorite_matches.find_by(user: viewing_as_user)&.destroy
+    @is_favorited = false
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to match_path(@match) }
+    end
+  end
+
+  private
+
+  def set_match
+    @match = Match.find(params[:match_id])
+  end
+end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -164,10 +164,21 @@ class MatchesController < ApplicationController
       @matches = scope.distinct
     end
 
+    # フィルター: お気に入りのみ
+    if params[:only_favorites] == "1" && viewing_as_user
+      @matches = @matches.joins(:favorite_matches).where(favorite_matches: { user_id: viewing_as_user.id })
+    end
+
     @per_page = [ 10, 20, 50 ].include?(params[:per].to_i) ? params[:per].to_i : 20
     @matches = @matches.page(params[:page]).per(@per_page)
     @emojis = MasterEmoji.active.ordered
     @latest_event = Event.order(held_on: :desc).first
+
+    @my_favorite_match_ids = if viewing_as_user
+      FavoriteMatch.where(user_id: viewing_as_user.id, match_id: @matches.map(&:id)).pluck(:match_id).to_set
+    else
+      Set.new
+    end
 
     # フィルター用のデータ
     @all_events = Event.order(held_on: :desc)
@@ -200,9 +211,11 @@ class MatchesController < ApplicationController
     @filter_damage_dealt_dir = params[:damage_dealt_dir].presence_in(%w[gte lte]) || "gte"
     @filter_damage_received_val = params[:damage_received_val].presence
     @filter_damage_received_dir = params[:damage_received_dir].presence_in(%w[gte lte]) || "gte"
+    @filter_only_favorites = params[:only_favorites] == "1"
   end
 
   def show
+    @is_favorited = viewing_as_user ? @match.favorite_matches.exists?(user: viewing_as_user) : false
   end
 
   def new

--- a/app/controllers/my_page_controller.rb
+++ b/app/controllers/my_page_controller.rb
@@ -12,5 +12,11 @@ class MyPageController < ApplicationController
     @all_suits      = MobileSuit.all.order(:id)
     @costs          = COSTS
     @counts_by_cost = MobileSuit.group(:cost).count
+
+    @favorite_matches = viewing_as_user.favorited_matches
+                                       .by_latest
+                                       .includes(:event, match_players: [ :user, :mobile_suit ])
+                                       .page(params[:fav_page])
+                                       .per(10)
   end
 end

--- a/app/models/favorite_match.rb
+++ b/app/models/favorite_match.rb
@@ -1,0 +1,6 @@
+class FavoriteMatch < ApplicationRecord
+  belongs_to :user
+  belongs_to :match
+
+  validates :match_id, uniqueness: { scope: :user_id }
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -5,6 +5,7 @@ class Match < ApplicationRecord
   has_many :match_players, dependent: :destroy
   has_many :reactions, dependent: :destroy
   has_one :match_timeline, dependent: :destroy
+  has_many :favorite_matches, dependent: :destroy
 
   accepts_nested_attributes_for :match_players
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
   has_many :reactions, dependent: :destroy
   has_many :user_announcement_reads, dependent: :destroy
   has_many :read_announcements, through: :user_announcement_reads, source: :announcement
+  has_many :favorite_matches, dependent: :destroy
+  has_many :favorited_matches, through: :favorite_matches, source: :match
 
   # Validations
   validates :username, presence: true, uniqueness: { case_sensitive: false },

--- a/app/views/favorite_matches/_favorite_button.html.erb
+++ b/app/views/favorite_matches/_favorite_button.html.erb
@@ -1,0 +1,26 @@
+<%# locals: (match:, is_favorited:) %>
+<% return unless viewing_as_user&.regular_user? %>
+
+<div id="<%= dom_id(match, "favorite_button") %>">
+  <% if is_favorited %>
+    <%= button_to match_favorite_path(match), method: :delete,
+        class: "flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-amber-100 text-amber-700 border border-amber-300 hover:bg-amber-200 transition-colors",
+        data: { turbo_stream: true },
+        title: "お気に入りを解除" do %>
+      <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M5 4a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 20V4z"/>
+      </svg>
+      保存済み
+    <% end %>
+  <% else %>
+    <%= button_to match_favorite_path(match), method: :post,
+        class: "flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-gray-100 text-gray-500 border border-gray-200 hover:bg-amber-50 hover:text-amber-600 hover:border-amber-200 transition-colors",
+        data: { turbo_stream: true },
+        title: "お気に入りに追加" do %>
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5 4a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 20V4z"/>
+      </svg>
+      保存
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/favorite_matches/create.turbo_stream.erb
+++ b/app/views/favorite_matches/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@match, "favorite_button") do %>
+  <%= render "favorite_matches/favorite_button", match: @match, is_favorited: true %>
+<% end %>

--- a/app/views/favorite_matches/destroy.turbo_stream.erb
+++ b/app/views/favorite_matches/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@match, "favorite_button") do %>
+  <%= render "favorite_matches/favorite_button", match: @match, is_favorited: false %>
+<% end %>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -18,6 +18,7 @@
   <!-- フィルターセクション -->
   <%
     _bp = { sort: @sort, per: @per_page, flip_team: @flip_team ? "1" : nil,
+            only_favorites: @filter_only_favorites ? "1" : nil,
             stat_player_id: @filter_stat_player_id, ol_filter: @filter_ol_filter,
             stat_filters: @filter_stat_filters,
             damage_dealt_val: @filter_damage_dealt_val, damage_dealt_dir: @filter_damage_dealt_dir,
@@ -123,6 +124,20 @@
       </div>
     <% end %>
 
+    <!-- お気に入り試合フィルター -->
+    <% if viewing_as_user&.regular_user? %>
+      <div class="flex items-center flex-wrap gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">保存済み</span>
+        <%= link_to matches_path(_all.merge(only_favorites: @filter_only_favorites ? nil : "1", page: nil)),
+            class: "flex items-center gap-1.5 #{@filter_only_favorites ? _btn_on : _btn_off}" do %>
+          <svg class="w-3.5 h-3.5" fill="<%= @filter_only_favorites ? 'currentColor' : 'none' %>" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 4a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 20V4z"/>
+          </svg>
+          お気に入りのみ
+        <% end %>
+      </div>
+    <% end %>
+
     <!-- 詳細条件（折りたたみ） -->
     <% stat_section_active = @filter_ol_filter.present? || @filter_stat_filters.any? || @filter_stat_player_id.present? || @filter_damage_dealt_val.present? || @filter_damage_received_val.present? %>
     <details class="group/detail rounded-xl border border-gray-200 overflow-hidden" <%= 'open' if stat_section_active %>>
@@ -152,6 +167,7 @@
           <% @filter_costs.each do |c| %><input type="hidden" name="costs[]" value="<%= c %>"><% end %>
           <% if @filter_my_mobile_suits %><input type="hidden" name="my_mobile_suits" value="1"><% end %>
           <% if @flip_team %><input type="hidden" name="flip_team" value="1"><% end %>
+          <% if @filter_only_favorites %><input type="hidden" name="only_favorites" value="1"><% end %>
           <input type="hidden" name="sort" value="<%= @sort %>">
           <input type="hidden" name="per" value="<%= @per_page %>">
 
@@ -333,6 +349,7 @@
                   <% end %>
                 <% end %>
               </div>
+              <%= render "favorite_matches/favorite_button", match: match, is_favorited: @my_favorite_match_ids.include?(match.id) %>
             </div>
 
             <%

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -20,6 +20,7 @@
                 配信を見る
               <% end %>
             <% end %>
+            <%= render "favorite_matches/favorite_button", match: @match, is_favorited: @is_favorited %>
           </div>
         </div>
         <% if current_user.is_admin? %>

--- a/app/views/my_page/show.html.erb
+++ b/app/views/my_page/show.html.erb
@@ -135,6 +135,105 @@
       </div>
     </div>
 
+    <%# ── お気に入り試合 ── %>
+    <div class="mt-6 bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+
+      <%# カードヘッダー %>
+      <div class="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+        <div class="flex items-center gap-2.5">
+          <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-amber-100 to-yellow-100 flex items-center justify-center">
+            <svg class="w-4 h-4 text-amber-600" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M5 4a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 20V4z"/>
+            </svg>
+          </div>
+          <h2 class="text-sm font-bold text-gray-900">お気に入り試合</h2>
+          <% if @favorite_matches.total_count > 0 %>
+            <span class="px-2 py-0.5 rounded-full bg-amber-50 text-amber-600 text-xs font-semibold">
+              <%= @favorite_matches.total_count %>
+            </span>
+          <% end %>
+        </div>
+        <% if @favorite_matches.total_count > 0 %>
+          <%= link_to "一覧で見る", matches_path(only_favorites: "1"),
+              class: "text-xs font-medium text-indigo-600 hover:text-indigo-700",
+              data: { turbo_frame: "_top" } %>
+        <% end %>
+      </div>
+
+      <% if @favorite_matches.any? %>
+        <ul class="divide-y divide-gray-100">
+          <% @favorite_matches.each do |match| %>
+            <%
+              all_mp = match.match_players.sort_by { |mp| [mp.team_number, mp.position] }
+              team1  = all_mp.select { |mp| mp.team_number == 1 }
+              team2  = all_mp.select { |mp| mp.team_number == 2 }
+            %>
+            <li class="px-6 py-4 hover:bg-gray-50 transition-colors cursor-pointer"
+                data-controller="card-link"
+                data-card-link-url-value="<%= match_path(match) %>"
+                data-action="click->card-link#navigate">
+              <%# 日付・イベント %>
+              <div class="flex items-center gap-2 mb-3 flex-wrap">
+                <span class="text-xs text-gray-400"><%= match.played_at.strftime('%Y年%m月%d日') %></span>
+                <span class="px-2 py-0.5 text-xs font-semibold rounded-full bg-blue-100 text-blue-800"><%= match.event.name %></span>
+              </div>
+
+              <%# 対戦カード %>
+              <div class="grid grid-cols-[1fr_auto_1fr] gap-2 items-center text-xs">
+                <%# チーム1 %>
+                <div class="<%= match.winning_team == 1 ? 'border-blue-300 bg-blue-50' : 'border-red-200 bg-red-50' %> rounded-lg border p-2 space-y-1.5">
+                  <span class="text-[10px] font-bold <%= match.winning_team == 1 ? 'text-blue-600' : 'text-red-500' %>">
+                    <%= match.winning_team == 1 ? 'WIN' : 'LOSE' %>
+                  </span>
+                  <% team1.each do |player| %>
+                    <div>
+                      <span class="font-semibold text-gray-800"><%= player.user.nickname %></span>
+                      <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                          class: "block text-[10px] text-indigo-500 hover:text-indigo-700 hover:underline leading-tight truncate",
+                          data: { turbo_frame: "_top" } %>
+                    </div>
+                  <% end %>
+                </div>
+
+                <%# VS %>
+                <div class="text-center text-gray-300 font-bold text-sm px-1">VS</div>
+
+                <%# チーム2 %>
+                <div class="<%= match.winning_team == 2 ? 'border-blue-300 bg-blue-50' : 'border-red-200 bg-red-50' %> rounded-lg border p-2 space-y-1.5">
+                  <span class="text-[10px] font-bold <%= match.winning_team == 2 ? 'text-blue-600' : 'text-red-500' %>">
+                    <%= match.winning_team == 2 ? 'WIN' : 'LOSE' %>
+                  </span>
+                  <% team2.each do |player| %>
+                    <div>
+                      <span class="font-semibold text-gray-800"><%= player.user.nickname %></span>
+                      <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                          class: "block text-[10px] text-indigo-500 hover:text-indigo-700 hover:underline leading-tight truncate",
+                          data: { turbo_frame: "_top" } %>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+
+        <% if @favorite_matches.total_pages > 1 %>
+          <div class="px-6 py-3 border-t border-gray-100 flex justify-center">
+            <%= paginate @favorite_matches, param_name: :fav_page %>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="px-6 py-10 text-center">
+          <svg class="mx-auto w-8 h-8 text-gray-300 mb-2" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 4a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 20V4z"/>
+          </svg>
+          <p class="text-sm text-gray-400">お気に入りに登録した試合はありません</p>
+          <p class="mt-1 text-xs text-gray-300">対戦履歴の「保存」ボタンから追加できます</p>
+        </div>
+      <% end %>
+
+    </div>
+
   </div>
 
   <%# 機体ピッカーモーダル（コントローラー内に配置） %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
       end
     end
     resource :stats, controller: "match_stats", only: [ :edit, :update, :destroy ]
+    resource :favorite, controller: "favorite_matches", only: [ :create, :destroy ]
   end
 
   # Rotations

--- a/db/migrate/20260315120000_create_favorite_matches.rb
+++ b/db/migrate/20260315120000_create_favorite_matches.rb
@@ -1,0 +1,10 @@
+class CreateFavoriteMatches < ActiveRecord::Migration[8.1]
+  def change
+    create_table :favorite_matches do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :match, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :favorite_matches, [ :user_id, :match_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_14_002422) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_15_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -42,6 +42,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_14_002422) do
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["held_on"], name: "index_events_on_held_on"
+  end
+
+  create_table "favorite_matches", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "match_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["match_id"], name: "index_favorite_matches_on_match_id"
+    t.index ["user_id", "match_id"], name: "index_favorite_matches_on_user_id_and_match_id", unique: true
+    t.index ["user_id"], name: "index_favorite_matches_on_user_id"
   end
 
   create_table "master_emojis", force: :cascade do |t|
@@ -215,6 +225,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_14_002422) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "favorite_matches", "matches"
+  add_foreign_key "favorite_matches", "users"
   add_foreign_key "match_players", "matches"
   add_foreign_key "match_players", "mobile_suits"
   add_foreign_key "match_players", "users"


### PR DESCRIPTION
## Summary
- `FavoriteMatch` モデルを追加（`user_id` + `match_id` のユニーク制約）
- 試合一覧の各カードと試合詳細ページに「保存」ボタンを追加（Turbo Stream でその場更新）
- 試合一覧フィルターに「お気に入りのみ」トグルを追加
- マイページにお気に入り試合セクションを追加（機体名リンク付き、ページネーション対応）
- お気に入りは一般ユーザーのみ操作可能（非公開）

## Test plan
- [x] 試合一覧で「保存」ボタンをクリック → ボタンが「保存済み」に切り替わる
- [x] 「保存済み」ボタンをクリック → 「保存」に戻る（解除）
- [x] 試合詳細ページでも同様に保存・解除できる
- [x] 試合一覧の「お気に入りのみ」フィルターで保存済み試合だけ表示される
- [x] マイページにお気に入り試合セクションが表示される
- [x] マイページの機体名クリックで機体詳細ページへ遷移する
- [x] マイページのカードクリックで試合詳細ページへ遷移する
- [x] マイページの「一覧で見る」リンクでお気に入りフィルター済み一覧へ遷移する
- [x] ゲストユーザーにはボタンが表示されない

## 関連Issue・PR
#192