### PR TITLE
feat: 統計ページのパートナー戦績タブでパートナー行クリック時に同チームフィルター付き対戦履歴へ遷移

### DIFF
--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -503,7 +503,7 @@
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
               <% @partners_list.each do |partner| %>
-                <tr class="hover:bg-gray-50">
+                <tr class="hover:bg-gray-50 cursor-pointer" onclick="window.location='<%= matches_path(team_player_ids: [viewing_as_user.id, partner[:user].id]) %>'">
                   <td class="px-6 py-4 whitespace-nowrap">
                     <div class="text-sm font-medium text-gray-900">
                       <%= partner[:user].nickname %>


### PR DESCRIPTION
## Summary
- 統計ページのパートナー戦績タブの各パートナー行をクリック可能にした
- クリックすると対戦履歴画面に遷移し、表示ユーザーと該当パートナーが**同チームで組んだ試合のみ**フィルターされた状態で表示される
- `viewing_as_user` を基準にしているため、管理者の視点切り替え・一般ユーザーのユーザー切り替え（#228）の両方に対応

PR #231 の再実装。旧実装は `users[]=&users_mode=and`（両者が参加した試合）だったが、PR #251 で実装された `team_player_ids[]` を使い、同チームの試合のみに絞り込むよう修正した。

Closes #252

## Test plan
- [x] 統計ページのパートナー戦績タブでパートナー行にカーソルを当て、ポインターカーソルになることを確認
- [x] パートナー行をクリックすると対戦履歴画面に遷移することを確認
- [x] 遷移後、URL に `team_player_ids[]=<自分のID>&team_player_ids[]=<パートナーID>` が含まれていることを確認
- [x] 遷移後の対戦履歴が、その2人が同チームで出た試合のみ表示されていることを確認（対戦相手として戦った試合は含まれない）
- [x] 管理者が視点切り替え中に遷移した場合、切り替え先ユーザーのIDが `team_player_ids[]` に含まれていることを確認
- [x] 一般ユーザーがユーザー切り替えタブで別ユーザーを選択した状態でクリックした場合も同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)