### PR TITLE
feat: 統計ページのパートナー戦績タブでパートナー行クリック時に対戦履歴へフィルター付き遷移

### DIFF
--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -503,7 +503,7 @@
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
               <% @partners_list.each do |partner| %>
-                <tr class="hover:bg-gray-50">
+                <tr class="hover:bg-gray-50 cursor-pointer" onclick="location.href='<%= matches_path(users: [viewing_as_user.id, partner[:user].id], users_mode: 'and') %>'">
                   <td class="px-6 py-4 whitespace-nowrap">
                     <div class="text-sm font-medium text-gray-900">
                       <%= partner[:user].nickname %>


### PR DESCRIPTION
## Summary
- 統計ページのパートナー戦績タブの各パートナー行をクリック可能にした
- クリックすると対戦履歴画面に遷移し、表示中のプレイヤーと該当パートナーの両方が参加した試合が AND フィルターされた状態で表示される
- `viewing_as_user` を基準にしているため、管理者の視点切り替え・一般ユーザーのユーザー切り替え（#228）の両方に対応

## Test plan
- [ ] 統計ページのパートナー戦績タブでパートナー行にカーソルを当て、ポインターカーソルになることを確認
- [ ] パートナー行をクリックすると対戦履歴画面に遷移することを確認
- [ ] 遷移後、URL に `users[]=<自分のID>&users[]=<パートナーID>&users_mode=and` が含まれていることを確認
- [ ] 遷移後の対戦履歴が、その2人が共に参加した試合のみ表示されていることを確認
- [ ] 管理者が視点切り替え中に遷移した場合、切り替え先ユーザーのIDが `users[]` に含まれていることを確認
- [ ] 一般ユーザーがユーザー切り替えタブで別ユーザーを選択した状態でクリックした場合も同様に確認

Closes #230