### PR TITLE
feat: 対戦履歴の機体・コストフィルターに対象プレイヤースコープ切替を追加

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -56,10 +56,11 @@ class MatchesController < ApplicationController
     end
 
     # フィルター: 使用機体（複数選択対応）
+    suit_scope_mine = params[:suit_scope] == "mine" && viewing_as_user
     if params[:mobile_suits].present?
       mobile_suit_ids = params[:mobile_suits].reject(&:blank?).map(&:to_i)
       if mobile_suit_ids.any?
-        if params[:my_mobile_suits] == "1"
+        if suit_scope_mine
           @matches = @matches.joins(:match_players).where(
             match_players: { mobile_suit_id: mobile_suit_ids, user_id: viewing_as_user.id }
           ).distinct
@@ -73,7 +74,13 @@ class MatchesController < ApplicationController
     if params[:costs].present?
       cost_values = params[:costs].reject(&:blank?).map(&:to_i)
       if cost_values.any?
-        @matches = @matches.joins(match_players: :mobile_suit).where(mobile_suits: { cost: cost_values }).distinct
+        if suit_scope_mine
+          @matches = @matches.joins(match_players: :mobile_suit).where(
+            mobile_suits: { cost: cost_values }, match_players: { user_id: viewing_as_user.id }
+          ).distinct
+        else
+          @matches = @matches.joins(match_players: :mobile_suit).where(mobile_suits: { cost: cost_values }).distinct
+        end
       end
     end
 
@@ -206,7 +213,7 @@ class MatchesController < ApplicationController
     @filter_streaming_users_mode = params[:streaming_users_mode].presence_in(%w[or and]) || "or"
     @filter_mobile_suits = params[:mobile_suits].present? ? params[:mobile_suits].reject(&:blank?).map(&:to_i) : []
     @filter_costs = params[:costs].present? ? params[:costs].reject(&:blank?).map(&:to_i) : []
-    @filter_my_mobile_suits = params[:my_mobile_suits] == "1"
+    @filter_suit_scope = params[:suit_scope].presence_in(%w[mine all]) || "all"
     @flip_team = params[:flip_team] == "1"
     @filter_stat_player_id = stat_player_id
     @filter_ol_filter = ol_filter

--- a/app/javascript/controllers/suit_select_controller.js
+++ b/app/javascript/controllers/suit_select_controller.js
@@ -19,7 +19,6 @@ export default class extends Controller {
       onChange: (value) => {
         const url = new URL(window.location.href)
         url.searchParams.delete('mobile_suits[]')
-        url.searchParams.delete('my_mobile_suits')
         if (this.clearCostValue) url.searchParams.delete('costs[]')
         if (value) url.searchParams.set('mobile_suits[]', value)
         window.location.href = url.toString()

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -40,8 +40,8 @@
   <div class="bg-white rounded-xl shadow-sm ring-1 ring-gray-900/5 mb-6 px-5 py-4 space-y-3">
 
     <!-- イベント -->
-    <div class="flex items-start gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">イベント</span>
+    <div class="flex items-center gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">イベント</span>
       <div class="flex flex-wrap gap-2">
         <%= link_to "全イベント", matches_path(_all.merge(events: [])), class: @filter_events.empty? ? _btn_on : _btn_off %>
         <% @all_events.each do |event| %>
@@ -51,12 +51,12 @@
     </div>
 
     <!-- 参加ユーザー -->
-    <div class="flex items-start gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">参加</span>
+    <div class="flex items-center gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">参加</span>
       <div class="flex flex-wrap gap-2">
         <div class="inline-flex rounded-md border border-gray-200 bg-white text-xs font-medium overflow-hidden shrink-0">
-          <%= link_to "OR", matches_path(_all.merge(users_mode: "or")), class: "block px-2 py-1 transition-colors #{@filter_users_mode == 'or' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
-          <%= link_to "AND", matches_path(_all.merge(users_mode: "and")), class: "block px-2 py-1 border-l border-gray-200 transition-colors #{@filter_users_mode == 'and' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
+          <%= link_to "OR", matches_path(_all.merge(users_mode: "or")), class: "block px-2 py-1.5 transition-colors #{@filter_users_mode == 'or' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
+          <%= link_to "AND", matches_path(_all.merge(users_mode: "and")), class: "block px-2 py-1.5 border-l border-gray-200 transition-colors #{@filter_users_mode == 'and' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
         </div>
         <%= link_to "全員", matches_path(_all.merge(users: [])), class: @filter_users.empty? ? _btn_on : _btn_off %>
         <% @all_users.each do |user| %>
@@ -67,8 +67,8 @@
 
     <!-- 配信台ユーザー -->
     <% _visible_streaming = @filter_users.any? ? @all_users.select { |u| @filter_users.include?(u.id) } : @all_users %>
-    <div class="flex items-start gap-2">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">配信台</span>
+    <div class="flex items-center gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">配信台</span>
       <div class="flex flex-wrap gap-2">
         <%= link_to "全員", matches_path(_all.merge(streaming_users: [])), class: @filter_streaming_users.empty? ? _btn_on : _btn_off %>
         <% _visible_streaming.each do |user| %>
@@ -128,8 +128,8 @@
       }
     %>
     <% if _fav_suits.any? %>
-      <div class="flex items-start gap-2">
-        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">お気に入り機体</span>
+      <div class="flex items-center gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">お気に入り機体</span>
         <div class="flex flex-wrap gap-2">
           <% _fav_suits.each do |fav| %>
             <%= link_to fav.mobile_suit.name, _fav_toggle.call(fav.mobile_suit.id),
@@ -141,8 +141,8 @@
 
     <!-- お気に入り試合 -->
     <% if viewing_as_user&.regular_user? %>
-      <div class="flex items-start gap-2">
-        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">お気に入り試合</span>
+      <div class="flex items-center gap-2">
+        <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">お気に入り試合</span>
         <div class="flex flex-wrap gap-2">
           <%= link_to matches_path(_all.merge(only_favorites: @filter_only_favorites ? nil : "1", page: nil)),
               class: "flex items-center gap-1.5 #{@filter_only_favorites ? _btn_on : _btn_off}" do %>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -25,7 +25,7 @@
             damage_received_val: @filter_damage_received_val, damage_received_dir: @filter_damage_received_dir }
     _cur = { events: @filter_events, users: @filter_users, users_mode: @filter_users_mode,
              streaming_users: @filter_streaming_users, mobile_suits: @filter_mobile_suits, costs: @filter_costs,
-             my_mobile_suits: @filter_my_mobile_suits ? "1" : nil }
+             suit_scope: @filter_suit_scope == "mine" ? "mine" : nil }
     _all = _bp.merge(_cur)
 
     _btn_on  = "px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-indigo-600 text-white"
@@ -78,17 +78,25 @@
     </div>
 
     <!-- 機体・コスト -->
-    <div class="flex flex-wrap items-start gap-3">
-      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0 pt-1.5">機体・コスト</span>
+    <div class="flex flex-wrap items-center gap-3">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">機体・コスト</span>
+      <% if @filter_mobile_suits.any? || @filter_costs.any? %>
+        <div class="inline-flex rounded-md border border-gray-200 bg-white text-xs font-medium overflow-hidden shrink-0">
+          <%= link_to "全プレイヤー", matches_path(_all.merge(suit_scope: nil)),
+              class: "block px-2 py-1.5 transition-colors #{@filter_suit_scope != 'mine' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
+          <%= link_to "自分のみ", matches_path(_all.merge(suit_scope: "mine")),
+              class: "block px-2 py-1.5 border-l border-gray-200 transition-colors #{@filter_suit_scope == 'mine' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50'}" %>
+        </div>
+      <% end %>
       <div class="flex rounded-xl bg-gray-100 p-1 gap-0.5 shrink-0">
-        <%= link_to "全体", matches_path(_all.merge(costs: [], mobile_suits: [], my_mobile_suits: nil)),
+        <%= link_to "全体", matches_path(_all.merge(costs: [], mobile_suits: [], suit_scope: nil)),
             class: "px-3 py-1.5 rounded-lg text-sm font-semibold transition-all whitespace-nowrap #{@filter_costs.empty? && @filter_mobile_suits.empty? ? 'bg-white shadow text-gray-900' : 'text-gray-500 hover:text-gray-700'}" %>
         <% [[3000, 'bg-red-500 text-white shadow-sm', 'text-red-500 hover:bg-red-100/80'],
             [2500, 'bg-orange-500 text-white shadow-sm', 'text-orange-500 hover:bg-orange-100/80'],
             [2000, 'bg-yellow-400 text-gray-900 shadow-sm', 'text-yellow-600 hover:bg-yellow-100/80'],
             [1500, 'bg-green-500 text-white shadow-sm', 'text-green-600 hover:bg-green-100/80']].each do |cost, active_cls, inactive_cls| %>
           <% is_cost_active = @filter_costs == [cost] && @filter_mobile_suits.empty? %>
-          <% cost_url = is_cost_active ? matches_path(_all.merge(costs: [], mobile_suits: [], my_mobile_suits: nil)) : matches_path(_all.merge(costs: [cost], mobile_suits: [], my_mobile_suits: nil)) %>
+          <% cost_url = is_cost_active ? matches_path(_all.merge(costs: [], mobile_suits: [], suit_scope: nil)) : matches_path(_all.merge(costs: [cost], mobile_suits: [])) %>
           <%= link_to cost.to_s, cost_url,
               class: "px-3 py-1.5 rounded-lg text-sm font-semibold transition-all whitespace-nowrap #{is_cost_active ? active_cls : inactive_cls}" %>
         <% end %>
@@ -101,7 +109,7 @@
         </select>
       </div>
       <% unless @filter_costs.empty? && @filter_mobile_suits.empty? %>
-        <%= link_to matches_path(_all.merge(costs: [], mobile_suits: [], my_mobile_suits: nil)),
+        <%= link_to matches_path(_all.merge(costs: [], mobile_suits: [], suit_scope: nil)),
             class: "flex items-center gap-1 text-xs text-gray-400 hover:text-red-500 transition-colors shrink-0" do %>
           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -116,7 +124,7 @@
       _fav_suits = viewing_as_user&.user_favorite_suits&.order(:slot)&.includes(:mobile_suit)&.to_a || []
       _fav_toggle = ->(suit_id) {
         new_arr = @filter_mobile_suits.include?(suit_id) ? @filter_mobile_suits - [suit_id] : @filter_mobile_suits + [suit_id]
-        matches_path(_all.merge(mobile_suits: new_arr, my_mobile_suits: new_arr.any? ? "1" : nil))
+        matches_path(_all.merge(mobile_suits: new_arr, suit_scope: new_arr.any? ? "mine" : nil))
       }
     %>
     <% if _fav_suits.any? %>
@@ -125,7 +133,7 @@
         <div class="flex flex-wrap gap-2">
           <% _fav_suits.each do |fav| %>
             <%= link_to fav.mobile_suit.name, _fav_toggle.call(fav.mobile_suit.id),
-                class: (@filter_mobile_suits.include?(fav.mobile_suit.id) && @filter_my_mobile_suits) ? _btn_on : _btn_off %>
+                class: @filter_mobile_suits.include?(fav.mobile_suit.id) ? _btn_on : _btn_off %>
           <% end %>
         </div>
       </div>
@@ -174,7 +182,7 @@
           <% @filter_streaming_users.each do |id| %><input type="hidden" name="streaming_users[]" value="<%= id %>"><% end %>
           <% @filter_mobile_suits.each do |id| %><input type="hidden" name="mobile_suits[]" value="<%= id %>"><% end %>
           <% @filter_costs.each do |c| %><input type="hidden" name="costs[]" value="<%= c %>"><% end %>
-          <% if @filter_my_mobile_suits %><input type="hidden" name="my_mobile_suits" value="1"><% end %>
+          <% if @filter_suit_scope == "mine" %><input type="hidden" name="suit_scope" value="mine"><% end %>
           <% if @flip_team %><input type="hidden" name="flip_team" value="1"><% end %>
           <% if @filter_only_favorites %><input type="hidden" name="only_favorites" value="1"><% end %>
           <input type="hidden" name="sort" value="<%= @sort %>">


### PR DESCRIPTION
## Summary
- 機体・コストフィルターに「全プレイヤー / 自分のみ」トグルを追加し、フィルター対象のスコープを切り替え可能にした
- `my_mobile_suits` パラメータを `suit_scope`（`mine` / `all`）に置換し、コストフィルターにも自分視点の絞り込みを適用可能にした
- お気に入り機体ボタンクリック時はデフォルト「自分のみ」、コスト・ドロップダウン選択時はデフォルト「全プレイヤー」
- フィルターセクション全体のラベル・ボタンを中央揃えに統一

## Test plan
- [x] 機体・コストフィルター未選択時、トグルが非表示であること
- [x] コストボタンクリック → トグルが「全プレイヤー」で表示、全プレイヤーの対戦が表示されること
- [x] お気に入り機体クリック → トグルが「自分のみ」で表示、自分の対戦のみ表示されること
- [x] トグルを「全プレイヤー」に切り替え → 該当機体を使った全プレイヤーの対戦が表示されること
- [x] トグルを「自分のみ」に切り替え → 自分がそのコスト/機体を使った対戦のみ表示されること
- [x] ドロップダウンで機体選択 → suit_scope が維持されること
- [x] クリアボタンでフィルター・トグルがリセットされること
- [x] 詳細条件フォームの適用時に suit_scope が引き継がれること
- [x] フィルター行のラベル・ボタンが中央揃えで表示されること
- [x] 管理者の view-as モードでも正しく動作すること

Closes #248