### PR TITLE
fix: プレイ分析タブのレンジバー min/max をコミュニティ値に固定する

### DIFF
--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1435,8 +1435,8 @@
                       <div class="text-2xl font-semibold text-gray-500"><%= @community_ex_remaining_rate %><span class="text-sm font-normal">%</span></div>
                       <% if @community_ex_remaining_min && @community_ex_remaining_max %>
                         <%
-                          c_min    = [@community_ex_remaining_min, ex_pct].min
-                          c_max    = [@community_ex_remaining_max, ex_pct].max
+                          c_min    = @community_ex_remaining_min
+                          c_max    = @community_ex_remaining_max
                         %>
                         <% if c_min != c_max %>
                         <%
@@ -1516,8 +1516,8 @@
                     </div>
                     <% if item[:comm_rate] && item[:comm_min] && item[:comm_max] %>
                       <%
-                        ic_min       = [item[:comm_min], item[:user_v]].min
-                        ic_max       = [item[:comm_max], item[:user_v]].max
+                        ic_min       = item[:comm_min]
+                        ic_max       = item[:comm_max]
                       %>
                       <% if ic_min != ic_max %>
                       <%
@@ -1623,8 +1623,8 @@
                     <div class="text-2xl font-semibold text-gray-500"><%= @community_opp_no_ol_win_rate %><span class="text-sm font-normal">%</span></div>
                     <% if @community_opp_no_ol_win_min && @community_opp_no_ol_win_max %>
                       <%
-                        c_min = [@community_opp_no_ol_win_min, opp_no_ol_pct].min
-                        c_max = [@community_opp_no_ol_win_max, opp_no_ol_pct].max
+                        c_min = @community_opp_no_ol_win_min
+                        c_max = @community_opp_no_ol_win_max
                       %>
                       <% if c_min != c_max %>
                         <%
@@ -1708,8 +1708,8 @@
                     <div class="text-2xl font-semibold text-gray-500"><%= @community_no_ol_loss_rate %><span class="text-sm font-normal">%</span></div>
                     <% if @community_no_ol_loss_min && @community_no_ol_loss_max %>
                       <%
-                        c_min = [@community_no_ol_loss_min, no_ol_pct].min
-                        c_max = [@community_no_ol_loss_max, no_ol_pct].max
+                        c_min = @community_no_ol_loss_min
+                        c_max = @community_no_ol_loss_max
                       %>
                       <% if c_min != c_max %>
                         <%
@@ -2020,8 +2020,8 @@
                               <div class="text-sm text-gray-600 font-medium"><%= "#{avg_val}#{row[:suffix]}" %></div>
                               <% if min_val && max_val && user_val %>
                                 <%
-                                  c_min = [min_val, user_val.to_f].min
-                                  c_max = [max_val, user_val.to_f].max
+                                  c_min = min_val
+                                  c_max = max_val
                                 %>
                                 <% if c_min != c_max %>
                                   <%


### PR DESCRIPTION
## Summary
- プレイ分析タブの各グラフ（EXバースト活用分析・EXオーバーリミット分析・基本パフォーマンス統計）で、レンジバーの最小値・最大値がコミュニティ全体の値と一致しない問題を修正

## 原因

ビュー側でレンジバーの表示範囲を計算する際、ユーザーの個人値でコミュニティ min/max を上書きしていた。

```erb
# 修正前
c_min = [@community_ex_remaining_min, ex_pct].min  # ユーザー値が範囲外だと拡張される
c_max = [@community_ex_remaining_max, ex_pct].max
```

フィルター適用時などにユーザーの個人値がコミュニティ範囲外になると、表示されるラベルがコミュニティの min/max ではなくユーザー値に引っ張られてしまっていた。

## 変更内容

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| EXバースト残率 | `[@community_ex_remaining_min, ex_pct].min/max` | `@community_ex_remaining_min/max` |
| EXバースト詳細（item ループ） | `[item[:comm_min], item[:user_v]].min/max` | `item[:comm_min/max]` |
| OL敗北時 | `[@community_no_ol_loss_min, no_ol_pct].min/max` | `@community_no_ol_loss_min/max` |
| OL勝利時 | `[@community_opp_no_ol_win_min, opp_no_ol_pct].min/max` | `@community_opp_no_ol_win_min/max` |
| 基本パフォーマンス統計 | `[min_val, user_val.to_f].min/max` | `min_val / max_val` |

ユーザードットの位置は既存の `.clamp(0, 100)` で端に収まるため、範囲外の値でも表示は正常。

## Test plan
- [x] プレイ分析タブを開き、EXバースト活用分析・EXオーバーリミット分析のレンジバー左右端の値がコミュニティ全体の値であることを確認
- [x] 基本パフォーマンス統計テーブルのレンジバー左右端の値がコミュニティ全体の値であることを確認
- [x] フィルター（イベント・機体など）を適用した状態でも左右端の値が変わらないことを確認

Closes #220