### PR TITLE
feat: 対戦履歴一覧UIの刷新（機体画像・コストバッジ・新カラーデザイン）

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -24,6 +24,12 @@ class EventsController < ApplicationController
 
     ordered_ids = @event.matches.order(:played_at, :id).pluck(:id)
     @match_numbers = ordered_ids.each_with_index.to_h { |id, i| [ id, i + 1 ] }
+
+    @my_favorite_match_ids = if viewing_as_user
+      FavoriteMatch.where(user_id: viewing_as_user.id, match_id: @matches.map(&:id)).pluck(:match_id).to_set
+    else
+      Set.new
+    end
   end
 
   def new

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -119,81 +119,55 @@
       </div>
       <div class="border-t border-gray-200">
         <% if @matches.any? %>
-          <ul class="divide-y divide-gray-200">
+          <ul class="divide-y divide-gray-100">
             <% @matches.each do |match| %>
+              <%
+                _team1 = match.match_players.to_a.select { |p| p.team_number == 1 }.sort_by(&:position)
+                _team2 = match.match_players.to_a.select { |p| p.team_number == 2 }.sort_by(&:position)
+                _streaming_id = _team1.first&.id
+              %>
               <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
-              <li class="px-4 py-3 hover:bg-gray-50 cursor-pointer"
+              <li class="px-5 py-5 hover:bg-gray-50 cursor-pointer"
                   data-controller="card-link"
                   data-card-link-url-value="<%= match_path(match) %>"
                   data-action="click->card-link#navigate">
-                  <div class="flex items-center gap-2 mb-2">
-                    <span class="text-sm font-semibold text-gray-900">第<%= @match_numbers[match.id] %>試合</span>
+
+                <%# メタ行 %>
+                <div class="flex items-center justify-between gap-2 mb-3">
+                  <div class="flex items-center flex-wrap gap-2">
+                    <span class="text-sm font-semibold text-gray-800">第<%= @match_numbers[match.id] %>試合</span>
                     <% if match.rotation_match&.started_at %>
-                      <span class="text-xs text-gray-500"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
+                      <span class="text-sm text-gray-400"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
                     <% elsif match.played_at %>
-                      <span class="text-xs text-gray-500"><%= match.played_at.strftime('%H:%M') %> 終了</span>
+                      <span class="text-sm text-gray-400"><%= match.played_at.strftime('%H:%M') %> 終了</span>
+                    <% end %>
+                    <% if match.video_url %>
+                      <span onclick="event.stopPropagation()">
+                        <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer",
+                            class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-600 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                          <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                          配信
+                        <% end %>
+                      </span>
                     <% end %>
                   </div>
-                  <% if match.video_url %>
-                    <div class="mb-2" onclick="event.stopPropagation()">
-                      <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
-                        <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
-                        配信を見る
-                      <% end %>
-                    </div>
-                  <% end %>
-                  <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
-                    <% team1_players = match.match_players.to_a.select { |p| p.team_number == 1 }.sort_by(&:position) %>
-                    <% team2_players = match.match_players.to_a.select { |p| p.team_number == 2 }.sort_by(&:position) %>
+                  <span onclick="event.stopPropagation()">
+                    <%= render "favorite_matches/favorite_button", match: match, is_favorited: @my_favorite_match_ids.include?(match.id) %>
+                  </span>
+                </div>
 
-                    <!-- Team 1 -->
-                    <div class="<%= match.winning_team == 1 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">
-                      <div class="text-xs font-semibold text-gray-500 mb-2 flex items-center justify-between">
-                        <span>チーム1</span>
-                        <span class="px-2 py-0.5 rounded text-xs font-bold <%= match.winning_team == 1 ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
-                          <%= match.winning_team == 1 ? 'WIN' : 'LOSE' %>
-                        </span>
-                      </div>
-                      <% team1_players.each_with_index do |player, index| %>
-                        <div class="mb-1">
-                          <span class="<%= index == 0 ? 'text-red-600 font-bold' : 'text-gray-700' %>">
-                            <%= player.user.nickname %>
-                            <% if index == 0 %>
-                              <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                            <% end %>
-                          </span>
-                          <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
-                              class: "text-gray-500 hover:text-indigo-600 hover:underline transition-colors" %>
-                        </div>
-                      <% end %>
-                    </div>
+                <%# チームグリッド %>
+                <%= render "matches/match_teams",
+                      left_players: _team1,
+                      right_players: _team2,
+                      left_wins: match.winning_team == 1,
+                      streaming_player_id: _streaming_id %>
 
-                    <!-- VS -->
-                    <div class="flex items-center justify-center text-gray-400 font-bold text-lg">
-                      VS
-                    </div>
-
-                    <!-- Team 2 -->
-                    <div class="<%= match.winning_team == 2 ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">
-                      <div class="text-xs font-semibold text-gray-500 mb-2 flex items-center justify-between">
-                        <span>チーム2</span>
-                        <span class="px-2 py-0.5 rounded text-xs font-bold <%= match.winning_team == 2 ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
-                          <%= match.winning_team == 2 ? 'WIN' : 'LOSE' %>
-                        </span>
-                      </div>
-                      <% team2_players.each do |player| %>
-                        <div class="mb-1">
-                          <span class="text-gray-700"><%= player.user.nickname %></span>
-                          <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
-                              class: "text-gray-500 hover:text-indigo-600 hover:underline transition-colors" %>
-                        </div>
-                      <% end %>
-                    </div>
-                  </div>
-                  <div onclick="event.stopPropagation()">
-                    <%= render "reactions/reaction_bar", match: match, compact: true, emojis: @emojis %>
-                  </div>
-                </li>
+                <%# リアクションバー %>
+                <div class="mt-3" onclick="event.stopPropagation()">
+                  <%= render "reactions/reaction_bar", match: match, compact: true, emojis: @emojis %>
+                </div>
+              </li>
             <% end %>
           </ul>
           <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>

--- a/app/views/matches/_match_teams.html.erb
+++ b/app/views/matches/_match_teams.html.erb
@@ -1,0 +1,106 @@
+<%
+  _cost_badge = ->(cost) {
+    case cost
+    when 3000 then "bg-red-100 text-red-700"
+    when 2500 then "bg-orange-100 text-orange-700"
+    when 2000 then "bg-yellow-100 text-yellow-700"
+    when 1500 then "bg-green-100 text-green-700"
+    else           "bg-gray-100 text-gray-500"
+    end
+  }
+  _streaming_player_id = local_assigns[:streaming_player_id]
+  _left_label  = local_assigns.fetch(:left_label,  "チーム1")
+  _right_label = local_assigns.fetch(:right_label, "チーム2")
+%>
+<div class="grid grid-cols-[1fr_3rem_1fr] gap-2 items-stretch">
+
+  <%# 左チーム %>
+  <div class="<%= left_wins ? 'bg-sky-50/70' : 'bg-red-50/70' %> rounded-xl p-4 flex flex-col gap-3">
+    <div class="flex items-center justify-between">
+      <span class="text-xs font-semibold text-gray-400 uppercase tracking-wide"><%= _left_label %></span>
+      <span class="px-2.5 py-1 rounded-full text-xs font-bold leading-none <%= left_wins ? 'bg-sky-100 text-sky-700' : 'bg-red-100 text-red-600' %>">
+        <%= left_wins ? 'WIN' : 'LOSE' %>
+      </span>
+    </div>
+    <% left_players.each do |player| %>
+      <div class="flex items-center gap-3">
+        <% if player.mobile_suit.image_filename.present? %>
+          <%= image_tag "/mobile_suits/#{player.mobile_suit.image_filename}",
+              alt: player.mobile_suit.name,
+              class: "w-24 h-16 object-contain shrink-0 rounded",
+              loading: "lazy" %>
+        <% else %>
+          <div class="w-24 h-16 shrink-0 rounded bg-gray-200 flex items-center justify-center">
+            <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+            </svg>
+          </div>
+        <% end %>
+        <div class="min-w-0">
+          <p class="text-sm font-semibold <%= player.id == _streaming_player_id ? 'text-red-600' : 'text-gray-800' %> truncate">
+            <%= player.user.nickname %>
+            <% if player.id == _streaming_player_id %>
+              <span class="ml-1 px-1.5 py-0.5 bg-red-100 text-red-600 rounded text-xs font-semibold">配信台</span>
+            <% end %>
+          </p>
+          <div class="flex items-center gap-1.5 mt-0.5">
+            <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                class: "text-xs text-gray-400 hover:text-indigo-500 hover:underline transition-colors truncate",
+                data: { turbo_frame: "_top" } %>
+            <span class="shrink-0 px-2 py-0.5 rounded-full text-xs font-bold leading-none <%= _cost_badge.call(player.mobile_suit.cost) %>">
+              <%= player.mobile_suit.cost %>
+            </span>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <%# VS %>
+  <div class="flex items-center justify-center text-sm font-bold text-gray-300 tracking-widest">
+    vs
+  </div>
+
+  <%# 右チーム %>
+  <div class="<%= left_wins ? 'bg-red-50/70' : 'bg-sky-50/70' %> rounded-xl p-4 flex flex-col gap-3">
+    <div class="flex items-center justify-between">
+      <span class="text-xs font-semibold text-gray-400 uppercase tracking-wide"><%= _right_label %></span>
+      <span class="px-2.5 py-1 rounded-full text-xs font-bold leading-none <%= left_wins ? 'bg-red-100 text-red-600' : 'bg-sky-100 text-sky-700' %>">
+        <%= left_wins ? 'LOSE' : 'WIN' %>
+      </span>
+    </div>
+    <% right_players.each do |player| %>
+      <div class="flex items-center gap-3">
+        <% if player.mobile_suit.image_filename.present? %>
+          <%= image_tag "/mobile_suits/#{player.mobile_suit.image_filename}",
+              alt: player.mobile_suit.name,
+              class: "w-24 h-16 object-contain shrink-0 rounded",
+              loading: "lazy" %>
+        <% else %>
+          <div class="w-24 h-16 shrink-0 rounded bg-gray-200 flex items-center justify-center">
+            <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+            </svg>
+          </div>
+        <% end %>
+        <div class="min-w-0">
+          <p class="text-sm font-semibold <%= player.id == _streaming_player_id ? 'text-red-600' : 'text-gray-800' %> truncate">
+            <%= player.user.nickname %>
+            <% if player.id == _streaming_player_id %>
+              <span class="ml-1 px-1.5 py-0.5 bg-red-100 text-red-600 rounded text-xs font-semibold">配信台</span>
+            <% end %>
+          </p>
+          <div class="flex items-center gap-1.5 mt-0.5">
+            <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
+                class: "text-xs text-gray-400 hover:text-indigo-500 hover:underline transition-colors truncate",
+                data: { turbo_frame: "_top" } %>
+            <span class="shrink-0 px-2 py-0.5 rounded-full text-xs font-bold leading-none <%= _cost_badge.call(player.mobile_suit.cost) %>">
+              <%= player.mobile_suit.cost %>
+            </span>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -326,119 +326,89 @@
         <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { matches_path(_all.merge(per: n)) } %>
       </div>
     </div>
-    <ul class="divide-y divide-gray-200">
+    <ul class="divide-y divide-gray-100">
       <% @matches.each do |match| %>
+        <%
+          _all_mp       = match.match_players.sort_by { |mp| [mp.team_number, mp.position] }
+          _team1        = _all_mp.select { |mp| mp.team_number == 1 }
+          _team2        = _all_mp.select { |mp| mp.team_number == 2 }
+          _streaming_id = _team1.first&.id
+
+          if @flip_team && viewing_as_user
+            _user_team = _all_mp.find { |mp| mp.user_id == viewing_as_user.id }&.team_number
+            if _user_team == 2
+              _left_players, _right_players = _team2, _team1
+              _left_wins = match.winning_team == 2
+            else
+              _left_players, _right_players = _team1, _team2
+              _left_wins = match.winning_team == 1
+            end
+            _left_label  = "自チーム"
+            _right_label = "相手チーム"
+          else
+            _left_players, _right_players = _team1, _team2
+            _left_wins    = match.winning_team == 1
+            _left_label   = "チーム1"
+            _right_label  = "チーム2"
+          end
+
+          _cost_badge = ->(cost) {
+            case cost
+            when 3000 then "bg-red-100 text-red-700"
+            when 2500 then "bg-orange-100 text-orange-700"
+            when 2000 then "bg-yellow-100 text-yellow-700"
+            when 1500 then "bg-green-100 text-green-700"
+            else           "bg-gray-100 text-gray-500"
+            end
+          }
+        %>
         <li class="<%= current_user.is_admin? ? 'pl-10' : '' %> relative">
           <% if current_user.is_admin? %>
             <div class="absolute left-2 top-4 z-10">
               <input type="checkbox" name="match_ids[]" value="<%= match.id %>" form="bulk-delete-form" class="match-checkbox rounded border-gray-300 text-blue-600 focus:ring-blue-500">
             </div>
           <% end %>
-          <div class="px-6 py-4">
+
+          <div class="px-5 py-5">
+            <%# メタ行 %>
             <div class="flex items-center justify-between mb-3">
-              <div class="flex items-center space-x-3">
-                <%= link_to match_path(match), class: "text-sm text-gray-500 hover:text-blue-600", data: { turbo_frame: "_top" } do %>
+              <div class="flex items-center flex-wrap gap-2">
+                <%= link_to match_path(match), class: "text-sm text-gray-400 hover:text-blue-600 transition-colors", data: { turbo_frame: "_top" } do %>
                   <%= match.played_at.strftime('%Y年%m月%d日') %>
                 <% end %>
-                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
+                <span class="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-indigo-50 text-indigo-600">
                   <%= match.event.name %>
                 </span>
                 <% if match.video_url %>
-                  <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-700 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                  <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer",
+                      class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-600 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
                     <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
-                    配信を見る
+                    配信
                   <% end %>
                 <% end %>
               </div>
               <%= render "favorite_matches/favorite_button", match: match, is_favorited: @my_favorite_match_ids.include?(match.id) %>
             </div>
 
-            <%
-              _all_mp      = match.match_players.sort_by { |mp| [mp.team_number, mp.position] }
-              _team1       = _all_mp.select { |mp| mp.team_number == 1 }
-              _team2       = _all_mp.select { |mp| mp.team_number == 2 }
-              _streaming_id = _team1.first&.id
-
-              if @flip_team && viewing_as_user
-                _user_team = _all_mp.find { |mp| mp.user_id == viewing_as_user.id }&.team_number
-                if _user_team == 2
-                  _left_players, _right_players = _team2, _team1
-                  _left_wins = match.winning_team == 2
-                else
-                  _left_players, _right_players = _team1, _team2
-                  _left_wins = match.winning_team == 1
-                end
-                _left_label  = "自チーム"
-                _right_label = "相手チーム"
-              else
-                _left_players, _right_players = _team1, _team2
-                _left_wins    = match.winning_team == 1
-                _left_label   = "チーム1"
-                _right_label  = "チーム2"
-              end
-            %>
+            <%# 対戦カード %>
             <div class="block cursor-pointer"
                  data-controller="card-link"
                  data-card-link-url-value="<%= match_path(match) %>"
                  data-action="click->card-link#navigate">
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs">
-
-                <!-- 左チーム -->
-                <div class="<%= _left_wins ? 'bg-blue-50 border-2 border-blue-400 rounded p-2' : 'bg-red-50 border-2 border-red-400 rounded p-2' %>">
-                  <div class="text-xs font-semibold text-gray-500 mb-2 flex items-center justify-between">
-                    <span><%= _left_label %></span>
-                    <span class="px-2 py-0.5 rounded text-xs font-bold <%= _left_wins ? 'bg-blue-600 text-white' : 'bg-red-600 text-white' %>">
-                      <%= _left_wins ? 'WIN' : 'LOSE' %>
-                    </span>
-                  </div>
-                  <% _left_players.each do |player| %>
-                    <div class="mb-1">
-                      <span class="<%= player.id == _streaming_id ? 'text-red-600 font-bold' : 'text-gray-700' %>">
-                        <%= player.user.nickname %>
-                        <% if player.id == _streaming_id %>
-                          <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                        <% end %>
-                      </span>
-                      <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
-                          class: "text-gray-500 hover:text-indigo-600 hover:underline transition-colors",
-                          data: { turbo_frame: "_top" } %>
-                    </div>
-                  <% end %>
-                </div>
-
-                <!-- VS -->
-                <div class="flex items-center justify-center text-gray-400 font-bold text-lg">
-                  VS
-                </div>
-
-                <!-- 右チーム -->
-                <div class="<%= _left_wins ? 'bg-red-50 border-2 border-red-400 rounded p-2' : 'bg-blue-50 border-2 border-blue-400 rounded p-2' %>">
-                  <div class="text-xs font-semibold text-gray-500 mb-2 flex items-center justify-between">
-                    <span><%= _right_label %></span>
-                    <span class="px-2 py-0.5 rounded text-xs font-bold <%= _left_wins ? 'bg-red-600 text-white' : 'bg-blue-600 text-white' %>">
-                      <%= _left_wins ? 'LOSE' : 'WIN' %>
-                    </span>
-                  </div>
-                  <% _right_players.each do |player| %>
-                    <div class="mb-1">
-                      <span class="<%= player.id == _streaming_id ? 'text-red-600 font-bold' : 'text-gray-700' %>">
-                        <%= player.user.nickname %>
-                        <% if player.id == _streaming_id %>
-                          <span class="ml-1 px-1 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                        <% end %>
-                      </span>
-                      <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
-                          class: "text-gray-500 hover:text-indigo-600 hover:underline transition-colors",
-                          data: { turbo_frame: "_top" } %>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
+              <%= render "matches/match_teams",
+                    left_players: _left_players,
+                    right_players: _right_players,
+                    left_wins: _left_wins,
+                    left_label: _left_label,
+                    right_label: _right_label,
+                    streaming_player_id: _streaming_id %>
             </div>
 
-            <!-- リアクションバー（リアルタイム更新対応） -->
-            <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
-            <%= render "reactions/reaction_bar", match: match, compact: true, emojis: @emojis %>
+            <%# リアクションバー %>
+            <div class="mt-3">
+              <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
+              <%= render "reactions/reaction_bar", match: match, compact: true, emojis: @emojis %>
+            </div>
           </div>
         </li>
       <% end %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -44,13 +44,13 @@
         <% team2_players = @match.match_players.select { |p| p.team_number == 2 }.sort_by(&:position) %>
 
         <!-- Team 1 -->
-        <div class="<%= @match.winning_team == 1 ? 'bg-blue-50 border-2 border-blue-400 rounded-lg p-6' : 'bg-red-50 border-2 border-red-400 rounded-lg p-6' %>">
+        <div class="<%= @match.winning_team == 1 ? 'bg-sky-50/70' : 'bg-red-50/70' %> rounded-xl p-6">
           <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-semibold text-gray-900">チーム1</h3>
+            <h3 class="text-base font-semibold text-gray-500 uppercase tracking-wide">チーム1</h3>
             <% if @match.winning_team == 1 %>
-              <span class="px-3 py-1 bg-blue-600 text-white rounded-full text-sm font-semibold">WIN</span>
+              <span class="px-3 py-1 bg-sky-100 text-sky-700 rounded-full text-sm font-bold">WIN</span>
             <% else %>
-              <span class="px-3 py-1 bg-red-600 text-white rounded-full text-sm font-semibold">LOSE</span>
+              <span class="px-3 py-1 bg-red-100 text-red-600 rounded-full text-sm font-bold">LOSE</span>
             <% end %>
           </div>
 
@@ -98,13 +98,13 @@
         </div>
 
         <!-- Team 2 -->
-        <div class="<%= @match.winning_team == 2 ? 'bg-blue-50 border-2 border-blue-400 rounded-lg p-6' : 'bg-red-50 border-2 border-red-400 rounded-lg p-6' %>">
+        <div class="<%= @match.winning_team == 2 ? 'bg-sky-50/70' : 'bg-red-50/70' %> rounded-xl p-6">
           <div class="flex items-center justify-between mb-4">
-            <h3 class="text-lg font-semibold text-gray-900">チーム2</h3>
+            <h3 class="text-base font-semibold text-gray-500 uppercase tracking-wide">チーム2</h3>
             <% if @match.winning_team == 2 %>
-              <span class="px-3 py-1 bg-blue-600 text-white rounded-full text-sm font-semibold">WIN</span>
+              <span class="px-3 py-1 bg-sky-100 text-sky-700 rounded-full text-sm font-bold">WIN</span>
             <% else %>
-              <span class="px-3 py-1 bg-red-600 text-white rounded-full text-sm font-semibold">LOSE</span>
+              <span class="px-3 py-1 bg-red-100 text-red-600 rounded-full text-sm font-bold">LOSE</span>
             <% end %>
           </div>
 
@@ -164,9 +164,9 @@
               <h3 class="text-sm font-semibold text-gray-600 mb-2">
                 チーム<%= team_num %>
                 <% if is_winner %>
-                  <span class="ml-1 text-blue-600">WIN</span>
+                  <span class="ml-1 px-2 py-0.5 rounded-full text-xs font-bold bg-sky-100 text-sky-700">WIN</span>
                 <% else %>
-                  <span class="ml-1 text-red-600">LOSE</span>
+                  <span class="ml-1 px-2 py-0.5 rounded-full text-xs font-bold bg-red-100 text-red-600">LOSE</span>
                 <% end %>
               </h3>
               <div class="overflow-x-auto">

--- a/app/views/my_page/show.html.erb
+++ b/app/views/my_page/show.html.erb
@@ -168,51 +168,31 @@
               team1  = all_mp.select { |mp| mp.team_number == 1 }
               team2  = all_mp.select { |mp| mp.team_number == 2 }
             %>
-            <li class="px-6 py-4 hover:bg-gray-50 transition-colors cursor-pointer"
+            <li class="px-5 py-5 hover:bg-gray-50 transition-colors cursor-pointer"
                 data-controller="card-link"
                 data-card-link-url-value="<%= match_path(match) %>"
                 data-action="click->card-link#navigate">
-              <%# 日付・イベント %>
+
+              <%# メタ行 %>
               <div class="flex items-center gap-2 mb-3 flex-wrap">
-                <span class="text-xs text-gray-400"><%= match.played_at.strftime('%Y年%m月%d日') %></span>
-                <span class="px-2 py-0.5 text-xs font-semibold rounded-full bg-blue-100 text-blue-800"><%= match.event.name %></span>
+                <span class="text-sm text-gray-400"><%= match.played_at.strftime('%Y年%m月%d日') %></span>
+                <span class="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-indigo-50 text-indigo-600"><%= match.event.name %></span>
+                <% if match.video_url %>
+                  <span onclick="event.stopPropagation()">
+                    <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer",
+                        class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-600 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                      <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
+                      配信
+                    <% end %>
+                  </span>
+                <% end %>
               </div>
 
-              <%# 対戦カード %>
-              <div class="grid grid-cols-[1fr_auto_1fr] gap-2 items-center text-xs">
-                <%# チーム1 %>
-                <div class="<%= match.winning_team == 1 ? 'border-blue-300 bg-blue-50' : 'border-red-200 bg-red-50' %> rounded-lg border p-2 space-y-1.5">
-                  <span class="text-[10px] font-bold <%= match.winning_team == 1 ? 'text-blue-600' : 'text-red-500' %>">
-                    <%= match.winning_team == 1 ? 'WIN' : 'LOSE' %>
-                  </span>
-                  <% team1.each do |player| %>
-                    <div>
-                      <span class="font-semibold text-gray-800"><%= player.user.nickname %></span>
-                      <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
-                          class: "block text-[10px] text-indigo-500 hover:text-indigo-700 hover:underline leading-tight truncate",
-                          data: { turbo_frame: "_top" } %>
-                    </div>
-                  <% end %>
-                </div>
-
-                <%# VS %>
-                <div class="text-center text-gray-300 font-bold text-sm px-1">VS</div>
-
-                <%# チーム2 %>
-                <div class="<%= match.winning_team == 2 ? 'border-blue-300 bg-blue-50' : 'border-red-200 bg-red-50' %> rounded-lg border p-2 space-y-1.5">
-                  <span class="text-[10px] font-bold <%= match.winning_team == 2 ? 'text-blue-600' : 'text-red-500' %>">
-                    <%= match.winning_team == 2 ? 'WIN' : 'LOSE' %>
-                  </span>
-                  <% team2.each do |player| %>
-                    <div>
-                      <span class="font-semibold text-gray-800"><%= player.user.nickname %></span>
-                      <%= link_to player.mobile_suit.name, mobile_suit_path(player.mobile_suit),
-                          class: "block text-[10px] text-indigo-500 hover:text-indigo-700 hover:underline leading-tight truncate",
-                          data: { turbo_frame: "_top" } %>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
+              <%# チームグリッド %>
+              <%= render "matches/match_teams",
+                    left_players: team1,
+                    right_players: team2,
+                    left_wins: match.winning_team == 1 %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
## Summary

- 試合カードの太枠ボーダーを廃止し、WIN側 `bg-sky-50/70`・LOSE側 `bg-red-50/70` の角丸カードへ刷新
- WIN/LOSEバッジをpillスタイル（sky/red）に変更
- 各プレイヤー行に機体サムネイル画像・コストバッジを追加
- チームグリッドを共通 partial `_match_teams` に切り出し、全画面で再利用
- イベント詳細画面にお気に入りボタンを追加（`EventsController#show` に `@my_favorite_match_ids` を追加）
- マイページのお気に入り試合に配信リンクボタンを追加
- 試合詳細画面のWIN/LOSEスタイルを一覧と統一

## Test plan

- [x] 対戦履歴一覧：試合カードが新デザインで表示される
- [x] 対戦履歴一覧：WIN側が水色、LOSE側が赤の背景になっている
- [x] 対戦履歴一覧：機体画像・コストバッジが表示される
- [x] 対戦履歴一覧：画像なし機体でプレースホルダーが表示される
- [x] イベント詳細：試合カードが新デザインで表示される
- [x] イベント詳細：お気に入りボタンが機能する（一般ユーザー）
- [x] マイページ：お気に入り試合が新デザインで表示される
- [x] マイページ：配信リンクボタンが表示される（動画ありの試合）
- [x] 試合詳細：チームボックスが新カラーデザインになっている
- [x] 試合詳細：対戦統計のWIN/LOSEラベルがpillバッジになっている
- [x] 自チームを左に・flip_team が正常動作する

Closes #196