### PR TITLE
chore: v1.9.1 リリース

### DIFF
--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -22,6 +22,15 @@ class Rotation < ApplicationRecord
     User.where(id: player_ids)
   end
 
+  def player_count
+    players.count
+  end
+
+  # 8人の場合のみ1セット6試合、それ以外は1セット3試合
+  def matches_per_set
+    player_count == 8 ? 6 : 3
+  end
+
   # Calculate statistics for each player
   def player_statistics
     stats = Hash.new do |h, k|

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -561,12 +561,13 @@
           </tr>
         </thead>
         <tbody class="bg-white">
+          <% mps = @rotation.matches_per_set %>
           <% @rotation_matches.each_with_index do |rm, index| %>
             <%
-              # 3試合1セットの計算
-              set_number = index / 3
-              is_set_start = (index % 3 == 0)
-              in_set_position = index % 3
+              # 人数に応じた1セットあたりの試合数（8人: 6試合、それ以外: 3試合）
+              set_number = index / mps
+              is_set_start = (index % mps == 0)
+              in_set_position = index % mps
 
               # 背景色（現在の試合のみハイライト）
               if index == @rotation.current_match_index

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1435,8 +1435,8 @@
                       <div class="text-2xl font-semibold text-gray-500"><%= @community_ex_remaining_rate %><span class="text-sm font-normal">%</span></div>
                       <% if @community_ex_remaining_min && @community_ex_remaining_max %>
                         <%
-                          c_min    = [@community_ex_remaining_min, ex_pct].min
-                          c_max    = [@community_ex_remaining_max, ex_pct].max
+                          c_min    = @community_ex_remaining_min
+                          c_max    = @community_ex_remaining_max
                         %>
                         <% if c_min != c_max %>
                         <%
@@ -1516,8 +1516,8 @@
                     </div>
                     <% if item[:comm_rate] && item[:comm_min] && item[:comm_max] %>
                       <%
-                        ic_min       = [item[:comm_min], item[:user_v]].min
-                        ic_max       = [item[:comm_max], item[:user_v]].max
+                        ic_min       = item[:comm_min]
+                        ic_max       = item[:comm_max]
                       %>
                       <% if ic_min != ic_max %>
                       <%
@@ -1623,8 +1623,8 @@
                     <div class="text-2xl font-semibold text-gray-500"><%= @community_opp_no_ol_win_rate %><span class="text-sm font-normal">%</span></div>
                     <% if @community_opp_no_ol_win_min && @community_opp_no_ol_win_max %>
                       <%
-                        c_min = [@community_opp_no_ol_win_min, opp_no_ol_pct].min
-                        c_max = [@community_opp_no_ol_win_max, opp_no_ol_pct].max
+                        c_min = @community_opp_no_ol_win_min
+                        c_max = @community_opp_no_ol_win_max
                       %>
                       <% if c_min != c_max %>
                         <%
@@ -1708,8 +1708,8 @@
                     <div class="text-2xl font-semibold text-gray-500"><%= @community_no_ol_loss_rate %><span class="text-sm font-normal">%</span></div>
                     <% if @community_no_ol_loss_min && @community_no_ol_loss_max %>
                       <%
-                        c_min = [@community_no_ol_loss_min, no_ol_pct].min
-                        c_max = [@community_no_ol_loss_max, no_ol_pct].max
+                        c_min = @community_no_ol_loss_min
+                        c_max = @community_no_ol_loss_max
                       %>
                       <% if c_min != c_max %>
                         <%
@@ -2020,8 +2020,8 @@
                               <div class="text-sm text-gray-600 font-medium"><%= "#{avg_val}#{row[:suffix]}" %></div>
                               <% if min_val && max_val && user_val %>
                                 <%
-                                  c_min = [min_val, user_val.to_f].min
-                                  c_max = [max_val, user_val.to_f].max
+                                  c_min = min_val
+                                  c_max = max_val
                                 %>
                                 <% if c_min != c_max %>
                                   <%


### PR DESCRIPTION
## Summary
release/v1.9.1 を main にマージするリリースPRです。

## 主な変更
- バグ修正: 統計プレイ分析タブの各グラフ最小値・最大値がコミュニティ全体の値と一致しない問題を修正
- バグ修正: ローテーション詳細の全試合一覧で8人の場合のセット区切りを1セット6試合に修正

## 関連Issue・PR
- #221 (fix: stats range bar bounds → #220)
- #223 (fix: 8-player rotation set display → #222)