### PR TITLE
feat: 対戦詳細画面から戻った際にフィルター状態を保持する

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,10 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+
+// 対戦履歴ページを離れる前にフィルター付き URL を保存
+document.addEventListener("turbo:before-visit", () => {
+  if (window.location.pathname === "/matches") {
+    sessionStorage.setItem("matchesReturnUrl", window.location.href)
+  }
+})

--- a/app/javascript/controllers/back_link_controller.js
+++ b/app/javascript/controllers/back_link_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { storageKey: String }
+
+  connect() {
+    const url = sessionStorage.getItem(this.storageKeyValue)
+    if (url) {
+      this.element.href = url
+    }
+  }
+}

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -2,7 +2,8 @@
 
 <div class="max-w-6xl mx-auto py-8">
   <div class="mb-6">
-    <%= link_to "← 対戦履歴に戻る", matches_path, class: "text-blue-600 hover:text-blue-500" %>
+    <%= link_to "← 対戦履歴に戻る", matches_path, class: "text-blue-600 hover:text-blue-500",
+        data: { controller: "back-link", back_link_storage_key_value: "matchesReturnUrl" } %>
   </div>
 
   <div class="bg-white shadow sm:rounded-lg">


### PR DESCRIPTION
## Summary
- 対戦履歴ページを離れる前に `turbo:before-visit` でフィルター付き URL を sessionStorage に保存
- 新規 `back-link` Stimulus コントローラーで、対戦詳細画面の戻るリンクの `href` を保存済み URL に復元
- sessionStorage に URL がない場合（直接アクセス時等）は従来通り `/matches` にフォールバック

## Test plan
- [x] 対戦履歴画面でフィルターを複数設定（イベント・ユーザー・コスト等）→ 試合カードをクリック → 「← 対戦履歴に戻る」でフィルターが保持されること
- [x] ページネーション（2ページ目等）の状態も保持されること
- [x] ソート順（新しい順 / 古い順 / リアクション順）も保持されること
- [x] 対戦詳細画面に直接アクセスした場合、戻るリンクが `/matches` にフォールバックすること
- [x] 日付リンクから対戦詳細に遷移した場合もフィルターが保持されること

Closes #246