### PR TITLE
feat: Discordイベント通知の定型文修正

### DIFF
--- a/app/jobs/event_reminder_job.rb
+++ b/app/jobs/event_reminder_job.rb
@@ -4,7 +4,7 @@ class EventReminderJob < ApplicationJob
   def perform
     today = Date.current
 
-    { 1 => "明日", 7 => "1週間後に" }.each do |days, label|
+    { 1 => "明日", 7 => "1週間後" }.each do |days, label|
       target_date = today + days
       events = Event.where(held_on: target_date)
       next if events.none?
@@ -22,9 +22,9 @@ class EventReminderJob < ApplicationJob
     lines = []
     lines << "@everyone"
     lines << "【リマインド】"
-    lines << "こちら、#{label}開催です！！"
-    lines << "参加したい方はフォーラムまで連絡下さい！！"
+    lines << "↓こちら、#{label}の開催です！！"
     lines << event.discord_thread_url if event.discord_thread_url.present?
+    lines << "参加したい方はフォーラムまで連絡下さい！！"
     lines.join("\n")
   end
 end


### PR DESCRIPTION
## Summary

- `↓こちら、{明日/1週間後}の開催です！！` に修正（`↓` 追加・`の` 追加）
- `discord_thread_url` の位置を「↓こちら〜」の直後に移動（末尾→3行目）
- ラベル「1週間後に」→「1週間後」

## Test plan

- [x] `bin/rails console` で `EventReminderJob.new.send(:build_message, event, "明日")` の出力が期待通りであること
- [x] `discord_thread_url` ありの場合、URLが「↓こちら〜」の直後に来ること
- [x] `discord_thread_url` なしの場合、3行で正しく出力されること

Closes #256