### PR TITLE
chore: セキュリティ脆弱性のある gem をアップデート

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.16)
+    action_text-trix (2.1.17)
       railties
     actioncable (8.1.2)
       actionpack (= 8.1.2)
@@ -97,7 +97,7 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (5.0.2)
+    devise (5.0.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 7.0)
@@ -169,7 +169,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.0)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)


### PR DESCRIPTION
## Summary
- `devise` 5.0.2 → 5.0.3（GHSA-57hq-95w6-v4fc: メール確認の race condition）
- `action_text-trix` 2.1.16 → 2.1.17（GHSA-qmpg-8xg6-ph5q: Stored XSS）

bundler-audit で検出された既知の脆弱性に対応。

## Test plan
- [ ] CI（scan_ruby）がパスすることを確認