### PR TITLE
feat: 統計ページに一般ユーザー向けユーザー切り替えタブを追加

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -10,7 +10,7 @@ class StatisticsController < ApplicationController
     # ゲストユーザー（または管理者がゲスト視点切り替え中）は個人統計タブにアクセス不可
     personal_tabs = %w[overview performance events event_progression mobile_suits opponent_suits partners opponents]
     if viewing_as_user.is_guest && personal_tabs.include?(@active_tab)
-      redirect_to statistics_path(tab: "overall"), alert: "個人統計を見るには管理者にアカウント発行を依頼してください"
+      redirect_to statistics_path(tab: "overall"), alert: "ゲストユーザーには個人統計データがありません"
       return
     end
 

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,5 +1,6 @@
 class StatisticsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_regular_users
   before_action :set_filters
   before_action :apply_filters
 
@@ -52,6 +53,20 @@ class StatisticsController < ApplicationController
   end
 
   private
+
+  def set_regular_users
+    @regular_users = User.regular_users.order(:nickname)
+  end
+
+  def viewing_as_user
+    return super if current_user&.is_admin
+
+    if params[:view_user_id].present?
+      User.regular_users.find_by(id: params[:view_user_id]) || current_user
+    else
+      current_user
+    end
+  end
 
   def set_filters
     @filter_events = params[:events].present? ? params[:events].map(&:to_i) : []

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -5,6 +5,25 @@
     <p class="mt-2 text-sm text-gray-600">詳細な戦績データを確認できます</p>
   </div>
 
+  <!-- User Switcher (一般ユーザー向け: 管理者はview-as機能を使用) -->
+  <% unless current_user.is_admin %>
+    <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4">
+      <div class="flex items-start gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">ユーザー</span>
+        <div class="flex flex-wrap gap-2">
+          <%= link_to statistics_path(tab: @active_tab),
+              class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{viewing_as_user.id == current_user.id ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" do %>
+            <%= current_user.nickname %>（自分）
+          <% end %>
+          <% @regular_users.reject { |u| u.id == current_user.id }.each do |user| %>
+            <%= link_to user.nickname, statistics_path(view_user_id: user.id, tab: @active_tab),
+                class: "px-3 py-1.5 text-sm font-medium rounded-md transition-colors #{viewing_as_user.id == user.id ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <!-- Tab Navigation - Mobile Dropdown -->
   <div class="mobile-only-view mb-6">
     <label for="mobile-tab-select" class="block text-sm font-medium text-gray-700 mb-2">表示する統計を選択</label>
@@ -84,35 +103,35 @@
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">パートナー別戦績</span>
         <span class="whitespace-nowrap py-4 px-1 border-b-2 border-transparent text-gray-300 font-medium text-sm ml-4 cursor-not-allowed" title="個人統計を見るには管理者にアカウント発行を依頼してください">対戦相手別戦績</span>
       <% else %>
-        <%= link_to statistics_path(tab: 'overview', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
+        <%= link_to statistics_path(tab: 'overview', view_user_id: params[:view_user_id], events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'overview' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm" do %>
           総合戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'performance', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
+        <%= link_to statistics_path(tab: 'performance', view_user_id: params[:view_user_id], events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'performance' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           プレイ分析
         <% end %>
-        <%= link_to statistics_path(tab: 'events', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
+        <%= link_to statistics_path(tab: 'events', view_user_id: params[:view_user_id], events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'events' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           イベント別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'event_progression', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
+        <%= link_to statistics_path(tab: 'event_progression', view_user_id: params[:view_user_id], events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'event_progression' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           イベント内期間別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'mobile_suits', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
+        <%= link_to statistics_path(tab: 'mobile_suits', view_user_id: params[:view_user_id], events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'mobile_suits' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           使用機体別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'opponent_suits', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
+        <%= link_to statistics_path(tab: 'opponent_suits', view_user_id: params[:view_user_id], events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'opponent_suits' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           対戦機体別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'partners', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
+        <%= link_to statistics_path(tab: 'partners', view_user_id: params[:view_user_id], events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'partners' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           パートナー別戦績
         <% end %>
-        <%= link_to statistics_path(tab: 'opponents', events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
+        <%= link_to statistics_path(tab: 'opponents', view_user_id: params[:view_user_id], events: params[:events], mobile_suits: params[:mobile_suits], partners: params[:partners], costs: params[:costs]),
             class: "#{@active_tab == 'opponents' ? 'border-blue-500 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'} whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm ml-4" do %>
           対戦相手別戦績
         <% end %>


### PR DESCRIPTION
## Summary
- 統計ページのタブナビゲーション上部にユーザー切り替えUIを追加（フィルターカードと同デザイン）
- `StatisticsController` で `viewing_as_user` をオーバーライドし、`?view_user_id=X` URLパラメータで対象ユーザーを解決
- 閲覧対象は `regular_users` スコープ（`is_admin: false, is_guest: false`）に限定
- 管理者は既存のview-as機能を使用するためUIを非表示
- デスクトップタブリンク8箇所に `view_user_id` を引き継ぎ（タブ切り替え時もユーザー選択を保持）
- モバイルのJSナビゲーション（`window.location.href` ベース）は変更不要

## Test plan
- [x] 一般ユーザーでログインし、統計ページにユーザー切り替えタブが表示されることを確認
- [x] 他ユーザーをクリックすると URL に `?view_user_id=X` が付き、そのユーザーの統計が表示されることを確認
- [x] タブ（総合戦績・プレイ分析など）を切り替えても `view_user_id` が保持されることを確認
- [x] 管理者でログインし、ユーザー切り替えタブが表示されないことを確認
- [x] `view_user_id` に存在しないID・管理者ID・ゲストIDを指定すると自分の統計が表示されることを確認

Closes #228