### PR TITLE
feat: イベント内期間別戦績のローテーション行クリックで詳細画面に遷移する

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -521,6 +521,7 @@ class StatisticsController < ApplicationController
         # ローテーションがある場合：ローテーション別に表示
         rotations_stats = data[:rotations].map do |rotation_id, rotation_data|
           {
+            rotation_id: rotation_id,
             rotation_name: rotation_data[:rotation_name],
             wins: rotation_data[:wins],
             total: rotation_data[:total],

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -847,8 +847,10 @@
                   </thead>
                   <tbody class="bg-white divide-y divide-gray-200">
                     <% event_prog[:rotations].each do |rotation| %>
-                      <tr class="hover:bg-gray-50">
-                        <td class="px-4 py-3 text-sm font-medium text-gray-900"><%= rotation[:rotation_name] %></td>
+                      <tr class="hover:bg-gray-50<%= rotation[:rotation_id] ? ' cursor-pointer' : '' %>"
+                          <% if rotation[:rotation_id] %>data-href="<%= rotation_path(rotation[:rotation_id]) %>"
+                          onclick="window.location.href=this.dataset.href"<% end %>>
+                        <td class="px-4 py-3 text-sm font-medium text-gray-900<%= rotation[:rotation_id] ? ' text-purple-700 hover:underline' : '' %>"><%= rotation[:rotation_name] %></td>
                         <td class="px-4 py-3 text-sm text-gray-500"><%= rotation[:total] %></td>
                         <td class="px-4 py-3 text-sm text-green-600 font-semibold"><%= rotation[:wins] %></td>
                         <td class="px-4 py-3 text-sm text-red-600 font-semibold"><%= rotation[:losses] %></td>


### PR DESCRIPTION
## Summary
- `statistics_controller.rb`: `calculate_event_progression_stats` のローテーション集計ハッシュに `rotation_id` を追加
- `statistics/index.html.erb`: 期間別戦績テーブルのローテーション行をクリッカブルにし、対応するローテーション詳細画面（`/rotations/:id`）に遷移するよう変更
  - ローテーションなしのターム行（第1ターム〜第4ターム）はクリック不可のまま
  - ローテーション行は周回名を紫色＋アンダーライン表示、行全体にポインターカーソルを設定

## Test plan
- [x] ローテーションありのイベントの期間別戦績で、周回行をクリックするとローテーション詳細画面に遷移することを確認
- [x] ローテーションなしのイベントのターム行はクリックしても何も起こらないことを確認
- [x] ログイン済みの一般ユーザーでも遷移できることを確認

Closes #236