### PR TITLE
fix: フィルターのラベル列が複数行ボタンに侵食される問題の修正と全フィルターへの共通化

### DIFF
--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -40,40 +40,46 @@
   <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4 space-y-3">
 
     <!-- イベント -->
-    <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">イベント</span>
-      <%= link_to "全イベント", matches_path(_all.merge(events: [])), class: @filter_events.empty? ? _btn_on : _btn_off %>
-      <% @all_events.each do |event| %>
-        <%= link_to event.name, _toggle.call(:events, event.id), class: @filter_events.include?(event.id) ? _btn_on : _btn_off %>
-      <% end %>
+    <div class="flex items-start gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">イベント</span>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "全イベント", matches_path(_all.merge(events: [])), class: @filter_events.empty? ? _btn_on : _btn_off %>
+        <% @all_events.each do |event| %>
+          <%= link_to event.name, _toggle.call(:events, event.id), class: @filter_events.include?(event.id) ? _btn_on : _btn_off %>
+        <% end %>
+      </div>
     </div>
 
     <!-- 参加ユーザー -->
-    <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">参加</span>
-      <div class="inline-flex rounded-md border border-gray-200 bg-white text-xs font-medium overflow-hidden shrink-0">
-        <%= link_to "OR", matches_path(_all.merge(users_mode: "or")), class: "block px-2 py-1 transition-colors #{@filter_users_mode == 'or' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
-        <%= link_to "AND", matches_path(_all.merge(users_mode: "and")), class: "block px-2 py-1 border-l border-gray-200 transition-colors #{@filter_users_mode == 'and' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
+    <div class="flex items-start gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">参加</span>
+      <div class="flex flex-wrap gap-2">
+        <div class="inline-flex rounded-md border border-gray-200 bg-white text-xs font-medium overflow-hidden shrink-0">
+          <%= link_to "OR", matches_path(_all.merge(users_mode: "or")), class: "block px-2 py-1 transition-colors #{@filter_users_mode == 'or' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
+          <%= link_to "AND", matches_path(_all.merge(users_mode: "and")), class: "block px-2 py-1 border-l border-gray-200 transition-colors #{@filter_users_mode == 'and' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
+        </div>
+        <%= link_to "全員", matches_path(_all.merge(users: [])), class: @filter_users.empty? ? _btn_on : _btn_off %>
+        <% @all_users.each do |user| %>
+          <%= link_to user.nickname, _toggle.call(:users, user.id), class: @filter_users.include?(user.id) ? _btn_on : _btn_off %>
+        <% end %>
       </div>
-      <%= link_to "全員", matches_path(_all.merge(users: [])), class: @filter_users.empty? ? _btn_on : _btn_off %>
-      <% @all_users.each do |user| %>
-        <%= link_to user.nickname, _toggle.call(:users, user.id), class: @filter_users.include?(user.id) ? _btn_on : _btn_off %>
-      <% end %>
     </div>
 
     <!-- 配信台ユーザー -->
     <% _visible_streaming = @filter_users.any? ? @all_users.select { |u| @filter_users.include?(u.id) } : @all_users %>
-    <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">配信台</span>
-      <%= link_to "全員", matches_path(_all.merge(streaming_users: [])), class: @filter_streaming_users.empty? ? _btn_on : _btn_off %>
-      <% _visible_streaming.each do |user| %>
-        <%= link_to user.nickname, _toggle.call(:streaming_users, user.id), class: @filter_streaming_users.include?(user.id) ? _btn_on : _btn_off %>
-      <% end %>
+    <div class="flex items-start gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">配信台</span>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "全員", matches_path(_all.merge(streaming_users: [])), class: @filter_streaming_users.empty? ? _btn_on : _btn_off %>
+        <% _visible_streaming.each do |user| %>
+          <%= link_to user.nickname, _toggle.call(:streaming_users, user.id), class: @filter_streaming_users.include?(user.id) ? _btn_on : _btn_off %>
+        <% end %>
+      </div>
     </div>
 
     <!-- 機体・コスト -->
-    <div class="flex flex-wrap items-center gap-3">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">機体・コスト</span>
+    <div class="flex flex-wrap items-start gap-3">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">機体・コスト</span>
       <div class="flex rounded-xl bg-gray-100 p-1 gap-0.5 shrink-0">
         <%= link_to "全体", matches_path(_all.merge(costs: [], mobile_suits: [], my_mobile_suits: nil)),
             class: "px-3 py-1.5 rounded-lg text-sm font-semibold transition-all whitespace-nowrap #{@filter_costs.empty? && @filter_mobile_suits.empty? ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}" %>
@@ -127,15 +133,17 @@
 
     <!-- お気に入り試合 -->
     <% if viewing_as_user&.regular_user? %>
-      <div class="flex items-center flex-wrap gap-2">
-        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">お気に入り試合</span>
-        <%= link_to matches_path(_all.merge(only_favorites: @filter_only_favorites ? nil : "1", page: nil)),
-            class: "flex items-center gap-1.5 #{@filter_only_favorites ? _btn_on : _btn_off}" do %>
-          <svg class="w-3.5 h-3.5" fill="<%= @filter_only_favorites ? 'currentColor' : 'none' %>" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M5 4a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 20V4z"/>
-          </svg>
-          保存済みのみ
-        <% end %>
+      <div class="flex items-start gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">お気に入り試合</span>
+        <div class="flex flex-wrap gap-2">
+          <%= link_to matches_path(_all.merge(only_favorites: @filter_only_favorites ? nil : "1", page: nil)),
+              class: "flex items-center gap-1.5 #{@filter_only_favorites ? _btn_on : _btn_off}" do %>
+            <svg class="w-3.5 h-3.5" fill="<%= @filter_only_favorites ? 'currentColor' : 'none' %>" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 4a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 20V4z"/>
+            </svg>
+            保存済みのみ
+          <% end %>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -124,14 +124,16 @@
   <% if @active_tab == 'overall' || @active_tab == 'highlights' %>
     <!-- 全体系タブ: イベント選択 -->
     <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4 space-y-3">
-      <div class="flex items-center flex-wrap gap-2">
-        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">イベント</span>
-        <%= link_to "全イベント", statistics_path(tab: @active_tab),
-            class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
-        <% @all_events.each do |event| %>
-          <%= link_to event.name, statistics_path(tab: @active_tab, events: [event.id]),
-              class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events == [event.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
-        <% end %>
+      <div class="flex items-start gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">イベント</span>
+        <div class="flex flex-wrap gap-2">
+          <%= link_to "全イベント", statistics_path(tab: @active_tab),
+              class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+          <% @all_events.each do |event| %>
+            <%= link_to event.name, statistics_path(tab: @active_tab, events: [event.id]),
+                class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events == [event.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+          <% end %>
+        </div>
       </div>
     </div>
   <% else %>
@@ -144,30 +146,34 @@
   %>
   <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4 space-y-3">
     <!-- イベント -->
-    <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">イベント</span>
-      <%= link_to "全イベント", statistics_path(ev_base),
-          class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
-      <% @all_events.each do |event| %>
-        <%= link_to event.name, statistics_path(ev_base.merge(events: [event.id])),
-            class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events == [event.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
-      <% end %>
+    <div class="flex items-start gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">イベント</span>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "全イベント", statistics_path(ev_base),
+            class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        <% @all_events.each do |event| %>
+          <%= link_to event.name, statistics_path(ev_base.merge(events: [event.id])),
+              class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_events == [event.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        <% end %>
+      </div>
     </div>
 
     <!-- パートナー -->
-    <div class="flex items-center flex-wrap gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">パートナー</span>
-      <%= link_to "全員", statistics_path(pt_base),
-          class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_partners.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
-      <% @all_partners.each do |partner| %>
-        <%= link_to partner.nickname, statistics_path(pt_base.merge(partners: [partner.id])),
-            class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_partners == [partner.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
-      <% end %>
+    <div class="flex items-start gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">パートナー</span>
+      <div class="flex flex-wrap gap-2">
+        <%= link_to "全員", statistics_path(pt_base),
+            class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_partners.empty? ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        <% @all_partners.each do |partner| %>
+          <%= link_to partner.nickname, statistics_path(pt_base.merge(partners: [partner.id])),
+              class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{@filter_partners == [partner.id] ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+        <% end %>
+      </div>
     </div>
 
     <!-- 機体・コスト -->
-    <div class="flex flex-wrap items-center gap-3">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">機体・コスト</span>
+    <div class="flex flex-wrap items-start gap-3">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">機体・コスト</span>
       <div class="flex rounded-xl bg-gray-100 p-1 gap-0.5 shrink-0">
         <%= link_to "全体", statistics_path(suit_base),
             class: "#{seg_btn} #{no_suit_cost ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}" %>


### PR DESCRIPTION
## Summary
- 対戦履歴・統計ページの全フィルター行を `flex items-start gap-2` + ラベルに `pt-1.5` + ボタン群を内側 `div.flex.flex-wrap` で内包するパターンに統一
- お気に入り機体フィルターで既に実装済みだった正しいレイアウトを、イベント・参加・配信台・お気に入り試合・パートナー・機体コストの各フィルターにも適用
- `items-center` から `items-start` への変更により、ボタンが複数行に折り返した場合もラベルが上端揃えで固定され、他行への侵食を防止

## Test plan
- [x] 対戦履歴ページでイベントフィルターのボタンが複数行になる状態でラベルが上端揃えになることを確認
- [x] 統計ページ（overall / highlights / personal 各タブ）でも同様に確認
- [x] 画面幅を狭めてフィルター全体の折り返し動作を確認
- [x] お気に入り機体フィルターの表示が変わっていないことを確認

## 関連Issue・PR
#205