### PR TITLE
refactor: フィルターUIのラベルを整理

### DIFF
--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -134,7 +134,7 @@
           <svg class="w-3.5 h-3.5" fill="<%= @filter_only_favorites ? 'currentColor' : 'none' %>" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 4a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 20V4z"/>
           </svg>
-          お気に入りのみ
+          保存済みのみ
         <% end %>
       </div>
     <% end %>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -41,7 +41,7 @@
 
     <!-- イベント -->
     <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">イベント</span>
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">イベント</span>
       <%= link_to "全イベント", matches_path(_all.merge(events: [])), class: @filter_events.empty? ? _btn_on : _btn_off %>
       <% @all_events.each do |event| %>
         <%= link_to event.name, _toggle.call(:events, event.id), class: @filter_events.include?(event.id) ? _btn_on : _btn_off %>
@@ -50,7 +50,7 @@
 
     <!-- 参加ユーザー -->
     <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">参加</span>
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">参加</span>
       <div class="inline-flex rounded-md border border-gray-200 bg-white text-xs font-medium overflow-hidden shrink-0">
         <%= link_to "OR", matches_path(_all.merge(users_mode: "or")), class: "block px-2 py-1 transition-colors #{@filter_users_mode == 'or' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
         <%= link_to "AND", matches_path(_all.merge(users_mode: "and")), class: "block px-2 py-1 border-l border-gray-200 transition-colors #{@filter_users_mode == 'and' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
@@ -64,7 +64,7 @@
     <!-- 配信台ユーザー -->
     <% _visible_streaming = @filter_users.any? ? @all_users.select { |u| @filter_users.include?(u.id) } : @all_users %>
     <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">配信台</span>
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">配信台</span>
       <%= link_to "全員", matches_path(_all.merge(streaming_users: [])), class: @filter_streaming_users.empty? ? _btn_on : _btn_off %>
       <% _visible_streaming.each do |user| %>
         <%= link_to user.nickname, _toggle.call(:streaming_users, user.id), class: @filter_streaming_users.include?(user.id) ? _btn_on : _btn_off %>
@@ -73,7 +73,7 @@
 
     <!-- 機体・コスト -->
     <div class="flex flex-wrap items-center gap-3">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">機体・コスト</span>
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">機体・コスト</span>
       <div class="flex rounded-xl bg-gray-100 p-1 gap-0.5 shrink-0">
         <%= link_to "全体", matches_path(_all.merge(costs: [], mobile_suits: [], my_mobile_suits: nil)),
             class: "px-3 py-1.5 rounded-lg text-sm font-semibold transition-all whitespace-nowrap #{@filter_costs.empty? && @filter_mobile_suits.empty? ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}" %>
@@ -106,28 +106,29 @@
     </div>
 
     <!-- お気に入り機体 -->
-    <% _fav_suits = viewing_as_user&.user_favorite_suits&.order(:slot)&.includes(:mobile_suit)&.to_a || [] %>
+    <%
+      _fav_suits = viewing_as_user&.user_favorite_suits&.order(:slot)&.includes(:mobile_suit)&.to_a || []
+      _fav_toggle = ->(suit_id) {
+        new_arr = @filter_mobile_suits.include?(suit_id) ? @filter_mobile_suits - [suit_id] : @filter_mobile_suits + [suit_id]
+        matches_path(_all.merge(mobile_suits: new_arr, my_mobile_suits: new_arr.any? ? "1" : nil))
+      }
+    %>
     <% if _fav_suits.any? %>
-      <%
-        _fav_toggle = ->(suit_id) {
-          new_arr = @filter_mobile_suits.include?(suit_id) ? @filter_mobile_suits - [suit_id] : @filter_mobile_suits + [suit_id]
-          matches_path(_all.merge(mobile_suits: new_arr, my_mobile_suits: new_arr.any? ? "1" : nil))
-        }
-      %>
-      <div class="flex items-center flex-wrap gap-2">
-        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">お気に入り</span>
-        <% _fav_suits.each do |fav| %>
-          <%= link_to fav.mobile_suit.name, _fav_toggle.call(fav.mobile_suit.id),
-              class: (@filter_mobile_suits.include?(fav.mobile_suit.id) && @filter_my_mobile_suits) ? _btn_on : _btn_off %>
-        <% end %>
-        <span class="text-xs text-gray-400 ml-1">自分が使用した試合のみ</span>
+      <div class="flex items-start gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">お気に入り機体</span>
+        <div class="flex flex-wrap gap-2">
+          <% _fav_suits.each do |fav| %>
+            <%= link_to fav.mobile_suit.name, _fav_toggle.call(fav.mobile_suit.id),
+                class: (@filter_mobile_suits.include?(fav.mobile_suit.id) && @filter_my_mobile_suits) ? _btn_on : _btn_off %>
+          <% end %>
+        </div>
       </div>
     <% end %>
 
-    <!-- お気に入り試合フィルター -->
+    <!-- お気に入り試合 -->
     <% if viewing_as_user&.regular_user? %>
       <div class="flex items-center flex-wrap gap-2">
-        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">保存済み</span>
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">お気に入り試合</span>
         <%= link_to matches_path(_all.merge(only_favorites: @filter_only_favorites ? nil : "1", page: nil)),
             class: "flex items-center gap-1.5 #{@filter_only_favorites ? _btn_on : _btn_off}" do %>
           <svg class="w-3.5 h-3.5" fill="<%= @filter_only_favorites ? 'currentColor' : 'none' %>" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -125,7 +125,7 @@
     <!-- 全体系タブ: イベント選択 -->
     <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4 space-y-3">
       <div class="flex items-center flex-wrap gap-2">
-        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">イベント</span>
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">イベント</span>
         <%= link_to "全イベント", statistics_path(tab: @active_tab),
             class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
         <% @all_events.each do |event| %>
@@ -145,7 +145,7 @@
   <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4 space-y-3">
     <!-- イベント -->
     <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">イベント</span>
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">イベント</span>
       <%= link_to "全イベント", statistics_path(ev_base),
           class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
       <% @all_events.each do |event| %>
@@ -156,7 +156,7 @@
 
     <!-- パートナー -->
     <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">パートナー</span>
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">パートナー</span>
       <%= link_to "全員", statistics_path(pt_base),
           class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_partners.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
       <% @all_partners.each do |partner| %>
@@ -167,7 +167,7 @@
 
     <!-- 機体・コスト -->
     <div class="flex flex-wrap items-center gap-3">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">機体・コスト</span>
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">機体・コスト</span>
       <div class="flex rounded-xl bg-gray-100 p-1 gap-0.5 shrink-0">
         <%= link_to "全体", statistics_path(suit_base),
             class: "#{seg_btn} #{no_suit_cost ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}" %>
@@ -203,7 +203,7 @@
     <% _fav_suits = viewing_as_user&.user_favorite_suits&.order(:slot)&.includes(:mobile_suit)&.to_a || [] %>
     <% if _fav_suits.any? %>
       <div class="flex items-center flex-wrap gap-2">
-        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-20 shrink-0">お気に入り</span>
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">お気に入り機体</span>
         <% _fav_suits.each do |fav| %>
           <% _new_suits = @filter_mobile_suits.include?(fav.mobile_suit.id) ? @filter_mobile_suits - [fav.mobile_suit.id] : @filter_mobile_suits + [fav.mobile_suit.id] %>
           <%= link_to fav.mobile_suit.name, statistics_path(suit_base.merge(mobile_suits: _new_suits)),


### PR DESCRIPTION
## Summary
- 試合一覧・統計ページのお気に入りフィルター行のラベルを整理
- 「お気に入りのみ」→「保存済みのみ」に変更（試合一覧）
- お気に入り機体フィルターのラベル表記を統一

## Test plan
- [x] 試合一覧でフィルター「保存済みのみ」が表示され、動作すること
- [x] 統計ページのフィルター表示が正常なこと

Closes #194