### PR TITLE
feat: EXバースト発動回数の機体別内訳表示を追加

### DIFF
--- a/app/controllers/concerns/match_stats_importable.rb
+++ b/app/controllers/concerns/match_stats_importable.rb
@@ -127,6 +127,17 @@ module MatchStatsImportable
       # exburst_count: バースト発動イベントの数
       exburst_count = burst_events.size
 
+      # first_unit_exburst_count: 1機体目（最初の被撃墜前）のバースト発動数
+      # ※ death_times はこの後に計算するため、ここでは player_events から直接導出する
+      first_death_cs_for_burst = player_events.select { |e| e["is_point"] }
+                                              .map { |e| e["start_cs"] }
+                                              .compact.min
+      first_unit_exburst_count = if first_death_cs_for_burst
+        burst_events.count { |b| (b["start_cs"] || 0) < first_death_cs_for_burst }
+      else
+        burst_events.size
+      end
+
       # exburst_deaths: 被撃墜時刻がバースト区間内に含まれる数
       exburst_deaths = player_events.select { |e| e["is_point"] }.count do |death|
         cs = death["start_cs"]
@@ -178,6 +189,7 @@ module MatchStatsImportable
 
       mp.update!(
         exburst_count:             exburst_count,
+        first_unit_exburst_count:  first_unit_exburst_count,
         exburst_deaths:            exburst_deaths,
         last_death_ex_available:   last_death_ex_available,
         survive_loss_ex_available: survive_loss_ex_available,

--- a/app/controllers/match_stats_controller.rb
+++ b/app/controllers/match_stats_controller.rb
@@ -31,7 +31,7 @@ class MatchStatsController < ApplicationController
     ActiveRecord::Base.transaction do
       # プレイヤー統計をリセット
       stat_columns = %i[match_rank score kills deaths damage_dealt damage_received
-                        exburst_damage exburst_count exburst_deaths
+                        exburst_damage exburst_count first_unit_exburst_count exburst_deaths
                         last_death_ex_available survive_loss_ex_available ex_overlimit_activated]
       @match.match_players.update_all(stat_columns.index_with(nil))
 

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -788,7 +788,7 @@ class StatisticsController < ApplicationController
           exburst_damage:            (sf.call(:exburst_damage)            / m).round(0),
           exburst_count:             (sf.call(:exburst_count)             / m).round(2),
           first_unit_exburst_count:  (sf.call(:first_unit_exburst_count)  / m).round(2),
-          later_unit_exburst_count:  [(sf.call(:exburst_count) - sf.call(:first_unit_exburst_count)) / m, 0].max.round(2),
+          later_unit_exburst_count:  [ (sf.call(:exburst_count) - sf.call(:first_unit_exburst_count)) / m, 0 ].max.round(2),
           exburst_deaths:            (sf.call(:exburst_deaths)            / m).round(2),
           exburst_death_rate: total_ex > 0 ? (total_ex_d * 100.0 / total_ex).round(1) : nil,
           ol_rate:            (ol_count * 100.0 / m).round(1)
@@ -878,7 +878,7 @@ class StatisticsController < ApplicationController
       later_unit_exburst_count: begin
                                   ec = avg_field.call(:exburst_count)
                                   fec = avg_field.call(:first_unit_exburst_count)
-                                  (ec && fec) ? [(ec - fec).round(2), 0].max : nil
+                                  (ec && fec) ? [ (ec - fec).round(2), 0 ].max : nil
                                 end,
       exburst_deaths:           avg_field.call(:exburst_deaths)&.round(2),
       exburst_death_rate: begin

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -785,9 +785,11 @@ class StatisticsController < ApplicationController
           deaths:             (sf.call(:deaths)          / m).round(2),
           damage_dealt:       (sf.call(:damage_dealt)    / m).round(0),
           damage_received:    (sf.call(:damage_received) / m).round(0),
-          exburst_damage:     (sf.call(:exburst_damage)  / m).round(0),
-          exburst_count:      (sf.call(:exburst_count)   / m).round(2),
-          exburst_deaths:     (sf.call(:exburst_deaths)  / m).round(2),
+          exburst_damage:            (sf.call(:exburst_damage)            / m).round(0),
+          exburst_count:             (sf.call(:exburst_count)             / m).round(2),
+          first_unit_exburst_count:  (sf.call(:first_unit_exburst_count)  / m).round(2),
+          later_unit_exburst_count:  [(sf.call(:exburst_count) - sf.call(:first_unit_exburst_count)) / m, 0].max.round(2),
+          exburst_deaths:            (sf.call(:exburst_deaths)            / m).round(2),
           exburst_death_rate: total_ex > 0 ? (total_ex_d * 100.0 / total_ex).round(1) : nil,
           ol_rate:            (ol_count * 100.0 / m).round(1)
         }
@@ -803,13 +805,15 @@ class StatisticsController < ApplicationController
           deaths:             (list.sum { |u| u[:deaths] }          / n).round(2),
           damage_dealt:       (list.sum { |u| u[:damage_dealt] }    / n).round(0),
           damage_received:    (list.sum { |u| u[:damage_received] } / n).round(0),
-          exburst_damage:     (list.sum { |u| u[:exburst_damage] }  / n).round(0),
-          exburst_count:      (list.sum { |u| u[:exburst_count] }   / n).round(2),
-          exburst_deaths:     (list.sum { |u| u[:exburst_deaths] }  / n).round(2),
+          exburst_damage:            (list.sum { |u| u[:exburst_damage] }           / n).round(0),
+          exburst_count:             (list.sum { |u| u[:exburst_count] }            / n).round(2),
+          first_unit_exburst_count:  (list.sum { |u| u[:first_unit_exburst_count] } / n).round(2),
+          later_unit_exburst_count:  (list.sum { |u| u[:later_unit_exburst_count] } / n).round(2),
+          exburst_deaths:            (list.sum { |u| u[:exburst_deaths] }           / n).round(2),
           exburst_death_rate: valid_dr.any? ? (valid_dr.sum / valid_dr.size).round(1) : nil,
           ol_rate:            (list.sum { |u| u[:ol_rate] }         / n).round(1)
         }
-        stat_keys = %i[score kills deaths damage_dealt damage_received exburst_damage exburst_count exburst_deaths ol_rate]
+        stat_keys = %i[score kills deaths damage_dealt damage_received exburst_damage exburst_count first_unit_exburst_count later_unit_exburst_count exburst_deaths ol_rate]
         min_h = stat_keys.to_h { |k| [ k, list.map { |u| u[k] }.compact.min ] }
         max_h = stat_keys.to_h { |k| [ k, list.map { |u| u[k] }.compact.max ] }
         if valid_dr.any?
@@ -868,9 +872,15 @@ class StatisticsController < ApplicationController
       deaths:          avg_field.call(:deaths)&.round(2),
       damage_dealt:    avg_field.call(:damage_dealt)&.round(0),
       damage_received: avg_field.call(:damage_received)&.round(0),
-      exburst_damage:  avg_field.call(:exburst_damage)&.round(0),
-      exburst_count:   avg_field.call(:exburst_count)&.round(2),
-      exburst_deaths:  avg_field.call(:exburst_deaths)&.round(2),
+      exburst_damage:           avg_field.call(:exburst_damage)&.round(0),
+      exburst_count:            avg_field.call(:exburst_count)&.round(2),
+      first_unit_exburst_count: avg_field.call(:first_unit_exburst_count)&.round(2),
+      later_unit_exburst_count: begin
+                                  ec = avg_field.call(:exburst_count)
+                                  fec = avg_field.call(:first_unit_exburst_count)
+                                  (ec && fec) ? [(ec - fec).round(2), 0].max : nil
+                                end,
+      exburst_deaths:           avg_field.call(:exburst_deaths)&.round(2),
       exburst_death_rate: begin
                             total_count  = mps.sum { |mp| mp.exburst_count.to_i }
                             total_deaths = mps.sum { |mp| mp.exburst_deaths.to_i }

--- a/app/views/match_stats/_player_stats_fields.html.erb
+++ b/app/views/match_stats/_player_stats_fields.html.erb
@@ -41,6 +41,11 @@
     </div>
 
     <div>
+      <label class="block text-xs font-medium text-gray-600 mb-1">1機体目 EXバースト使用回数 ※</label>
+      <%= number_field_tag "#{pfx}[first_unit_exburst_count]", player.first_unit_exburst_count, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
       <label class="block text-xs font-medium text-gray-600 mb-1">バースト中被撃墜 ※</label>
       <%= number_field_tag "#{pfx}[exburst_deaths]", player.exburst_deaths, min: 0, class: "w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
     </div>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -2071,8 +2071,10 @@
                     {
                       label: "EXバースト",
                       rows: [
-                        { label: "EXバースト発動回数",   key: :exburst_count,      suffix: "",  higher_is_better: true },
-                        { label: "EXバースト中被撃墜数", key: :exburst_deaths,     suffix: "",  higher_is_better: false },
+                        { label: "EXバースト発動回数（合計）", key: :exburst_count,             suffix: "",  higher_is_better: true },
+                        { label: "1機体目",                    key: :first_unit_exburst_count,  suffix: "",  higher_is_better: true, sub: true },
+                        { label: "2機体目以降",                key: :later_unit_exburst_count,  suffix: "",  higher_is_better: true, sub: true },
+                        { label: "EXバースト中被撃墜数",       key: :exburst_deaths,            suffix: "",  higher_is_better: false },
                         { label: "EXバースト中被撃墜率", key: :exburst_death_rate, suffix: "%", higher_is_better: false, na_if_nil: true },
                       ]
                     },
@@ -2109,8 +2111,17 @@
                     </td>
                   </tr>
                   <% group[:rows].each do |row| %>
-                    <tr class="hover:bg-gray-50">
-                      <td class="px-6 py-4 text-sm text-gray-700 pl-8"><%= row[:label] %></td>
+                    <tr class="hover:bg-gray-50 <%= 'bg-gray-50/50' if row[:sub] %>">
+                      <td class="px-6 py-4 text-sm <%= row[:sub] ? 'text-gray-500 pl-12' : 'text-gray-700 pl-8' %>">
+                        <% if row[:sub] %>
+                          <span class="inline-flex items-center gap-1.5">
+                            <span class="text-gray-300 text-xs">└</span>
+                            <%= row[:label] %>
+                          </span>
+                        <% else %>
+                          <%= row[:label] %>
+                        <% end %>
+                      </td>
                       <% perf_columns.each do |col| %>
                         <%# ユーザー値セル %>
                         <td class="px-6 py-4 text-center text-sm font-semibold <%= col[:color] %> <%= col[:border] %>">

--- a/db/migrate/20260330130613_add_first_unit_exburst_count_to_match_players.rb
+++ b/db/migrate/20260330130613_add_first_unit_exburst_count_to_match_players.rb
@@ -1,0 +1,5 @@
+class AddFirstUnitExburstCountToMatchPlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :match_players, :first_unit_exburst_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_15_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_30_130613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -72,6 +72,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_15_120000) do
     t.integer "exburst_count"
     t.integer "exburst_damage"
     t.integer "exburst_deaths"
+    t.integer "first_unit_exburst_count"
     t.integer "kills"
     t.boolean "last_death_ex_available"
     t.bigint "match_id", null: false

--- a/lib/tasks/matches.rake
+++ b/lib/tasks/matches.rake
@@ -1,4 +1,27 @@
 namespace :matches do
+  desc "match_timeline が存在する全試合のタイムライン導出統計（survival_times / first_unit_exburst_count 等）を再計算する"
+  task backfill_timeline_derived_stats: :environment do
+    matches = Match.joins(:match_timeline).includes(:match_timeline, match_players: :user)
+    total   = matches.count
+    puts "対象試合数: #{total}"
+
+    runner = Class.new do
+      include MatchStatsImportable
+      attr_accessor :match
+
+      def initialize(match)
+        @match = match
+      end
+    end
+
+    matches.find_each.with_index(1) do |match, i|
+      runner.new(match).send(:recalculate_timeline_derived_stats)
+      print "\r#{i}/#{total} 完了" if (i % 10).zero? || i == total
+    end
+
+    puts "\n完了"
+  end
+
   desc "match_timeline が存在する全試合の survival_times を再計算する"
   task backfill_survival_times: :environment do
     matches = Match.joins(:match_timeline).includes(:match_timeline, match_players: :user)


### PR DESCRIPTION
## Summary
- `first_unit_exburst_count` カラムを追加し、タイムラインから1機体目（最初の被撃墜前）のEXバースト発動回数を導出・保存
- プレイ分析タブのEXバーストセクションで「合計 / 1機体目 / 2機体目以降」の内訳をサブ行（└）で表示
- 「2機体目以降」は `exburst_count - first_unit_exburst_count` で算出（DBカラム追加不要）
- 既存データ用のバックフィル rake タスク `matches:backfill_timeline_derived_stats` を追加

## Test plan
- [x] `bin/rails db:migrate` でマイグレーション実行
- [x] `bin/rails matches:backfill_timeline_derived_stats` で既存データにバックフィル
- [x] 統計 > プレイ分析タブでEXバースト内訳（合計・1機体目・2機体目以降）が表示されることを確認
- [x] 試合詳細のタイムライン再インポートで `first_unit_exburst_count` が正しく計算されることを確認

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)