### PR TITLE
refactor: 全画面の最大幅を拡大し、レイアウトコンテナを共通化する

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,49 @@
 @import "tailwindcss";
+
+/* ============================================================
+   ページレイアウト共通クラス
+   ============================================================ */
+
+/* ページコンテナ: 全ページ共通の最大幅・中央寄せ・水平パディング */
+.page-container {
+  max-width: 1536px; /* max-w-screen-2xl 相当 */
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1rem;   /* px-4 */
+  padding-right: 1rem;
+}
+@media (min-width: 640px) {
+  .page-container {
+    padding-left: 1.5rem; /* sm:px-6 */
+    padding-right: 1.5rem;
+  }
+}
+@media (min-width: 1024px) {
+  .page-container {
+    padding-left: 2rem; /* lg:px-8 */
+    padding-right: 2rem;
+  }
+}
+
+/* ページヘッダー: タイトルとアクションボタンを横並びにするレイアウト */
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem; /* mb-6 */
+}
+@media (min-width: 640px) {
+  .page-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+/* モバイル・デスクトップ表示切り替え（768px 境界） */
+.mobile-only-view  { display: block !important; }
+.desktop-only-view { display: none  !important; }
+@media (min-width: 768px) {
+  .mobile-only-view  { display: none  !important; }
+  .desktop-only-view { display: block !important; }
+}

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -1,5 +1,5 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+<div class="py-8">
+  <div class="page-header">
     <div>
       <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">お知らせ管理</h1>
       <p class="mt-2 text-sm text-gray-600">アプリ起動時に表示されるお知らせを管理できます</p>

--- a/app/views/admin/announcements/show.html.erb
+++ b/app/views/admin/announcements/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
     <div>
       <h1 class="text-2xl sm:text-3xl font-bold text-gray-900"><%= @announcement.title %></h1>

--- a/app/views/admin/discord_channels/index.html.erb
+++ b/app/views/admin/discord_channels/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <div class="mb-6">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">Discord チャンネル設定</h1>
     <p class="mt-2 text-sm text-gray-600">用途ごとに投稿先の Webhook URL を設定します。未設定のチャンネルへは投稿されません。</p>

--- a/app/views/admin/master_emojis/index.html.erb
+++ b/app/views/admin/master_emojis/index.html.erb
@@ -1,5 +1,5 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <div class="page-header flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+<div class="py-8">
+  <div class="page-header">
     <div>
       <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">スタンプマスタ</h1>
       <p class="mt-2 text-sm text-gray-600">リアクションで使用できるスタンプの一覧を管理できます</p>
@@ -109,27 +109,3 @@
   <% end %>
 </div>
 
-<style>
-  /* ページヘッダー */
-  .page-header {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-  @media (min-width: 640px) {
-    .page-header {
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-    }
-  }
-
-  /* モバイル（768px未満）*/
-  .mobile-only-view { display: block !important; }
-  .desktop-only-view { display: none !important; }
-  /* デスクトップ（768px以上）*/
-  @media (min-width: 768px) {
-    .mobile-only-view { display: none !important; }
-    .desktop-only-view { display: block !important; }
-  }
-</style>

--- a/app/views/admin/mobile_suits/index.html.erb
+++ b/app/views/admin/mobile_suits/index.html.erb
@@ -1,5 +1,5 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <div class="page-header flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+<div class="py-8">
+  <div class="page-header">
     <div>
       <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">機体マスタ</h1>
       <p class="mt-2 text-sm text-gray-600">使用できる機体の一覧を管理できます</p>
@@ -67,27 +67,3 @@
   </div>
 </div>
 
-<style>
-  /* ページヘッダー */
-  .page-header {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-  @media (min-width: 640px) {
-    .page-header {
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-    }
-  }
-
-  /* モバイル（768px未満）*/
-  .mobile-only-view { display: block !important; }
-  .desktop-only-view { display: none !important; }
-  /* デスクトップ（768px以上）*/
-  @media (min-width: 768px) {
-    .mobile-only-view { display: none !important; }
-    .desktop-only-view { display: block !important; }
-  }
-</style>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,5 +1,5 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <div class="page-header flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+<div class="py-8">
+  <div class="page-header">
     <div>
       <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">ユーザー管理</h1>
       <p class="mt-2 text-sm text-gray-600">ユーザーの作成・編集・削除ができます</p>

--- a/app/views/dashboard/admin_dashboard.html.erb
+++ b/app/views/dashboard/admin_dashboard.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <!-- Header -->
   <div class="mb-8">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">管理ダッシュボード</h1>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <div class="mb-8">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">ダッシュボード</h1>
     <p class="mt-2 text-sm text-gray-600">ようこそ、<%= viewing_as_user.nickname %>さん</p>

--- a/app/views/events/edit_timestamps.html.erb
+++ b/app/views/events/edit_timestamps.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <div class="mb-6">
     <%= link_to "← イベントに戻る", event_path(@event), class: "text-blue-600 hover:text-blue-500" %>
   </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,5 +1,5 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <div class="page-header flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+<div class="py-8">
+  <div class="page-header">
     <div>
       <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">イベント一覧</h1>
       <p class="mt-2 text-sm text-gray-600">イベントの管理と試合記録の閲覧ができます</p>
@@ -132,27 +132,3 @@
   <% end %>
 </div>
 
-<style>
-  /* ページヘッダー */
-  .page-header {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-  @media (min-width: 640px) {
-    .page-header {
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-    }
-  }
-
-  /* モバイル（768px未満）*/
-  .mobile-only-view { display: block !important; }
-  .desktop-only-view { display: none !important; }
-  /* デスクトップ（768px以上）*/
-  @media (min-width: 768px) {
-    .mobile-only-view { display: none !important; }
-    .desktop-only-view { display: block !important; }
-  }
-</style>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <div class="mb-6">
     <%= link_to "← イベント一覧に戻る", events_path, class: "text-blue-600 hover:text-blue-500" %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -481,14 +481,16 @@
     </nav>
 
     <!-- フラッシュメッセージ -->
-    <div id="flash-messages" class="<%= 'main-content-with-sidebar' if user_signed_in? %> max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div id="flash-messages" class="<%= 'main-content-with-sidebar' if user_signed_in? %> page-container">
       <% flash.each do |type, message| %>
         <%= render "shared/flash_message", type: type, message: message %>
       <% end %>
     </div>
 
     <main class="<%= 'main-content-with-sidebar' if user_signed_in? %>">
-      <%= yield %>
+      <div class="page-container">
+        <%= yield %>
+      </div>
     </main>
 
     <%# お知らせモーダル %>

--- a/app/views/matches/edit.html.erb
+++ b/app/views/matches/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="max-w-4xl mx-auto py-8">
   <div class="mb-6">
     <%= link_to "← 対戦詳細に戻る", match_path(@match), class: "text-blue-600 hover:text-blue-500" %>
   </div>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="matches-content" data-turbo-action="advance">
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <div class="page-header flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4 mb-6">
+<div class="py-8">
+  <div class="page-header">
     <div>
       <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">対戦履歴</h1>
       <p class="mt-2 text-sm text-gray-600">試合の一覧を表示・フィルタリングできます</p>
@@ -471,19 +471,6 @@
 <% end %>
 
 <style>
-  /* ページヘッダー */
-  .page-header {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-  @media (min-width: 640px) {
-    .page-header {
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-    }
-  }
   /* summary デフォルトマーカー非表示 */
   .stat-summary { list-style: none; }
   .stat-summary::-webkit-details-marker { display: none; }

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="max-w-4xl mx-auto py-8">
   <div class="mb-6">
     <%= link_to "← イベントに戻る", event_path(@event), class: "text-blue-600 hover:text-blue-500" %>
   </div>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_from "match_#{@match.id}_reactions" %>
 
-<div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="max-w-6xl mx-auto py-8">
   <div class="mb-6">
     <%= link_to "← 対戦履歴に戻る", matches_path, class: "text-blue-600 hover:text-blue-500" %>
   </div>

--- a/app/views/mobile_suits/index.html.erb
+++ b/app/views/mobile_suits/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
 
   <%# ページヘッダー %>
   <div class="mb-6">

--- a/app/views/mobile_suits/show.html.erb
+++ b/app/views/mobile_suits/show.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-5xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+<div class="max-w-5xl mx-auto py-8 space-y-6">
 
   <%# ── 戻るリンク（上） %>
   <%= link_to mobile_suits_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 transition-colors" do %>

--- a/app/views/my_page/show.html.erb
+++ b/app/views/my_page/show.html.erb
@@ -3,7 +3,7 @@
 <div data-controller="favorite-picker"
      data-favorite-picker-initial-value="<%= @selected_suit_ids.to_json %>">
 
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="py-8">
 
     <%# ── view-as バナー ── %>
     <% if viewing_as_someone_else? %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="max-w-2xl mx-auto py-8">
   <div class="mb-6">
     <h1 class="text-3xl font-bold text-gray-900">設定</h1>
     <p class="mt-2 text-sm text-gray-600">アカウント設定を変更できます</p>

--- a/app/views/rotations/index.html.erb
+++ b/app/views/rotations/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <div class="mb-6">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">ローテーション一覧</h1>
     <p class="mt-2 text-sm text-gray-600">イベントごとのローテーション表を管理できます</p>
@@ -124,13 +124,3 @@
   <% end %>
 </div>
 
-<style>
-  /* モバイル（768px未満）*/
-  .mobile-only-view { display: block !important; }
-  .desktop-only-view { display: none !important; }
-  /* デスクトップ（768px以上）*/
-  @media (min-width: 768px) {
-    .mobile-only-view { display: none !important; }
-    .desktop-only-view { display: block !important; }
-  }
-</style>

--- a/app/views/rotations/new.html.erb
+++ b/app/views/rotations/new.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="max-w-4xl mx-auto py-8">
   <div class="mb-6">
     <h1 class="text-3xl font-bold text-gray-900">ローテーション作成</h1>
     <p class="mt-2 text-sm text-gray-600">イベント: <%= @event.name %> (<%= @event.held_on.strftime('%Y/%m/%d') %>)</p>

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -58,7 +58,7 @@
   </script>
 <% end %>
 
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <!-- Header -->
   <div class="mb-6">
     <div class="flex justify-between items-start">

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="py-8">
   <!-- Header -->
   <div class="mb-6">
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">統計</h1>
@@ -2416,15 +2416,6 @@
 </script>
 
 <style>
-  /* モバイル（768px未満）*/
-  .mobile-only-view { display: block !important; }
-  .desktop-only-view { display: none !important; }
-  /* デスクトップ（768px以上）*/
-  @media (min-width: 768px) {
-    .mobile-only-view { display: none !important; }
-    .desktop-only-view { display: block !important; }
-  }
-
   /* 全体サマリーグリッド */
   .overall-summary-grid {
     display: grid;


### PR DESCRIPTION
## Summary
- コンテンツの最大幅を `max-w-7xl`（1280px）→ `max-w-screen-2xl`（1536px）相当に拡大し、大画面モニターでの余白問題を解消
- `application.html.erb` の `<main>` 内にコンテナラッパーを追加し、各ページの `max-w-7xl mx-auto px-4 sm:px-6 lg:px-8` の重複記述を一掃
- `.page-header` / `.mobile-only-view` / `.desktop-only-view` の CSS を `application.css` に集約し、5 つ以上のビューに重複していた `<style>` ブロックを削除

## Test plan
- [x] ダッシュボード・対戦履歴・統計など主要ページで、大画面モニター時にコンテンツが広く表示されることを確認
- [x] モバイル・小画面では表示が崩れないことを確認
- [x] `profiles/edit`（設定ページ）が引き続き狭い幅で表示されることを確認
- [x] `matches/show`（対戦詳細）が `max-w-6xl` で表示されることを確認
- [x] モバイル表示切り替え（テーブル ↔ カード）が正常に動作することを確認
- [x] フラッシュメッセージがコンテナに収まることを確認

Closes #208