### PR TITLE
feat: ローテーション詳細の全試合一覧に記録済み試合の機体名を表示する

### DIFF
--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -10,7 +10,8 @@ class RotationsController < ApplicationController
 
   def show
     @rotation_matches = @rotation.rotation_matches
-                                  .includes(:team1_player1, :team1_player2, :team2_player1, :team2_player2, :match)
+                                  .includes(:team1_player1, :team1_player2, :team2_player1, :team2_player2,
+                                            match: { match_players: :mobile_suit })
                                   .order(:match_index)
     @current_match = @rotation_matches[@rotation.current_match_index]
     @player_statistics = @rotation.player_statistics

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -596,11 +596,24 @@
                   <% end %>
                 </div>
               </td>
+              <%
+                mp1 = rm.match&.match_players&.find { |mp| mp.position == 1 }
+                mp2 = rm.match&.match_players&.find { |mp| mp.position == 2 }
+                mp3 = rm.match&.match_players&.find { |mp| mp.position == 3 }
+                mp4 = rm.match&.match_players&.find { |mp| mp.position == 4 }
+              %>
               <td class="px-6 py-4 whitespace-nowrap">
                 <div class="text-sm text-gray-900">
                   <span class="font-bold text-red-600"><%= rm.team1_player1.nickname %></span>
-                  <span class="ml-1 px-1.5 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span><br>
+                  <span class="ml-1 px-1.5 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
+                  <% if mp1&.mobile_suit %>
+                    <a href="<%= mobile_suit_path(mp1.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp1.mobile_suit.name %>)</a>
+                  <% end %>
+                  <br>
                   <%= rm.team1_player2.nickname %>
+                  <% if mp2&.mobile_suit %>
+                    <a href="<%= mobile_suit_path(mp2.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp2.mobile_suit.name %>)</a>
+                  <% end %>
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-center">
@@ -608,8 +621,15 @@
               </td>
               <td class="px-6 py-4 whitespace-nowrap">
                 <div class="text-sm text-gray-900">
-                  <%= rm.team2_player1.nickname %><br>
+                  <%= rm.team2_player1.nickname %>
+                  <% if mp3&.mobile_suit %>
+                    <a href="<%= mobile_suit_path(mp3.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp3.mobile_suit.name %>)</a>
+                  <% end %>
+                  <br>
                   <%= rm.team2_player2.nickname %>
+                  <% if mp4&.mobile_suit %>
+                    <a href="<%= mobile_suit_path(mp4.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp4.mobile_suit.name %>)</a>
+                  <% end %>
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-center">


### PR DESCRIPTION
## Summary
- `rotations_controller.rb` の `show` アクションで `match_players` と `mobile_suit` を eager loading に追加（N+1 防止）
- 全試合一覧テーブルのチーム1・チーム2列で、記録済み試合のプレイヤー名横に機体名を `(機体名)` 形式でリンク付き表示（機体詳細ページへ遷移）
- ループをまたいで変数が残ることで未記録行にも機体名が表示されるバグを修正（セーフナビゲーションで毎イテレーション上書き）
- 動的更新は既存の Action Cable → `window.location.reload()` で対応済みのため追加実装なし

## Test plan
- [x] 記録済み試合がある行のチーム1・チーム2列に機体名が表示されること
- [x] 機体名をクリックすると機体詳細ページへ遷移すること（行クリックによる試合詳細への遷移は妨げないこと）
- [x] 未記録・スキップ行では機体名が表示されないこと
- [x] 「記録して次へ」送信後にページが再読込され、新しく記録した試合の機体名が一覧に反映されること

Closes #215