### PR TITLE
feat: イベント内期間別戦績にターム別/ローテーション別の切り替え表示を追加

### DIFF
--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -517,9 +517,9 @@ class StatisticsController < ApplicationController
     end
 
     @event_progression_list = event_progression_data.map do |event_id, data|
-      if data[:has_rotation]
-        # ローテーションがある場合：ローテーション別に表示
-        rotations_stats = data[:rotations].map do |rotation_id, rotation_data|
+      # ローテーション別データ（ローテーションがある場合のみ）
+      rotation_stats = if data[:has_rotation]
+        data[:rotations].map do |rotation_id, rotation_data|
           {
             rotation_id: rotation_id,
             rotation_name: rotation_data[:rotation_name],
@@ -530,48 +530,45 @@ class StatisticsController < ApplicationController
           }
         end
       else
-        # ローテーションがない場合：試合を時系列順に4等分（ターム表示）
-        sorted_matches = data[:all_matches].sort_by { |mp| mp.match.played_at }
-        total_matches = sorted_matches.size
-
-        if total_matches > 0
-          # 4等分（第1ターム、第2ターム、第3ターム、第4ターム）
-          quarter_size = (total_matches / 4.0).ceil
-          quarters = [
-            { name: "第1ターム", matches: sorted_matches[0...quarter_size] },
-            { name: "第2ターム", matches: sorted_matches[quarter_size...(quarter_size * 2)] },
-            { name: "第3ターム", matches: sorted_matches[(quarter_size * 2)...(quarter_size * 3)] },
-            { name: "第4ターム", matches: sorted_matches[(quarter_size * 3)..-1] }
-          ]
-
-          rotations_stats = quarters.map do |quarter|
-            next if quarter[:matches].nil? || quarter[:matches].empty?
-
-            wins = quarter[:matches].count { |mp| mp.match.winning_team == mp.team_number }
-            total = quarter[:matches].size
-
-            {
-              rotation_name: quarter[:name],
-              wins: wins,
-              total: total,
-              losses: total - wins,
-              win_rate: total > 0 ? (wins.to_f / total * 100).round(1) : 0
-            }
-          end.compact
-        else
-          rotations_stats = []
-        end
+        []
       end
+
+      # ターム別データ（8等分）：ローテーションの有無に関わらず常に計算
+      sorted_matches = data[:all_matches].sort_by { |mp| mp.match.played_at }
+      term_stats = if sorted_matches.any?
+        n = sorted_matches.size
+        (1..8).map do |i|
+          start_idx = ((i - 1) * n / 8.0).round
+          end_idx   = (i * n / 8.0).round
+          slice = sorted_matches[start_idx...end_idx]
+          next if slice.nil? || slice.empty?
+
+          wins = slice.count { |mp| mp.match.winning_team == mp.team_number }
+          total = slice.size
+          {
+            rotation_name: "第#{i}ターム",
+            wins: wins,
+            total: total,
+            losses: total - wins,
+            win_rate: (wins.to_f / total * 100).round(1)
+          }
+        end.compact
+      else
+        []
+      end
+
+      all_total = data[:all_matches].size
+      all_wins  = data[:all_matches].count { |mp| mp.match.winning_team == mp.team_number }
 
       {
         event: data[:event],
         has_rotation: data[:has_rotation],
-        rotations: rotations_stats,
-        total_matches: rotations_stats.sum { |r| r[:total] },
-        overall_win_rate: rotations_stats.sum { |r| r[:total] } > 0 ?
-          (rotations_stats.sum { |r| r[:wins] }.to_f / rotations_stats.sum { |r| r[:total] } * 100).round(1) : 0
+        rotation_stats: rotation_stats,
+        term_stats: term_stats,
+        total_matches: all_total,
+        overall_win_rate: all_total > 0 ? (all_wins.to_f / all_total * 100).round(1) : 0
       }
-    end.select { |e| e[:rotations].any? }.sort_by { |e| e[:event].held_on }.reverse
+    end.select { |e| e[:term_stats].any? || e[:rotation_stats].any? }.sort_by { |e| e[:event].held_on }.reverse
   end
 
   def calculate_performance_stats

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -807,66 +807,139 @@
     <div class="space-y-6">
       <div class="bg-white rounded-lg shadow p-6">
         <h3 class="text-lg font-semibold text-gray-900 mb-2">イベント内期間別戦績</h3>
-        <p class="text-sm text-gray-500 mb-6">各イベント内でのローテーション別の勝率推移を確認できます。ローテーションが定義されていないイベントでは、試合を時系列順に4分割したターム別で集計します。</p>
+        <p class="text-sm text-gray-500 mb-6">各イベント内での勝率推移を確認できます。ターム別（試合を時系列順に8分割）とローテーション別（ローテーション定義がある場合）を切り替えて表示できます。</p>
 
         <% if @event_progression_list.any? %>
           <% @event_progression_list.each do |event_prog| %>
+            <% event_id = event_prog[:event].id %>
             <div class="mb-8 last:mb-0 bg-white border border-gray-200 rounded-lg shadow-sm">
               <!-- イベントヘッダー -->
               <div class="px-6 py-4 border-b border-gray-200">
-                <div class="flex items-center justify-between">
+                <div class="flex items-start justify-between gap-4">
                   <div>
                     <h4 class="text-xl font-bold text-gray-900"><%= event_prog[:event].name %></h4>
                     <p class="text-gray-500 text-sm mt-1"><%= event_prog[:event].held_on.strftime('%Y年%m月%d日') %></p>
                   </div>
-                  <div class="text-right">
-                    <div class="text-gray-500 text-sm">総試合数: <%= event_prog[:total_matches] %></div>
-                    <div class="text-2xl font-bold text-purple-600">勝率 <%= event_prog[:overall_win_rate] %>%</div>
+                  <div class="flex flex-col items-end gap-2">
+                    <div class="text-right">
+                      <div class="text-gray-500 text-sm">総試合数: <%= event_prog[:total_matches] %></div>
+                      <div class="text-2xl font-bold text-purple-600">勝率 <%= event_prog[:overall_win_rate] %>%</div>
+                    </div>
+                    <!-- 切り替えボタン -->
+                    <div class="flex items-center gap-1 bg-gray-100 rounded-lg p-1">
+                      <button type="button"
+                              id="btn-term-<%= event_id %>"
+                              onclick="setEventProgressionMode(<%= event_id %>, 'term')"
+                              class="px-3 py-1 rounded-md text-sm font-semibold transition-colors">
+                        ターム別
+                      </button>
+                      <button type="button"
+                              id="btn-rotation-<%= event_id %>"
+                              onclick="setEventProgressionMode(<%= event_id %>, 'rotation')"
+                              class="px-3 py-1 rounded-md text-sm font-semibold transition-colors">
+                        ローテーション別
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
 
               <!-- グラフ・テーブルコンテナ -->
               <div class="p-6">
-                <!-- グラフ -->
-                <div class="mb-4" style="position: relative; height: 250px;">
-                <canvas id="eventProgressionChart_<%= event_prog[:event].id %>"></canvas>
-              </div>
 
-              <!-- テーブル -->
-              <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200">
-                  <thead class="bg-gray-50">
-                    <tr>
-                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"><%= event_prog[:has_rotation] ? '周回' : 'ターム' %></th>
-                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">試合数</th>
-                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">勝利</th>
-                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">敗北</th>
-                      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">勝率</th>
-                    </tr>
-                  </thead>
-                  <tbody class="bg-white divide-y divide-gray-200">
-                    <% event_prog[:rotations].each do |rotation| %>
-                      <tr class="hover:bg-gray-50<%= rotation[:rotation_id] ? ' cursor-pointer' : '' %>"
-                          <% if rotation[:rotation_id] %>data-href="<%= rotation_path(rotation[:rotation_id]) %>"
-                          onclick="window.location.href=this.dataset.href"<% end %>>
-                        <td class="px-4 py-3 text-sm font-medium text-gray-900<%= rotation[:rotation_id] ? ' text-purple-700 hover:underline' : '' %>"><%= rotation[:rotation_name] %></td>
-                        <td class="px-4 py-3 text-sm text-gray-500"><%= rotation[:total] %></td>
-                        <td class="px-4 py-3 text-sm text-green-600 font-semibold"><%= rotation[:wins] %></td>
-                        <td class="px-4 py-3 text-sm text-red-600 font-semibold"><%= rotation[:losses] %></td>
-                        <td class="px-4 py-3">
-                          <div class="flex items-center">
-                            <span class="text-sm font-semibold text-purple-600"><%= rotation[:win_rate] %>%</span>
-                            <div class="ml-2 sm:ml-3 w-12 sm:w-20 md:w-24 bg-gray-200 rounded-full h-2">
-                              <div class="bg-purple-600 h-2 rounded-full" style="width: <%= rotation[:win_rate].to_f %>%"></div>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
+                <!-- ターム別コンテナ -->
+                <div id="container-term-<%= event_id %>">
+                  <!-- ターム別グラフ -->
+                  <div class="mb-4" style="position: relative; height: 250px;">
+                    <canvas id="eventProgressionChart_term_<%= event_id %>"></canvas>
+                  </div>
+                  <!-- ターム別テーブル -->
+                  <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                      <thead class="bg-gray-50">
+                        <tr>
+                          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ターム</th>
+                          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">試合数</th>
+                          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">勝利</th>
+                          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">敗北</th>
+                          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">勝率</th>
+                        </tr>
+                      </thead>
+                      <tbody class="bg-white divide-y divide-gray-200">
+                        <% event_prog[:term_stats].each do |stat| %>
+                          <tr class="hover:bg-gray-50">
+                            <td class="px-4 py-3 text-sm font-medium text-gray-900"><%= stat[:rotation_name] %></td>
+                            <td class="px-4 py-3 text-sm text-gray-500"><%= stat[:total] %></td>
+                            <td class="px-4 py-3 text-sm text-green-600 font-semibold"><%= stat[:wins] %></td>
+                            <td class="px-4 py-3 text-sm text-red-600 font-semibold"><%= stat[:losses] %></td>
+                            <td class="px-4 py-3">
+                              <div class="flex items-center">
+                                <span class="text-sm font-semibold text-purple-600"><%= stat[:win_rate] %>%</span>
+                                <div class="ml-2 sm:ml-3 w-12 sm:w-20 md:w-24 bg-gray-200 rounded-full h-2">
+                                  <div class="bg-purple-600 h-2 rounded-full" style="width: <%= stat[:win_rate].to_f %>%"></div>
+                                </div>
+                              </div>
+                            </td>
+                          </tr>
+                        <% end %>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+
+                <!-- 周回別コンテナ -->
+                <div id="container-rotation-<%= event_id %>" class="hidden">
+                  <% if event_prog[:has_rotation] %>
+                    <!-- 周回別グラフ -->
+                    <div class="mb-4" style="position: relative; height: 250px;">
+                      <canvas id="eventProgressionChart_rotation_<%= event_id %>"></canvas>
+                    </div>
+                    <!-- 周回別テーブル -->
+                    <div class="overflow-x-auto">
+                      <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                          <tr>
+                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">周回</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">試合数</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">勝利</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">敗北</th>
+                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">勝率</th>
+                          </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                          <% event_prog[:rotation_stats].each do |rotation| %>
+                            <tr class="hover:bg-gray-50 cursor-pointer"
+                                data-href="<%= rotation_path(rotation[:rotation_id]) %>"
+                                onclick="window.location.href=this.dataset.href">
+                              <td class="px-4 py-3 text-sm font-medium text-purple-700 hover:underline"><%= rotation[:rotation_name] %></td>
+                              <td class="px-4 py-3 text-sm text-gray-500"><%= rotation[:total] %></td>
+                              <td class="px-4 py-3 text-sm text-green-600 font-semibold"><%= rotation[:wins] %></td>
+                              <td class="px-4 py-3 text-sm text-red-600 font-semibold"><%= rotation[:losses] %></td>
+                              <td class="px-4 py-3">
+                                <div class="flex items-center">
+                                  <span class="text-sm font-semibold text-purple-600"><%= rotation[:win_rate] %>%</span>
+                                  <div class="ml-2 sm:ml-3 w-12 sm:w-20 md:w-24 bg-gray-200 rounded-full h-2">
+                                    <div class="bg-purple-600 h-2 rounded-full" style="width: <%= rotation[:win_rate].to_f %>%"></div>
+                                  </div>
+                                </div>
+                              </td>
+                            </tr>
+                          <% end %>
+                        </tbody>
+                      </table>
+                    </div>
+                  <% else %>
+                    <!-- ローテーション未定義の場合 -->
+                    <div class="py-10 text-center">
+                      <svg class="mx-auto h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                      </svg>
+                      <p class="mt-3 text-sm text-gray-500">このイベントにはローテーションがありません</p>
+                      <p class="mt-1 text-xs text-gray-400">ターム別での集計をご確認ください</p>
+                    </div>
+                  <% end %>
+                </div>
+
               </div>
             </div>
           <% end %>
@@ -875,7 +948,7 @@
             <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
             </svg>
-            <p class="mt-2 text-sm text-gray-500">ローテーションデータがありません</p>
+            <p class="mt-2 text-sm text-gray-500">データがありません</p>
             <p class="mt-1 text-xs text-gray-400">ローテーション表から試合を記録すると、イベント内の推移が表示されます</p>
           </div>
         <% end %>
@@ -884,83 +957,112 @@
 
     <!-- Chart.js Script for Event Progression -->
     <script>
+      function setEventProgressionMode(eventId, mode) {
+        var ACTIVE   = 'px-3 py-1 rounded-md text-sm font-semibold transition-colors bg-white text-gray-800 shadow-sm';
+        var INACTIVE = 'px-3 py-1 rounded-md text-sm font-semibold transition-colors text-gray-500 hover:text-gray-700';
+
+        document.getElementById('btn-term-' + eventId).className     = (mode === 'term')     ? ACTIVE : INACTIVE;
+        document.getElementById('btn-rotation-' + eventId).className = (mode === 'rotation') ? ACTIVE : INACTIVE;
+
+        document.getElementById('container-term-' + eventId).classList.toggle('hidden', mode !== 'term');
+        document.getElementById('container-rotation-' + eventId).classList.toggle('hidden', mode !== 'rotation');
+      }
+
       window.initEventProgressionCharts = function() {
-        // Ensure Chart.js is loaded
         if (typeof Chart === 'undefined') {
           console.error('Chart.js is not loaded');
           return;
         }
 
-        <% @event_progression_list.each do |event_prog| %>
-          const ctx_<%= event_prog[:event].id %> = document.getElementById('eventProgressionChart_<%= event_prog[:event].id %>');
-          if (ctx_<%= event_prog[:event].id %>) {
-            // Destroy existing chart if any
-            if (ctx_<%= event_prog[:event].id %>.chart) {
-              ctx_<%= event_prog[:event].id %>.chart.destroy();
+        var chartOptions = {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: { offset: true },
+            y: {
+              beginAtZero: true,
+              max: 100,
+              ticks: {
+                callback: function(value) { return value + '%'; }
+              }
             }
-
-            ctx_<%= event_prog[:event].id %>.chart = new Chart(ctx_<%= event_prog[:event].id %>, {
-              type: 'line',
-              data: {
-                labels: <%= raw event_prog[:rotations].map { |r| r[:rotation_name] }.to_json %>,
-                datasets: [{
-                  label: '勝率 (%)',
-                  data: <%= raw event_prog[:rotations].map { |r| r[:win_rate] }.to_json %>,
-                  borderColor: 'rgb(147, 51, 234)',
-                  backgroundColor: 'rgba(147, 51, 234, 0.1)',
-                  tension: 0.4,
-                  pointBackgroundColor: 'rgb(147, 51, 234)',
-                  pointRadius: 5
-                }]
-              },
-              options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                scales: {
-                  x: {
-                    offset: true
-                  },
-                  y: {
-                    beginAtZero: true,
-                    max: 100,
-                    ticks: {
-                      callback: function(value) {
-                        return value + '%';
-                      }
-                    }
-                  }
-                },
-                plugins: {
-                  legend: {
-                    display: false
-                  },
-                  tooltip: {
-                    callbacks: {
-                      label: function(context) {
-                        return context.dataset.label + ': ' + context.parsed.y + '%';
-                      }
-                    }
-                  },
-                  datalabels: {
-                    color: 'rgb(147, 51, 234)',
-                    anchor: function(context) {
-                      return context.dataset.data[context.dataIndex] > 70 ? 'start' : 'end';
-                    },
-                    align: function(context) {
-                      return context.dataset.data[context.dataIndex] > 70 ? 'bottom' : 'top';
-                    },
-                    font: {
-                      weight: 'bold',
-                      size: 14
-                    },
-                    formatter: function(value) {
-                      return value + '%';
-                    }
-                  }
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: function(context) {
+                  return context.dataset.label + ': ' + context.parsed.y + '%';
                 }
               }
-            });
+            },
+            datalabels: {
+              color: 'rgb(147, 51, 234)',
+              anchor: function(context) {
+                return context.dataset.data[context.dataIndex] > 70 ? 'start' : 'end';
+              },
+              align: function(context) {
+                return context.dataset.data[context.dataIndex] > 70 ? 'bottom' : 'top';
+              },
+              font: { weight: 'bold', size: 14 },
+              formatter: function(value) { return value + '%'; }
+            }
           }
+        };
+
+        function buildDataset(labels, data) {
+          return {
+            labels: labels,
+            datasets: [{
+              label: '勝率 (%)',
+              data: data,
+              borderColor: 'rgb(147, 51, 234)',
+              backgroundColor: 'rgba(147, 51, 234, 0.1)',
+              tension: 0.4,
+              pointBackgroundColor: 'rgb(147, 51, 234)',
+              pointRadius: 5
+            }]
+          };
+        }
+
+        <% @event_progression_list.each do |event_prog| %>
+          <% eid = event_prog[:event].id %>
+
+          // ターム別グラフ
+          (function() {
+            var canvas = document.getElementById('eventProgressionChart_term_<%= eid %>');
+            if (!canvas) return;
+            if (canvas.chart) canvas.chart.destroy();
+            canvas.chart = new Chart(canvas, {
+              type: 'line',
+              data: buildDataset(
+                <%= raw event_prog[:term_stats].map { |r| r[:rotation_name] }.to_json %>,
+                <%= raw event_prog[:term_stats].map { |r| r[:win_rate] }.to_json %>
+              ),
+              options: chartOptions
+            });
+          })();
+
+          <% if event_prog[:has_rotation] %>
+          // 周回別グラフ
+          (function() {
+            var canvas = document.getElementById('eventProgressionChart_rotation_<%= eid %>');
+            if (!canvas) return;
+            if (canvas.chart) canvas.chart.destroy();
+            canvas.chart = new Chart(canvas, {
+              type: 'line',
+              data: buildDataset(
+                <%= raw event_prog[:rotation_stats].map { |r| r[:rotation_name] }.to_json %>,
+                <%= raw event_prog[:rotation_stats].map { |r| r[:win_rate] }.to_json %>
+              ),
+              options: chartOptions
+            });
+          })();
+          <% end %>
+
+          // デフォルト表示モードを適用
+          setEventProgressionMode(<%= eid %>, '<%= event_prog[:has_rotation] ? 'rotation' : 'term' %>');
+
         <% end %>
       };
     </script>


### PR DESCRIPTION
## Summary
- イベント内期間別戦績に「ターム別」「ローテーション別」切り替えボタンを追加
- ターム別は試合を時系列順に8等分（均等分割）し、常にローテーションの有無に関わらず計算
- ローテーション定義があるイベントはデフォルト「ローテーション別」、ないイベントはデフォルト「ターム別」で表示
- ローテーション未定義のイベントで「ローテーション別」を選ぶとプレースホルダーを表示
- ターム分割の均等化: 従来の `ceil` 方式（最後のタームに余りが集中）から `(i * n / 8.0).round` 境界計算に変更

## Test plan
- [x] ローテーションが定義されているイベントでデフォルト「ローテーション別」が表示されること
- [x] 「ターム別」ボタンでターム別グラフ・テーブルに切り替わること
- [x] 8ターム全体で試合数がほぼ均等に分散されること（最後のタームだけ極端に少なくならないこと）
- [x] ローテーションがないイベントでデフォルト「ターム別」が表示されること
- [x] ローテーションがないイベントで「ローテーション別」を選ぶとプレースホルダーが表示されること
- [x] 総試合数・全体勝率がヘッダーに正しく表示されること

Closes #239