### PR TITLE
feat: 対戦履歴に古い順ソートを追加

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -5,10 +5,14 @@ class MatchesController < ApplicationController
   before_action :set_match, only: [ :show, :edit, :update, :destroy ]
 
   def index
-    sort = params[:sort].presence_in(%w[latest reactions]) || "latest"
+    sort = params[:sort].presence_in(%w[latest oldest reactions]) || "latest"
     @sort = sort
 
-    base_scope = sort == "reactions" ? Match.by_reactions : Match.by_latest
+    base_scope = case sort
+                 when "reactions" then Match.by_reactions
+                 when "oldest"    then Match.by_oldest
+                 else                  Match.by_latest
+                 end
     @matches = base_scope.includes(:event, { match_players: [ :user, :mobile_suit ] }, { reactions: :user })
 
     # フィルター: イベント（複数選択対応）

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -9,10 +9,10 @@ class MatchesController < ApplicationController
     @sort = sort
 
     base_scope = case sort
-                 when "reactions" then Match.by_reactions
-                 when "oldest"    then Match.by_oldest
-                 else                  Match.by_latest
-                 end
+    when "reactions" then Match.by_reactions
+    when "oldest"    then Match.by_oldest
+    else                  Match.by_latest
+    end
     @matches = base_scope.includes(:event, { match_players: [ :user, :mobile_suit ] }, { reactions: :user })
 
     # フィルター: イベント（複数選択対応）

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -309,7 +309,7 @@
         <p class="text-sm text-gray-600">全 <%= @matches.total_count %> 試合</p>
         <div class="flex items-center gap-2 text-sm text-gray-600">
           <span>ソート:</span>
-          <% [["latest", "最新順"], ["reactions", "リアクション順"]].each do |value, label| %>
+          <% [["latest", "新しい順"], ["oldest", "古い順"], ["reactions", "リアクション順"]].each do |value, label| %>
             <% if value == @sort %>
               <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
             <% else %>


### PR DESCRIPTION
## Summary
- 対戦履歴画面のソートオプションに「古い順」を追加
- 既存の「最新順」ラベルを「新しい順」に変更し、「古い順」との統一感を持たせた
- `Match.by_oldest` スコープは既にモデルに定義済みのため、コントローラーとビューの変更のみ

## Test plan
- [x] 対戦履歴画面で「新しい順」「古い順」「リアクション順」の3つのソートボタンが表示される
- [x] 「古い順」を選択すると、古い試合から順に表示される
- [x] 「古い順」選択時にフィルターやページネーションが正常に動作する
- [x] 「新しい順」「リアクション順」の既存ソートが引き続き正常に動作する

Closes #244