### PR TITLE
feat: 前日リマインドに事前準備メッセージをイベントチャンネルへ追加投稿する

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -213,6 +213,6 @@ class EventsController < ApplicationController
   end
 
   def event_params
-    params.require(:event).permit(:name, :held_on, :description, :broadcast_url, :discord_thread_url)
+    params.require(:event).permit(:name, :held_on, :description, :broadcast_url, :discord_thread_url, :discord_channel_webhook_url)
   end
 end

--- a/app/jobs/event_reminder_job.rb
+++ b/app/jobs/event_reminder_job.rb
@@ -42,7 +42,7 @@ class EventReminderJob < ApplicationJob
       【事前準備のお願い】
 
       明日のイベントに向けて、以下の準備をお願いします！
-      ・アプリ設定
+      ・通知設定（ホーム画面に追加 & プッシュ通知ON）
       ・Cookieの共有
       ・お気に入り機体の設定
 

--- a/app/jobs/event_reminder_job.rb
+++ b/app/jobs/event_reminder_job.rb
@@ -1,6 +1,8 @@
 class EventReminderJob < ApplicationJob
   queue_as :default
 
+  PREPARATION_MESSAGE_URL = "https://discord.com/channels/731348521269329971/1483812692023181554/1483813049029623910"
+
   def perform
     today = Date.current
 
@@ -12,6 +14,13 @@ class EventReminderJob < ApplicationJob
       events.each do |event|
         message = build_message(event, label)
         DiscordWebhookService.post(purpose: :reminder, message: message)
+
+        if days == 1 && event.discord_channel_webhook_url.present?
+          DiscordWebhookService.post_to_webhook_url(
+            url: event.discord_channel_webhook_url,
+            message: build_preparation_message
+          )
+        end
       end
     end
   end
@@ -26,5 +35,19 @@ class EventReminderJob < ApplicationJob
     lines << event.discord_thread_url if event.discord_thread_url.present?
     lines << "参加したい方はフォーラムまで連絡下さい！！"
     lines.join("\n")
+  end
+
+  def build_preparation_message
+    <<~MSG.chomp
+      【事前準備のお願い】
+
+      明日のイベントに向けて、以下の準備をお願いします！
+      ・アプリ設定
+      ・Cookieの共有
+      ・お気に入り機体の設定
+
+      準備内容の詳細はこちら↓
+      #{PREPARATION_MESSAGE_URL}
+    MSG
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,6 +4,7 @@ class Event < ApplicationRecord
   validates :held_on, presence: true
   validates :broadcast_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
   validates :discord_thread_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
+  validates :discord_channel_webhook_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
 
   # Associations
   has_many :matches, dependent: :destroy

--- a/app/services/discord_webhook_service.rb
+++ b/app/services/discord_webhook_service.rb
@@ -6,7 +6,15 @@ class DiscordWebhookService
       channel = DiscordChannel.find_by(purpose: purpose)
       return if channel&.webhook_url.blank?
 
-      uri = URI(channel.webhook_url)
+      post_to_webhook_url(url: channel.webhook_url, message: message)
+    rescue => e
+      Rails.logger.error("[DiscordWebhookService] Failed to post (purpose=#{purpose}): #{e.message}")
+    end
+
+    def post_to_webhook_url(url:, message:)
+      return if url.blank?
+
+      uri = URI(url)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
 
@@ -14,7 +22,7 @@ class DiscordWebhookService
       req.body = { content: message }.to_json
       http.request(req)
     rescue => e
-      Rails.logger.error("[DiscordWebhookService] Failed to post (purpose=#{purpose}): #{e.message}")
+      Rails.logger.error("[DiscordWebhookService] Failed to post_to_webhook_url (url=#{url}): #{e.message}")
     end
   end
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -37,6 +37,12 @@
     <p class="mt-1 text-sm text-gray-500">設定するとDiscordリマインドメッセージにスレッドリンクが含まれます</p>
   </div>
 
+  <div>
+    <%= form.label :discord_channel_webhook_url, "DiscordチャンネルWebhook URL（任意）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.url_field :discord_channel_webhook_url, placeholder: "https://discord.com/api/webhooks/...", class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    <p class="mt-1 text-sm text-gray-500">設定すると前日リマインド時にこのチャンネルへ事前準備メッセージを投稿します</p>
+  </div>
+
   <div class="flex justify-end space-x-3">
     <%= link_to "キャンセル", events_path, class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
     <%= form.submit event.new_record? ? "作成" : "更新", class: "px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700" %>

--- a/db/migrate/20260404010220_add_discord_channel_webhook_url_to_events.rb
+++ b/db/migrate/20260404010220_add_discord_channel_webhook_url_to_events.rb
@@ -1,0 +1,5 @@
+class AddDiscordChannelWebhookUrlToEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :events, :discord_channel_webhook_url, :string
+  end
+end


### PR DESCRIPTION
## Summary

- `events` テーブルに `discord_channel_webhook_url` カラムを追加（イベント固有の投稿先Webhook URL）
- `DiscordWebhookService.post_to_webhook_url` を追加し、任意のWebhook URLへ投稿可能に
- 前日リマインド時（`days == 1`）かつ `discord_channel_webhook_url` 設定済みのイベントに以下を自動投稿:

```
【事前準備のお願い】

明日のイベントに向けて、以下の準備をお願いします！
・通知設定（ホーム画面に追加 & プッシュ通知ON）
・Cookieの共有
・お気に入り機体の設定

準備内容の詳細はこちら↓
https://discord.com/channels/...
```

- イベント作成・編集フォームにWebhook URL入力欄を追加
- `discord_channel_webhook_url` 未設定のイベントはスキップ（既存イベントへの影響なし）

## Test plan

- [x] `bin/rails console` で `EventReminderJob.new.send(:build_preparation_message)` の出力が期待通りであること
- [x] イベント編集フォームに「DiscordチャンネルWebhook URL」欄が表示されること
- [x] Webhook URLを設定して保存できること
- [x] `discord_channel_webhook_url` 未設定のイベントで事前準備メッセージが送信されないこと

Closes #257