### PR TITLE
feat: /api/events/:id/stats のペイロード形式変更対応（expired_users 通知）

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -53,10 +53,13 @@ module Api
       event = Event.find_by(id: params[:id])
       return render json: { error: "Event not found" }, status: :not_found unless event
 
-      matches_data = JSON.parse(request.body.read)
-      unless matches_data.is_a?(Array)
-        return render json: { error: "リクエストボディは JSON 配列である必要があります" }, status: :unprocessable_entity
+      payload = JSON.parse(request.body.read)
+      unless payload.is_a?(Hash) && payload["matches"].is_a?(Array)
+        return render json: { error: "リクエストボディは matches キーを持つ JSON オブジェクトである必要があります" }, status: :unprocessable_entity
       end
+
+      matches_data  = payload["matches"]
+      expired_users = Array(payload["expired_users"])
 
       db_matches = event.matches.includes(:match_timeline, match_players: [ :user ]).order(:played_at, :id)
 
@@ -74,7 +77,9 @@ module Api
         end
       end
 
-      render json: { message: "OK", updated: db_matches.size }
+      PushNotificationService.notify_expired_cookies(event: event, users: expired_users) if expired_users.any?
+
+      render json: { message: "OK", updated: db_matches.size, expired_users: expired_users }
     rescue JSON::ParserError
       render json: { error: "リクエストボディが不正な JSON 形式です" }, status: :unprocessable_entity
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -55,6 +55,19 @@ class PushNotificationService
       end
     end
 
+    def notify_expired_cookies(event:, users:)
+      User.where(is_admin: true).find_each do |user|
+        next unless user.push_notifications_enabled?
+
+        SendPushNotificationJob.perform_later(
+          user_id: user.id,
+          title: "Cookie 期限切れユーザーあり",
+          body: "#{event.name}: #{users.join(', ')} の Cookie が期限切れです",
+          path: "/events/#{event.id}"
+        )
+      end
+    end
+
     def notify_rotation_activated(rotation:)
       player_ids = collect_player_ids(rotation)
       return if player_ids.empty?


### PR DESCRIPTION
## 概要

スクレイパー側改修（exvs2ib-vsmobile-scraper#18）に合わせ、`POST /api/events/:id/stats` の受信ペイロード形式を変更。
Cookie 期限切れユーザーがいた場合に管理者へプッシュ通知する。

## 変更内容

- `params` のパース処理を配列形式 → オブジェクト形式（`{matches, expired_users}`）に変更
- `expired_users` が空でない場合、`PushNotificationService.notify_expired_cookies` で管理者に通知
- レスポンスに `expired_users` を含める

## テスト計画

- [x] 正常系: `{"matches": [...], "expired_users": []}` で統計データが登録される
- [x] 正常系: `{"matches": [...], "expired_users": ["user_b"]}` で統計登録＋管理者通知が飛ぶ
- [x] 異常系: 配列をそのまま POST すると 422 エラーが返る
- [x] 異常系: `matches` の件数不一致で 422 エラーが返る

## 関連

- Closes #211
- スクレイパー側: exvs2ib-vsmobile-scraper#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)