### PR TITLE
fix: お気に入り機体ピッカーの表示順をpositionに修正

### DIFF
--- a/app/controllers/my_page_controller.rb
+++ b/app/controllers/my_page_controller.rb
@@ -9,7 +9,7 @@ class MyPageController < ApplicationController
                                      .index_by(&:slot)
     @selected_suit_ids = (0..11).filter_map { |s| @favorites_by_slot[s]&.mobile_suit_id }
 
-    @all_suits      = MobileSuit.all.order(:id)
+    @all_suits      = MobileSuit.all.order(:position)
     @costs          = COSTS
     @counts_by_cost = MobileSuit.group(:cost).count
 


### PR DESCRIPTION
## Summary
- お気に入り機体編集ピッカーで、機体が `id` 順ではなく `position` 順（機体一覧と同じ順序）で表示されるよう修正

## 原因
`MyPageController#show` で `MobileSuit.all.order(:id)` としていたため、後から追加されたセラヴィーガンダム（id が最大）が一覧の末尾に表示されていた。`position` カラムは正しく設定済みだったが参照されていなかった。

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `app/controllers/my_page_controller.rb` | `order(:id)` | `order(:position)` |

## Test plan
- [x] マイページのお気に入り機体編集ピッカーを開き、セラヴィーガンダムが適切な位置（機体一覧画面と同じ順序）に表示されることを確認

## 関連Issue・PR
#203