### PR TITLE
fix: フィルター時のコミュニティ最小値・最大値をフィルター後の母集団で算出する

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -106,6 +106,13 @@ class StatisticsController < ApplicationController
     end
   end
 
+  # コミュニティ側クエリの基底スコープ（イベントフィルターのみ適用）
+  def community_base_scope
+    scope = MatchPlayer.joins(:match, :user).where(users: { is_guest: false })
+    scope = scope.where(matches: { event_id: @filter_events }) if @filter_events.any?
+    scope
+  end
+
   def calculate_overview_stats
     # サマリーカード用の統計
     @total_matches = @filtered_matches.count
@@ -679,8 +686,7 @@ class StatisticsController < ApplicationController
     }
 
     # EXバースト活用分析のコミュニティ分布（ユーザー別率 → avg/min/max）
-    ex_loss_mps = MatchPlayer.joins(:match, :user).includes(:match)
-      .where(users: { is_guest: false })
+    ex_loss_mps = community_base_scope.includes(:match)
       .where("matches.winning_team IS NOT NULL AND matches.winning_team != match_players.team_number")
       .where("last_death_ex_available IS NOT NULL OR survive_loss_ex_available IS NOT NULL")
       .to_a
@@ -706,8 +712,7 @@ class StatisticsController < ApplicationController
     end
 
     # OL分析のコミュニティ分布（ユーザー別率 → avg/min/max）
-    ol_mps_all = MatchPlayer.joins(:match, :user).includes(:match)
-      .where(users: { is_guest: false })
+    ol_mps_all = community_base_scope.includes(:match)
       .where("matches.winning_team IS NOT NULL")
       .to_a
     if ol_mps_all.any?
@@ -746,8 +751,8 @@ class StatisticsController < ApplicationController
     # コミュニティ平均を算出（基本パフォーマンス統計テーブル用）
     has_stats_sql = "score IS NOT NULL AND kills IS NOT NULL AND deaths IS NOT NULL AND " \
                     "damage_dealt IS NOT NULL AND damage_received IS NOT NULL AND exburst_damage IS NOT NULL"
-    all_stats_mps = MatchPlayer.joins(:match, :user).includes(:match)
-      .where(has_stats_sql).where(users: { is_guest: false }).to_a
+    all_stats_mps = community_base_scope.includes(:match)
+      .where(has_stats_sql).to_a
     if all_stats_mps.any?
       by_user = all_stats_mps.group_by(&:user_id)
 
@@ -875,8 +880,7 @@ class StatisticsController < ApplicationController
     return [] if user_st_mps.empty?
 
     # コミュニティデータ（非ゲストかつ survival_times 存在）
-    community_q = MatchPlayer.joins(:match, :user)
-      .where(users: { is_guest: false })
+    community_q = community_base_scope
       .where("survival_times IS NOT NULL AND jsonb_array_length(survival_times) > 0")
     community_q = case community_scope
     when :wins   then community_q.where("matches.winning_team = match_players.team_number")


### PR DESCRIPTION
## Summary
- 統計ページのプレイ分析タブで、イベントフィルターをかけた際にコミュニティの最小値・最大値が全件データから算出されていたバグを修正

## 原因
コミュニティ統計（EXバースト分析・OL分析・基本パフォーマンス統計・生存時間統計）の4箇所のクエリが、ユーザー側のフィルターを無視して常に全件を対象にしていた。

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| コミュニティクエリ基底 | `MatchPlayer.joins(:match, :user).where(users: { is_guest: false })` | `community_base_scope`（イベントフィルターを適用） |
| EXバースト分析 | 全件クエリ | `community_base_scope` を使用 |
| OL分析 | 全件クエリ | `community_base_scope` を使用 |
| 基本パフォーマンス統計 | 全件クエリ | `community_base_scope` を使用 |
| 生存時間統計 | 全件クエリ | `community_base_scope` を使用 |

※ イベントフィルター以外（機体・コスト・パートナー）はコミュニティ母集団を絞らない設計。

## Test plan
- [x] イベントフィルターなし → コミュニティ min/max が従来通り全件で算出されること
- [x] イベントフィルターあり → コミュニティ min/max が同じイベントの母集団で算出されること
- [x] 機体・コスト・パートナーフィルターあり → コミュニティ min/max は全件のまま（変化なし）
- [x] レンジバーの位置が実態と乖離しないこと（EXバースト・OL・パフォーマンス・生存時間の各グラフ）

Closes #226