### PR TITLE
feat: ダッシュボードカードをパフォーマンスデータで刷新する

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -86,17 +86,26 @@ class DashboardController < ApplicationController
     # ベストパートナー
     calculate_best_partners
 
-    # 機体使用トレンド（直近のイベント）
+    # 機体使用トレンド（直近のイベント）—— パーソナルハイライトのフォールバック用
     calculate_event_mobile_suit_trend
 
     # 対戦会クイック比較
     calculate_event_comparison
 
-    # コスト帯分析
+    # コスト帯分析 —— EXバーストサマリーのフォールバック用
     calculate_cost_analysis
 
-    # 対面相性マトリクス
+    # 対面相性マトリクス —— パフォーマンススナップショットのフォールバック用
     calculate_matchup_matrix
+
+    # パフォーマンス スナップショット（新規）
+    calculate_performance_snapshot
+
+    # パーソナル ハイライト（新規）
+    calculate_personal_highlights
+
+    # EXバースト サマリー（新規）
+    calculate_exburst_summary
 
     # 最近の試合（キャッシュ済みデータから取得）
     # IDでユニーク化して順序を保つ
@@ -110,22 +119,23 @@ class DashboardController < ApplicationController
       end
     end
 
-    # 人気機体TOP5（データベースで集計）
-    @popular_mobile_suits = MobileSuit.joins(:match_players)
-                                      .select("mobile_suits.*, COUNT(match_players.id) as usage_count")
-                                      .group("mobile_suits.id")
-                                      .order("usage_count DESC")
-                                      .limit(5)
-
-    # ユーザーのお気に入り機体（キャッシュ済みデータから集計）
-    user_suit_usage = Hash.new(0)
-    @all_user_matches.each { |mp| user_suit_usage[mp.mobile_suit] += 1 }
-    @user_favorite_suits = user_suit_usage.sort_by { |_, count| -count }
+    # ユーザーのお気に入り機体（勝率付き）
+    user_suit_stats = Hash.new { |h, k| h[k] = { count: 0, wins: 0 } }
+    @all_user_matches.each do |mp|
+      user_suit_stats[mp.mobile_suit][:count] += 1
+      user_suit_stats[mp.mobile_suit][:wins] += 1 if mp.match.winning_team == mp.team_number
+    end
+    @user_favorite_suits = user_suit_stats.sort_by { |_, stats| -stats[:count] }
                                           .take(3)
-                                          .map { |suit, count| suit.tap { |s| s.define_singleton_method(:usage_count) { count } } }
+                                          .map do |suit, stats|
+                                            win_rate = stats[:count] > 0 ? (stats[:wins].to_f / stats[:count] * 100).round(1) : 0
+                                            suit.tap do |s|
+                                              s.define_singleton_method(:usage_count) { stats[:count] }
+                                              s.define_singleton_method(:win_rate) { win_rate }
+                                            end
+                                          end
 
     @upcoming_events = Event.where("held_on >= ?", Time.zone.today).order(held_on: :asc).limit(3)
-    @latest_event = Event.order(held_on: :desc).first
 
     render "index"
   end
@@ -151,6 +161,17 @@ class DashboardController < ApplicationController
       "(matches.winning_team = 1 AND match_players.team_number = 1) OR (matches.winning_team = 2 AND match_players.team_number = 2)"
     ).count
     @user_win_rate = @user_total_matches > 0 ? (@user_wins.to_f / @user_total_matches * 100).round(1) : 0
+
+    # パフォーマンスデータのある試合から平均を計算
+    stats_mps = @all_user_matches.select(&:has_stats?)
+    @user_has_stats = stats_mps.any?
+    if @user_has_stats
+      total = stats_mps.size
+      total_kills = stats_mps.sum { |mp| mp.kills.to_i }
+      total_deaths = stats_mps.sum { |mp| mp.deaths.to_i }
+      @user_avg_damage = (stats_mps.sum { |mp| mp.damage_dealt.to_i }.to_f / total).round(0).to_i
+      @user_avg_kd = total_deaths > 0 ? (total_kills.to_f / total_deaths).round(2) : nil
+    end
   end
 
   def calculate_realtime_status
@@ -360,13 +381,17 @@ class DashboardController < ApplicationController
       total = event_matches.size
       wins = event_matches.count { |mp| mp.match.winning_team == mp.team_number }
 
+      stats_mps = event_matches.select(&:has_stats?)
+      avg_damage = stats_mps.any? ? (stats_mps.sum { |mp| mp.damage_dealt.to_i }.to_f / stats_mps.size).round(0).to_i : nil
+
       {
         event: event,
         total: total,
         wins: wins,
         losses: total - wins,
         win_rate: total > 0 ? (wins.to_f / total * 100).round(1) : 0,
-        is_today: event.held_on == Time.zone.today
+        is_today: event.held_on == Time.zone.today,
+        avg_damage: avg_damage
       }
     end
   end
@@ -412,6 +437,60 @@ class DashboardController < ApplicationController
                         }
                       end
                       .sort_by { |c| -c[:win_rate] }
+  end
+
+  def calculate_performance_snapshot
+    stats_mps = @all_user_matches.select(&:has_stats?)
+    return if stats_mps.empty?
+
+    total = stats_mps.size
+    total_kills = stats_mps.sum { |mp| mp.kills.to_i }
+    total_deaths = stats_mps.sum { |mp| mp.deaths.to_i }
+
+    @performance_snapshot = {
+      avg_score: (stats_mps.sum { |mp| mp.score.to_i }.to_f / total).round(1),
+      avg_damage: (stats_mps.sum { |mp| mp.damage_dealt.to_i }.to_f / total).round(0).to_i,
+      kd_ratio: total_deaths > 0 ? (total_kills.to_f / total_deaths).round(2) : nil,
+      avg_exburst_damage: (stats_mps.sum { |mp| mp.exburst_damage.to_i }.to_f / total).round(0).to_i
+    }
+
+    # コミュニティ平均（ゲスト以外・stats あり）
+    community_base = MatchPlayer.joins(:user).where(users: { is_guest: false }).where.not(damage_dealt: nil)
+    if community_base.exists?
+      @community_snapshot = {
+        avg_score: community_base.average(:score)&.round(1),
+        avg_damage: community_base.average(:damage_dealt)&.round(0)&.to_i,
+        avg_exburst_damage: community_base.average(:exburst_damage)&.round(0)&.to_i
+      }
+    end
+  end
+
+  def calculate_personal_highlights
+    stats_mps = @all_user_matches.select { |mp| mp.has_stats? && mp.damage_dealt.to_i > 0 }
+    return if stats_mps.empty?
+
+    @highlight_best_damage_mp = stats_mps.max_by { |mp| mp.damage_dealt.to_i }
+
+    kd_mps = stats_mps.select { |mp| mp.kills.to_i > 0 || mp.deaths.to_i > 0 }
+    @highlight_best_kd_mp = kd_mps.max_by { |mp| mp.kills.to_f / [ mp.deaths.to_i, 1 ].max } if kd_mps.any?
+  end
+
+  def calculate_exburst_summary
+    ex_mps = @all_user_matches.select { |mp| mp.exburst_count.present? }
+    return if ex_mps.empty?
+
+    total = ex_mps.size
+    total_deaths = ex_mps.sum { |mp| mp.deaths.to_i }
+
+    @exburst_summary = {
+      avg_count: (ex_mps.sum { |mp| mp.exburst_count.to_i }.to_f / total).round(2),
+      avg_damage: (ex_mps.sum { |mp| mp.exburst_damage.to_i }.to_f / total).round(0).to_i,
+      death_rate: total_deaths > 0 ? (ex_mps.sum { |mp| mp.exburst_deaths.to_i }.to_f / total_deaths * 100).round(1) : 0.0
+    }
+
+    # コミュニティ平均
+    community_avg = MatchPlayer.joins(:user).where(users: { is_guest: false }).where.not(exburst_count: nil).average(:exburst_count)
+    @exburst_summary[:community_avg_count] = community_avg&.round(2)
   end
 
   def calculate_matchup_matrix

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -234,11 +234,13 @@
             <p class="mt-2 text-sm text-gray-500">アカウントを発行してもらうと、以下の機能が利用できます：</p>
             <ul class="mt-4 text-sm text-gray-600 space-y-2">
               <li>調子メーター（直近の勝敗傾向）</li>
+              <li>パフォーマンス スナップショット（avg ダメージ・K/D 比など）</li>
+              <li>パーソナル ハイライト（ベストダメージ・ベスト K/D）</li>
+              <li>EXバースト サマリー</li>
               <li>イベントごとの戦績比較</li>
               <li>最近の対戦履歴</li>
-              <li>対面相性マトリクス</li>
               <li>ベストパートナー分析</li>
-              <li>使用機体の統計</li>
+              <li>使用機体の統計と勝率</li>
             </ul>
             <p class="mt-6 text-xs text-gray-400">管理者にアカウント発行を依頼してください</p>
           </div>
@@ -322,9 +324,12 @@
                     <span class="bg-gray-500 text-white px-2 py-1 rounded text-xs font-semibold">完了</span>
                   <% end %>
                 </div>
-                <div class="flex items-center space-x-4 text-sm">
+                <div class="flex items-center flex-wrap gap-x-4 gap-y-1 text-sm">
                   <span class="text-gray-600">戦績: <%= ec[:wins] %>勝<%= ec[:losses] %>敗</span>
                   <span class="font-semibold text-blue-600">勝率: <%= ec[:win_rate] %>%</span>
+                  <% if ec[:avg_damage] %>
+                    <span class="text-orange-600 font-semibold">💥 avg <%= number_with_delimiter(ec[:avg_damage]) %></span>
+                  <% end %>
                 </div>
               </div>
             <% end %>
@@ -377,6 +382,14 @@
                   <span class="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-indigo-50 text-indigo-600">
                     <%= match.event.name %>
                   </span>
+                  <% if _my_player&.has_stats? %>
+                    <% if _my_player.score.present? %>
+                      <span class="px-2 py-0.5 text-xs font-semibold rounded-full bg-yellow-50 text-yellow-700">Score <%= number_with_delimiter(_my_player.score) %></span>
+                    <% end %>
+                    <% if _my_player.damage_dealt.present? %>
+                      <span class="px-2 py-0.5 text-xs font-semibold rounded-full bg-orange-50 text-orange-700">💥 <%= number_with_delimiter(_my_player.damage_dealt) %></span>
+                    <% end %>
+                  <% end %>
                 </div>
                 <%# 対戦カード %>
                 <div class="block cursor-pointer"
@@ -409,53 +422,97 @@
         <% end %>
       </div>
 
-      <!-- 5. 対面相性マトリクス -->
-      <div class="bg-white shadow rounded-lg p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-lg font-bold text-gray-900">⚔️ 対面相性マトリクス</h2>
-          <span class="text-xs text-gray-500" title="よく使う機体での対戦相手との相性を確認できます">ℹ️ 機体相性</span>
+      <!-- 5. パフォーマンス スナップショット（stats なし時は対面相性マトリクスを表示） -->
+      <% if @performance_snapshot %>
+        <div class="bg-white shadow rounded-lg p-6">
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-lg font-bold text-gray-900">📊 パフォーマンス スナップショット</h2>
+            <span class="text-xs text-gray-500">全試合平均</span>
+          </div>
+          <div class="grid grid-cols-2 gap-4 mb-4">
+            <div class="bg-indigo-50 rounded-lg p-3 text-center">
+              <div class="text-xs text-indigo-500 mb-1 font-medium">平均スコア</div>
+              <div class="text-2xl font-bold text-indigo-700"><%= number_with_delimiter(@performance_snapshot[:avg_score]) %></div>
+              <% if @community_snapshot&.dig(:avg_score) %>
+                <div class="text-xs text-gray-400 mt-1">全体 avg <%= number_with_delimiter(@community_snapshot[:avg_score]) %></div>
+              <% end %>
+            </div>
+            <div class="bg-orange-50 rounded-lg p-3 text-center">
+              <div class="text-xs text-orange-500 mb-1 font-medium">平均ダメージ</div>
+              <div class="text-2xl font-bold text-orange-600"><%= number_with_delimiter(@performance_snapshot[:avg_damage]) %></div>
+              <% if @community_snapshot&.dig(:avg_damage) %>
+                <div class="text-xs text-gray-400 mt-1">全体 avg <%= number_with_delimiter(@community_snapshot[:avg_damage]) %></div>
+              <% end %>
+            </div>
+            <div class="bg-green-50 rounded-lg p-3 text-center">
+              <div class="text-xs text-green-600 mb-1 font-medium">K/D 比</div>
+              <% if @performance_snapshot[:kd_ratio] %>
+                <div class="text-2xl font-bold text-green-700"><%= @performance_snapshot[:kd_ratio] %></div>
+              <% else %>
+                <div class="text-2xl font-bold text-gray-400">—</div>
+              <% end %>
+            </div>
+            <div class="bg-yellow-50 rounded-lg p-3 text-center">
+              <div class="text-xs text-yellow-600 mb-1 font-medium">平均 EX ダメージ</div>
+              <div class="text-2xl font-bold text-yellow-700"><%= number_with_delimiter(@performance_snapshot[:avg_exburst_damage]) %></div>
+              <% if @community_snapshot&.dig(:avg_exburst_damage) %>
+                <div class="text-xs text-gray-400 mt-1">全体 avg <%= number_with_delimiter(@community_snapshot[:avg_exburst_damage]) %></div>
+              <% end %>
+            </div>
+          </div>
+          <div class="text-right">
+            <%= link_to "詳細を見る →", statistics_path(tab: "performance"), class: "text-sm text-blue-600 hover:text-blue-500" %>
+          </div>
         </div>
-        <% if @matchup_matrix.any? %>
-          <div class="space-y-4">
-            <% @matchup_matrix.each do |matrix| %>
-              <div class="border rounded p-4">
-                <div class="font-semibold text-gray-900 mb-3 flex items-center gap-2">
-                  <%= link_to matrix[:my_suit].name, mobile_suit_path(matrix[:my_suit]),
-                      class: "hover:text-indigo-600 hover:underline transition-colors" %>
-                  <%= cost_badge(matrix[:my_suit].cost) %>
-                </div>
-                <div class="space-y-2">
-                  <% matrix[:matchups].each do |matchup| %>
-                    <div class="flex items-center justify-between text-sm bg-gray-50 rounded p-2">
-                      <div class="flex-1">
-                        <%= link_to matchup[:opponent_suit].name, mobile_suit_path(matchup[:opponent_suit]),
-                            class: "text-gray-700 hover:text-indigo-600 hover:underline transition-colors" %>
-                        <span class="text-xs text-gray-500 ml-2"><%= matchup[:wins] %>勝<%= matchup[:losses] %>敗</span>
-                      </div>
-                      <div class="flex items-center space-x-2">
-                        <span class="font-semibold <%= matchup[:win_rate] >= 60 ? 'text-blue-600' : (matchup[:win_rate] >= 40 ? 'text-gray-600' : 'text-red-600') %>">
-                          <%= matchup[:win_rate] %>%
-                        </span>
-                        <span class="px-2 py-1 rounded text-xs font-semibold <%= matchup[:compatibility] == '得意' ? 'bg-blue-100 text-blue-800' : (matchup[:compatibility] == '普通' ? 'bg-gray-100 text-gray-800' : 'bg-red-100 text-red-800') %>">
-                          <%= matchup[:compatibility] %>
-                        </span>
-                      </div>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
-            <% end %>
+      <% else %>
+        <!-- フォールバック: 対面相性マトリクス -->
+        <div class="bg-white shadow rounded-lg p-6">
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-lg font-bold text-gray-900">⚔️ 対面相性マトリクス</h2>
+            <span class="text-xs text-gray-500" title="よく使う機体での対戦相手との相性を確認できます">ℹ️ 機体相性</span>
           </div>
-        <% else %>
-          <div class="text-center py-8">
-            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-            </svg>
-            <p class="mt-2 text-sm text-gray-500">データが不足しています</p>
-            <p class="mt-1 text-xs text-gray-400">同じ機体で2試合以上対戦すると、相性データが表示されます</p>
-          </div>
-        <% end %>
-      </div>
+          <% if @matchup_matrix.any? %>
+            <div class="space-y-4">
+              <% @matchup_matrix.each do |matrix| %>
+                <div class="border rounded p-4">
+                  <div class="font-semibold text-gray-900 mb-3 flex items-center gap-2">
+                    <%= link_to matrix[:my_suit].name, mobile_suit_path(matrix[:my_suit]),
+                        class: "hover:text-indigo-600 hover:underline transition-colors" %>
+                    <%= cost_badge(matrix[:my_suit].cost) %>
+                  </div>
+                  <div class="space-y-2">
+                    <% matrix[:matchups].each do |matchup| %>
+                      <div class="flex items-center justify-between text-sm bg-gray-50 rounded p-2">
+                        <div class="flex-1">
+                          <%= link_to matchup[:opponent_suit].name, mobile_suit_path(matchup[:opponent_suit]),
+                              class: "text-gray-700 hover:text-indigo-600 hover:underline transition-colors" %>
+                          <span class="text-xs text-gray-500 ml-2"><%= matchup[:wins] %>勝<%= matchup[:losses] %>敗</span>
+                        </div>
+                        <div class="flex items-center space-x-2">
+                          <span class="font-semibold <%= matchup[:win_rate] >= 60 ? 'text-blue-600' : (matchup[:win_rate] >= 40 ? 'text-gray-600' : 'text-red-600') %>">
+                            <%= matchup[:win_rate] %>%
+                          </span>
+                          <span class="px-2 py-1 rounded text-xs font-semibold <%= matchup[:compatibility] == '得意' ? 'bg-blue-100 text-blue-800' : (matchup[:compatibility] == '普通' ? 'bg-gray-100 text-gray-800' : 'bg-red-100 text-red-800') %>">
+                            <%= matchup[:compatibility] %>
+                          </span>
+                        </div>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          <% else %>
+            <div class="text-center py-8">
+              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+              </svg>
+              <p class="mt-2 text-sm text-gray-500">データが不足しています</p>
+              <p class="mt-1 text-xs text-gray-400">同じ機体で2試合以上対戦すると、相性データが表示されます</p>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
       <% end %>
 
     </div>
@@ -507,6 +564,20 @@
               <div class="text-3xl font-bold text-purple-600"><%= @user_win_rate %>%</div>
               <div class="text-sm text-gray-500 mt-1">勝率</div>
             </div>
+            <% if @user_has_stats %>
+              <div class="border-t border-gray-100 pt-4 space-y-3">
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-gray-500">💥 平均ダメージ</span>
+                  <span class="font-semibold text-orange-600"><%= number_with_delimiter(@user_avg_damage) %></span>
+                </div>
+                <% if @user_avg_kd %>
+                  <div class="flex items-center justify-between text-sm">
+                    <span class="text-gray-500">⚔️ K/D 比</span>
+                    <span class="font-semibold text-green-600"><%= @user_avg_kd %></span>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           </div>
         </div>
         <% end %>
@@ -560,108 +631,189 @@
         </div>
       </div>
 
-      <!-- 4. 機体使用トレンド（直近イベント） -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <div class="flex items-center justify-between">
-            <h2 class="text-lg font-bold text-gray-900">📱 機体トレンド</h2>
-            <span class="text-xs text-gray-500" title="直近イベントでの使用機体と勝率">ℹ️ イベント別</span>
+      <!-- 4. パーソナル ハイライト（stats なし時は機体トレンドを表示） -->
+      <% if !viewing_as_user.is_guest && (@highlight_best_damage_mp || @highlight_best_kd_mp) %>
+        <div class="bg-white shadow rounded-lg">
+          <div class="px-6 py-5 border-b border-gray-200">
+            <h2 class="text-lg font-bold text-gray-900">🏅 パーソナル ハイライト</h2>
           </div>
-          <% if !viewing_as_user.is_guest && @trend_event %>
-            <p class="text-xs text-gray-500 mt-1">
-              <%= @trend_event.name %>
-              <% if @is_today_event %>
-                <span class="ml-1 px-2 py-0.5 bg-blue-500 text-white rounded text-xs">開催中</span>
-              <% end %>
-            </p>
-          <% end %>
-        </div>
-        <div class="divide-y divide-gray-200">
-          <% if viewing_as_user.is_guest %>
-            <div class="px-6 py-8 text-center">
-              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-              <p class="mt-2 text-sm text-gray-500">ゲストアカウントでは表示されません</p>
-              <p class="mt-1 text-xs text-gray-400">管理者にアカウント発行を依頼してください</p>
-            </div>
-          <% elsif @event_suit_trend&.any? %>
-            <% @event_suit_trend.each do |trend| %>
+          <div class="divide-y divide-gray-200">
+            <% if @highlight_best_damage_mp %>
+              <%
+                _hmp = @highlight_best_damage_mp
+                _hmatch = _hmp.match
+              %>
               <div class="px-6 py-4">
                 <div class="flex items-center justify-between mb-1">
-                  <div class="font-medium text-gray-900">
-                    <%= link_to trend[:mobile_suit].name, mobile_suit_path(trend[:mobile_suit]),
-                        class: "hover:text-indigo-600 hover:underline transition-colors" %>
-                  </div>
-                  <div class="text-sm font-semibold <%= trend[:win_rate] >= 60 ? 'text-blue-600' : 'text-gray-600' %>">
-                    <%= trend[:win_rate] %>%
-                  </div>
+                  <div class="text-sm font-semibold text-orange-600">💥 ベストダメージ</div>
+                  <div class="text-lg font-bold text-orange-600"><%= number_with_delimiter(_hmp.damage_dealt) %></div>
                 </div>
-                <div class="text-xs text-gray-500">使用回数: <%= trend[:usage] %>回</div>
-                <% if trend[:recommended] %>
-                  <div class="text-xs text-blue-600 mt-1">✨ 調子が良い機体です！</div>
-                <% end %>
+                <div class="text-xs text-gray-500">
+                  <%= _hmatch.event.name %> ·
+                  <%= link_to _hmp.mobile_suit.name, mobile_suit_path(_hmp.mobile_suit), class: "hover:text-indigo-600 hover:underline" %>
+                  · <%= link_to _hmatch.played_at.strftime('%m/%d'), match_path(_hmatch), class: "hover:text-blue-600" %>
+                </div>
               </div>
             <% end %>
-          <% else %>
-            <div class="px-6 py-8 text-center">
-              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
-              </svg>
-              <p class="mt-2 text-sm text-gray-500">まだ試合データがありません</p>
-              <p class="mt-1 text-xs text-gray-400">イベントで試合をすると、機体の使用状況が表示されます</p>
-            </div>
-          <% end %>
-        </div>
-      </div>
-
-      <!-- 5. コスト帯分析 -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <div class="flex items-center justify-between">
-            <h2 class="text-lg font-bold text-gray-900">💰 コスト帯分析</h2>
-            <span class="text-xs text-gray-500" title="チームコストの組み合わせ別の勝率">ℹ️ コスト別</span>
+            <% if @highlight_best_kd_mp %>
+              <%
+                _kmp = @highlight_best_kd_mp
+                _kmatch = _kmp.match
+                _kd_val = _kmp.deaths.to_i > 0 ? (_kmp.kills.to_f / _kmp.deaths).round(2) : _kmp.kills.to_s
+              %>
+              <div class="px-6 py-4">
+                <div class="flex items-center justify-between mb-1">
+                  <div class="text-sm font-semibold text-green-600">⚔️ ベスト K/D</div>
+                  <div class="text-lg font-bold text-green-600"><%= _kd_val %> (<%= _kmp.kills %>/<%= _kmp.deaths %>)</div>
+                </div>
+                <div class="text-xs text-gray-500">
+                  <%= _kmatch.event.name %> ·
+                  <%= link_to _kmp.mobile_suit.name, mobile_suit_path(_kmp.mobile_suit), class: "hover:text-indigo-600 hover:underline" %>
+                  · <%= link_to _kmatch.played_at.strftime('%m/%d'), match_path(_kmatch), class: "hover:text-blue-600" %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+          <div class="px-6 py-4 bg-gray-50 text-center">
+            <%= link_to "ハイライト一覧 →", statistics_path(tab: "highlights"), class: "text-sm text-blue-600 hover:text-blue-500" %>
           </div>
         </div>
-        <div class="divide-y divide-gray-200">
-          <% if viewing_as_user.is_guest %>
-            <div class="px-6 py-8 text-center">
-              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-              <p class="mt-2 text-sm text-gray-500">ゲストアカウントでは表示されません</p>
-              <p class="mt-1 text-xs text-gray-400">管理者にアカウント発行を依頼してください</p>
+      <% else %>
+        <!-- フォールバック: 機体使用トレンド -->
+        <div class="bg-white shadow rounded-lg">
+          <div class="px-6 py-5 border-b border-gray-200">
+            <div class="flex items-center justify-between">
+              <h2 class="text-lg font-bold text-gray-900">📱 機体トレンド</h2>
+              <span class="text-xs text-gray-500" title="直近イベントでの使用機体と勝率">ℹ️ イベント別</span>
             </div>
-          <% elsif @cost_analysis.any? %>
-            <% @cost_analysis.each do |cost| %>
-              <div class="px-6 py-4">
-                <div class="flex items-center justify-between mb-2">
-                  <div>
-                    <div class="font-semibold text-gray-900 flex items-center"><%= cost_combo_badges(cost[:cost_combo]) %></div>
-                    <div class="text-xs text-gray-500 mt-1"><%= cost[:wins] %>勝<%= cost[:losses] %>敗</div>
-                  </div>
-                  <div class="text-right">
-                    <div class="text-lg font-bold <%= cost[:win_rate] >= 60 ? 'text-blue-600' : (cost[:win_rate] >= 40 ? 'text-gray-600' : 'text-red-600') %>">
-                      <%= cost[:win_rate] %>%
+            <% if !viewing_as_user.is_guest && @trend_event %>
+              <p class="text-xs text-gray-500 mt-1">
+                <%= @trend_event.name %>
+                <% if @is_today_event %>
+                  <span class="ml-1 px-2 py-0.5 bg-blue-500 text-white rounded text-xs">開催中</span>
+                <% end %>
+              </p>
+            <% end %>
+          </div>
+          <div class="divide-y divide-gray-200">
+            <% if viewing_as_user.is_guest %>
+              <div class="px-6 py-8 text-center">
+                <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                </svg>
+                <p class="mt-2 text-sm text-gray-500">ゲストアカウントでは表示されません</p>
+                <p class="mt-1 text-xs text-gray-400">管理者にアカウント発行を依頼してください</p>
+              </div>
+            <% elsif @event_suit_trend&.any? %>
+              <% @event_suit_trend.each do |trend| %>
+                <div class="px-6 py-4">
+                  <div class="flex items-center justify-between mb-1">
+                    <div class="font-medium text-gray-900">
+                      <%= link_to trend[:mobile_suit].name, mobile_suit_path(trend[:mobile_suit]),
+                          class: "hover:text-indigo-600 hover:underline transition-colors" %>
                     </div>
-                    <span class="text-xs px-2 py-1 rounded <%= cost[:judgment] == '得意' ? 'bg-blue-100 text-blue-800' : (cost[:judgment] == '普通' ? 'bg-gray-100 text-gray-800' : 'bg-red-100 text-red-800') %>">
-                      <%= cost[:judgment] %>
-                    </span>
+                    <div class="text-sm font-semibold <%= trend[:win_rate] >= 60 ? 'text-blue-600' : 'text-gray-600' %>">
+                      <%= trend[:win_rate] %>%
+                    </div>
                   </div>
+                  <div class="text-xs text-gray-500">使用回数: <%= trend[:usage] %>回</div>
+                  <% if trend[:recommended] %>
+                    <div class="text-xs text-blue-600 mt-1">✨ 調子が良い機体です！</div>
+                  <% end %>
                 </div>
+              <% end %>
+            <% else %>
+              <div class="px-6 py-8 text-center">
+                <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                </svg>
+                <p class="mt-2 text-sm text-gray-500">まだ試合データがありません</p>
+                <p class="mt-1 text-xs text-gray-400">イベントで試合をすると、機体の使用状況が表示されます</p>
               </div>
             <% end %>
-          <% else %>
-            <div class="px-6 py-8 text-center">
-              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <p class="mt-2 text-sm text-gray-500">まだデータがありません</p>
-              <p class="mt-1 text-xs text-gray-400">同じコスト組み合わせで3試合以上プレイすると表示されます</p>
-            </div>
-          <% end %>
+          </div>
         </div>
-      </div>
+      <% end %>
+
+      <!-- 5. EXバースト サマリー（stats なし時はコスト帯分析を表示） -->
+      <% if !viewing_as_user.is_guest && @exburst_summary %>
+        <div class="bg-white shadow rounded-lg p-6">
+          <div class="flex items-center justify-between mb-4">
+            <h2 class="text-lg font-bold text-gray-900">⚡ EXバースト サマリー</h2>
+            <span class="text-xs text-gray-500">全試合平均</span>
+          </div>
+          <div class="space-y-3">
+            <div class="flex items-center justify-between text-sm">
+              <span class="text-gray-600">平均 EXバースト 回数</span>
+              <div class="text-right">
+                <span class="font-bold text-yellow-600 text-lg"><%= @exburst_summary[:avg_count] %></span>
+                <% if @exburst_summary[:community_avg_count] %>
+                  <span class="text-xs text-gray-400 ml-1">（全体 avg <%= @exburst_summary[:community_avg_count] %>）</span>
+                <% end %>
+              </div>
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span class="text-gray-600">平均 EXバースト ダメージ</span>
+              <span class="font-bold text-yellow-600 text-lg"><%= number_with_delimiter(@exburst_summary[:avg_damage]) %></span>
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span class="text-gray-600">EXバースト 中被撃墜率</span>
+              <span class="font-bold <%= @exburst_summary[:death_rate] >= 30 ? 'text-red-600' : 'text-gray-700' %> text-lg"><%= @exburst_summary[:death_rate] %>%</span>
+            </div>
+          </div>
+          <div class="mt-4 text-right">
+            <%= link_to "詳細を見る →", statistics_path(tab: "performance"), class: "text-sm text-blue-600 hover:text-blue-500" %>
+          </div>
+        </div>
+      <% else %>
+        <!-- フォールバック: コスト帯分析 -->
+        <div class="bg-white shadow rounded-lg">
+          <div class="px-6 py-5 border-b border-gray-200">
+            <div class="flex items-center justify-between">
+              <h2 class="text-lg font-bold text-gray-900">💰 コスト帯分析</h2>
+              <span class="text-xs text-gray-500" title="チームコストの組み合わせ別の勝率">ℹ️ コスト別</span>
+            </div>
+          </div>
+          <div class="divide-y divide-gray-200">
+            <% if viewing_as_user.is_guest %>
+              <div class="px-6 py-8 text-center">
+                <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                </svg>
+                <p class="mt-2 text-sm text-gray-500">ゲストアカウントでは表示されません</p>
+                <p class="mt-1 text-xs text-gray-400">管理者にアカウント発行を依頼してください</p>
+              </div>
+            <% elsif @cost_analysis.any? %>
+              <% @cost_analysis.each do |cost| %>
+                <div class="px-6 py-4">
+                  <div class="flex items-center justify-between mb-2">
+                    <div>
+                      <div class="font-semibold text-gray-900 flex items-center"><%= cost_combo_badges(cost[:cost_combo]) %></div>
+                      <div class="text-xs text-gray-500 mt-1"><%= cost[:wins] %>勝<%= cost[:losses] %>敗</div>
+                    </div>
+                    <div class="text-right">
+                      <div class="text-lg font-bold <%= cost[:win_rate] >= 60 ? 'text-blue-600' : (cost[:win_rate] >= 40 ? 'text-gray-600' : 'text-red-600') %>">
+                        <%= cost[:win_rate] %>%
+                      </div>
+                      <span class="text-xs px-2 py-1 rounded <%= cost[:judgment] == '得意' ? 'bg-blue-100 text-blue-800' : (cost[:judgment] == '普通' ? 'bg-gray-100 text-gray-800' : 'bg-red-100 text-red-800') %>">
+                        <%= cost[:judgment] %>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            <% else %>
+              <div class="px-6 py-8 text-center">
+                <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <p class="mt-2 text-sm text-gray-500">まだデータがありません</p>
+                <p class="mt-1 text-xs text-gray-400">同じコスト組み合わせで3試合以上プレイすると表示されます</p>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
 
       <!-- 6. あなたのお気に入り機体（TOP3） -->
       <div class="bg-white shadow rounded-lg">
@@ -691,7 +843,10 @@
                     <div class="text-xs text-gray-500"><%= suit.series %></div>
                   </div>
                 </div>
-                <span class="text-sm text-purple-600 font-semibold"><%= suit.usage_count %>回</span>
+                <div class="text-right">
+                  <div class="text-sm text-purple-600 font-semibold"><%= suit.usage_count %>回</div>
+                  <div class="text-xs font-semibold <%= suit.win_rate >= 60 ? 'text-blue-600' : (suit.win_rate >= 40 ? 'text-gray-500' : 'text-red-500') %>"><%= suit.win_rate %>%</div>
+                </div>
               </div>
             <% end %>
           <% else %>
@@ -733,42 +888,6 @@
     </div>
   </div>
 
-  <!-- 下部全幅 - 人気の機体TOP5 -->
-  <div class="mt-6">
-    <div class="bg-white shadow rounded-lg">
-      <div class="px-6 py-5 border-b border-gray-200">
-        <h2 class="text-lg font-bold text-gray-900">🔥 人気の機体 TOP5</h2>
-      </div>
-      <div class="divide-y divide-gray-200">
-        <% if @popular_mobile_suits.any? %>
-          <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5">
-            <% @popular_mobile_suits.each_with_index do |suit, index| %>
-              <div class="px-4 sm:px-6 py-4 border-b sm:border-b-0 sm:border-r border-gray-200 last:border-b-0 last:border-r-0">
-                <div class="flex items-center justify-between mb-2">
-                  <span class="text-xl sm:text-2xl font-bold text-gray-300"><%= index + 1 %></span>
-                  <span class="text-xs sm:text-sm text-blue-600 font-semibold"><%= suit.usage_count %>回</span>
-                </div>
-                <div class="text-xs sm:text-sm font-medium text-gray-900">
-                  <%= link_to suit.name, mobile_suit_path(suit),
-                      class: "hover:text-indigo-600 hover:underline transition-colors" %>
-                </div>
-                <div class="text-xs text-gray-500 mt-1 truncate"><%= suit.series %></div>
-                <div class="mt-1"><%= cost_badge(suit.cost) %></div>
-              </div>
-            <% end %>
-          </div>
-        <% else %>
-          <div class="px-6 py-8 text-center">
-            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
-            </svg>
-            <p class="mt-2 text-sm text-gray-500">まだ試合データがありません</p>
-            <p class="mt-1 text-xs text-gray-400">試合が記録されると、人気機体のランキングが表示されます</p>
-          </div>
-        <% end %>
-      </div>
-    </div>
-  </div>
 
 </div>
 


### PR DESCRIPTION
## Summary
- 新規カード「パフォーマンス スナップショット」追加（avg スコア・ダメージ・K/D・EX ダメージ + コミュニティ平均）
- 新規カード「パーソナル ハイライト」追加（ベストダメージ試合・ベスト K/D 試合）
- 新規カード「EXバースト サマリー」追加（avg EXバースト回数・ダメージ・被撃墜率）
- 既存カード強化: イベント比較に avg ダメージ追加・最近の試合にスコア/ダメージバッジ追加・個人成績に avg ダメージ/K/D 追加・お気に入り機体に勝率追加
- 人気機体 TOP5（全幅）を削除（統計ページに同等機能あり）
- stats データなしユーザーは従来カードが fallback 表示（後方互換）

## Test plan
- [x] stats ありユーザーでログイン → スナップショット・ハイライト・EXバーストカードが表示される
- [x] stats なしユーザーでログイン → 各カードが fallback（旧カード）表示になる
- [x] ゲストユーザー → 従来通り「ゲストアカウント」警告のみ表示
- [x] ローテーションアクティブ時 → リアルタイムカードが正常表示される
- [x] 調子メーター → 変更なしで正常表示される
- [x] 統計ページへの「詳細を見る →」リンクが正しいタブに遷移する

Closes #213