### PR TITLE
chore: イベントリマインド送信時刻を12時から8時に変更する

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -17,4 +17,4 @@ production:
   event_reminder:
     class: EventReminderJob
     queue: default
-    schedule: every day at 12pm
+    schedule: every day at 8am


### PR DESCRIPTION
## Summary
- `config/recurring.yml` の `event_reminder` スケジュールを `every day at 12pm` → `every day at 8am` に変更

## Test plan
- [ ] 本番環境でリマインドが朝8時に送信されることを確認

Closes #217