### PR TITLE
fix: 8人ローテーション全試合一覧のセット区切りを1セット6試合に修正

### DIFF
--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -22,6 +22,15 @@ class Rotation < ApplicationRecord
     User.where(id: player_ids)
   end
 
+  def player_count
+    players.count
+  end
+
+  # 8人の場合のみ1セット6試合、それ以外は1セット3試合
+  def matches_per_set
+    player_count == 8 ? 6 : 3
+  end
+
   # Calculate statistics for each player
   def player_statistics
     stats = Hash.new do |h, k|

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -561,12 +561,13 @@
           </tr>
         </thead>
         <tbody class="bg-white">
+          <% mps = @rotation.matches_per_set %>
           <% @rotation_matches.each_with_index do |rm, index| %>
             <%
-              # 3試合1セットの計算
-              set_number = index / 3
-              is_set_start = (index % 3 == 0)
-              in_set_position = index % 3
+              # 人数に応じた1セットあたりの試合数（8人: 6試合、それ以外: 3試合）
+              set_number = index / mps
+              is_set_start = (index % mps == 0)
+              in_set_position = index % mps
 
               # 背景色（現在の試合のみハイライト）
               if index == @rotation.current_match_index


### PR DESCRIPTION
## Summary
- 8人ローテーションの全試合一覧で、セット区切りが「3試合1セット」にハードコードされており、14セットに分割されてしまっていた問題を修正

## 原因

`show.html.erb` のセット計算が `index / 3` にハードコードされており、人数に関係なく常に3試合1セットで区切られていた。

## 変更内容

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `Rotation#matches_per_set` | なし | 追加（8人→6、それ以外→3） |
| `Rotation#player_count` | なし | 追加（`players.count` を返す） |
| `show.html.erb` セット計算 | `index / 3`（ハードコード） | `index / mps`（動的） |

8人ローテーション（42試合）のセット数: 14セット → 7セット

## Test plan
- [ ] 8人ローテーションの詳細画面で、全試合一覧が7セット（各6試合）で区切られることを確認
- [ ] 4人・5人等のローテーションで、引き続き3試合1セットで区切られることを確認

Closes #222