### PR TITLE
feat: 対戦履歴に同チーム指定フィルターを追加する

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -175,6 +175,26 @@ class MatchesController < ApplicationController
       @matches = scope.distinct
     end
 
+    # フィルター: チーム指定（同一チームにいたユーザーの組み合わせ）
+    if params[:team_player_ids].present?
+      team_player_ids = params[:team_player_ids].reject(&:blank?).map(&:to_i)
+      if team_player_ids.length >= 2
+        uid1, uid2 = team_player_ids[0], team_player_ids[1]
+        @matches = @matches.where(
+          "EXISTS (" \
+          "SELECT 1 FROM match_players mp1 " \
+          "JOIN match_players mp2 ON mp1.match_id = mp2.match_id AND mp1.team_number = mp2.team_number " \
+          "WHERE mp1.match_id = matches.id AND mp1.user_id = ? AND mp2.user_id = ?" \
+          ")", uid1, uid2
+        )
+      elsif team_player_ids.length == 1
+        @matches = @matches.where(
+          "EXISTS (SELECT 1 FROM match_players mp WHERE mp.match_id = matches.id AND mp.user_id = ?)",
+          team_player_ids[0]
+        )
+      end
+    end
+
     # フィルター: お気に入りのみ
     if params[:only_favorites] == "1" && viewing_as_user
       @matches = @matches.joins(:favorite_matches).where(favorite_matches: { user_id: viewing_as_user.id })
@@ -223,6 +243,7 @@ class MatchesController < ApplicationController
     @filter_damage_received_val = params[:damage_received_val].presence
     @filter_damage_received_dir = params[:damage_received_dir].presence_in(%w[gte lte]) || "gte"
     @filter_only_favorites = params[:only_favorites] == "1"
+    @filter_team_player_ids = params[:team_player_ids].present? ? params[:team_player_ids].reject(&:blank?).map(&:to_i) : []
   end
 
   def show

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -25,7 +25,8 @@
             damage_received_val: @filter_damage_received_val, damage_received_dir: @filter_damage_received_dir }
     _cur = { events: @filter_events, users: @filter_users, users_mode: @filter_users_mode,
              streaming_users: @filter_streaming_users, mobile_suits: @filter_mobile_suits, costs: @filter_costs,
-             suit_scope: @filter_suit_scope == "mine" ? "mine" : nil }
+             suit_scope: @filter_suit_scope == "mine" ? "mine" : nil,
+             team_player_ids: @filter_team_player_ids }
     _all = _bp.merge(_cur)
 
     _btn_on  = "px-3 py-1.5 text-sm font-medium rounded-md transition-colors bg-indigo-600 text-white"
@@ -61,6 +62,37 @@
         <%= link_to "全員", matches_path(_all.merge(users: [])), class: @filter_users.empty? ? _btn_on : _btn_off %>
         <% @all_users.each do |user| %>
           <%= link_to user.nickname, _toggle.call(:users, user.id), class: @filter_users.include?(user.id) ? _btn_on : _btn_off %>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- チーム指定 -->
+    <%
+      _team_toggle = ->(user_id) {
+        if @filter_team_player_ids.include?(user_id)
+          matches_path(_all.merge(team_player_ids: @filter_team_player_ids - [user_id]))
+        elsif @filter_team_player_ids.length < 2
+          matches_path(_all.merge(team_player_ids: @filter_team_player_ids + [user_id]))
+        else
+          matches_path(_all.merge(team_player_ids: [@filter_team_player_ids[1], user_id]))
+        end
+      }
+    %>
+    <div class="flex items-center gap-2">
+      <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide w-24 shrink-0">同チーム</span>
+      <div class="flex flex-wrap gap-2">
+        <% @all_users.each do |user| %>
+          <%= link_to user.nickname, _team_toggle.call(user.id),
+              class: @filter_team_player_ids.include?(user.id) ? _btn_on : _btn_off %>
+        <% end %>
+        <% if @filter_team_player_ids.any? %>
+          <%= link_to matches_path(_all.merge(team_player_ids: [])),
+              class: "flex items-center gap-1 text-xs text-gray-400 hover:text-red-500 transition-colors shrink-0" do %>
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+            クリア
+          <% end %>
         <% end %>
       </div>
     </div>
@@ -185,6 +217,7 @@
           <% if @filter_suit_scope == "mine" %><input type="hidden" name="suit_scope" value="mine"><% end %>
           <% if @flip_team %><input type="hidden" name="flip_team" value="1"><% end %>
           <% if @filter_only_favorites %><input type="hidden" name="only_favorites" value="1"><% end %>
+          <% @filter_team_player_ids.each do |id| %><input type="hidden" name="team_player_ids[]" value="<%= id %>"><% end %>
           <input type="hidden" name="sort" value="<%= @sort %>">
           <input type="hidden" name="per" value="<%= @per_page %>">
 


### PR DESCRIPTION
## Summary
- 対戦履歴フィルターに「同チーム」セクションを追加
- 2名選択時: `match_players.team_number` の自己結合で、2人が同一チームにいた試合に絞り込む
- 1名選択時: そのユーザーが参加した試合に絞り込む
- 3名目を選択すると最初の選択が外れる（常に最大2名）
- 選択中はユーザーボタンの右端に「クリア」ボタンを表示
- 詳細条件フォームの hidden フィールドにも `team_player_ids[]` を引き継ぎ

## Test plan
- [x] 2名選択 → その2人が同チームだった試合のみ表示されること
- [x] 2名選択 → 対戦相手として対面した試合は表示されないこと
- [x] 1名選択 → そのユーザーが参加した試合が表示されること
- [x] 3名目を選択すると1名目が外れ、2名になること
- [x] クリアボタンで選択が全解除されること
- [x] 他のフィルター（参加・イベント等）と組み合わせて動作すること
- [x] 詳細条件フォームを開いて送信した際にチームフィルターが引き継がれること

Closes #250