### PR TITLE
feat: ローテーション詳細画面の全試合一覧に WIN/LOSE バッジと背景色を追加

### DIFF
--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -555,9 +555,6 @@
             <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
               状態
             </th>
-            <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-              結果
-            </th>
           </tr>
         </thead>
         <tbody class="bg-white">
@@ -603,65 +600,56 @@
                 mp3 = rm.match&.match_players&.find { |mp| mp.position == 3 }
                 mp4 = rm.match&.match_players&.find { |mp| mp.position == 4 }
               %>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm text-gray-900">
-                  <span class="font-bold text-red-600"><%= rm.team1_player1.nickname %></span>
-                  <span class="ml-1 px-1.5 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                  <% if mp1&.mobile_suit %>
-                    <a href="<%= mobile_suit_path(mp1.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp1.mobile_suit.name %>)</a>
-                  <% end %>
-                  <br>
-                  <%= rm.team1_player2.nickname %>
-                  <% if mp2&.mobile_suit %>
-                    <a href="<%= mobile_suit_path(mp2.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp2.mobile_suit.name %>)</a>
+              <td class="px-6 py-4 whitespace-nowrap <%= rm.match ? (rm.match.winning_team == 1 ? 'bg-sky-50/70' : 'bg-red-50/70') : '' %>">
+                <div class="flex items-start justify-between gap-2">
+                  <div class="text-sm text-gray-900">
+                    <span class="font-bold text-red-600"><%= rm.team1_player1.nickname %></span>
+                    <span class="ml-1 px-1.5 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
+                    <% if mp1&.mobile_suit %>
+                      <a href="<%= mobile_suit_path(mp1.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp1.mobile_suit.name %>)</a>
+                    <% end %>
+                    <br>
+                    <%= rm.team1_player2.nickname %>
+                    <% if mp2&.mobile_suit %>
+                      <a href="<%= mobile_suit_path(mp2.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp2.mobile_suit.name %>)</a>
+                    <% end %>
+                  </div>
+                  <% if rm.match %>
+                    <span class="shrink-0 px-2.5 py-1 rounded-full text-xs font-bold leading-none <%= rm.match.winning_team == 1 ? 'bg-sky-100 text-sky-700' : 'bg-red-100 text-red-600' %>">
+                      <%= rm.match.winning_team == 1 ? 'WIN' : 'LOSE' %>
+                    </span>
                   <% end %>
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-center">
                 <span class="text-gray-400 font-semibold">VS</span>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm text-gray-900">
-                  <%= rm.team2_player1.nickname %>
-                  <% if mp3&.mobile_suit %>
-                    <a href="<%= mobile_suit_path(mp3.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp3.mobile_suit.name %>)</a>
-                  <% end %>
-                  <br>
-                  <%= rm.team2_player2.nickname %>
-                  <% if mp4&.mobile_suit %>
-                    <a href="<%= mobile_suit_path(mp4.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp4.mobile_suit.name %>)</a>
+              <td class="px-6 py-4 whitespace-nowrap <%= rm.match ? (rm.match.winning_team == 2 ? 'bg-sky-50/70' : 'bg-red-50/70') : '' %>">
+                <div class="flex items-start justify-between gap-2">
+                  <div class="text-sm text-gray-900">
+                    <%= rm.team2_player1.nickname %>
+                    <% if mp3&.mobile_suit %>
+                      <a href="<%= mobile_suit_path(mp3.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp3.mobile_suit.name %>)</a>
+                    <% end %>
+                    <br>
+                    <%= rm.team2_player2.nickname %>
+                    <% if mp4&.mobile_suit %>
+                      <a href="<%= mobile_suit_path(mp4.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp4.mobile_suit.name %>)</a>
+                    <% end %>
+                  </div>
+                  <% if rm.match %>
+                    <span class="shrink-0 px-2.5 py-1 rounded-full text-xs font-bold leading-none <%= rm.match.winning_team == 2 ? 'bg-sky-100 text-sky-700' : 'bg-red-100 text-red-600' %>">
+                      <%= rm.match.winning_team == 2 ? 'WIN' : 'LOSE' %>
+                    </span>
                   <% end %>
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-center">
                 <% if rm.match %>
-                  <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-                    記録済み
-                  </span>
-                <% elsif index < @rotation.current_match_index %>
-                  <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
-                    スキップ
-                  </span>
-                <% else %>
-                  <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                    未記録
-                  </span>
-                <% end %>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-center">
-                <% if rm.match %>
                   <div class="flex flex-col items-center space-y-2">
-                    <div>
-                      <% if rm.match.winning_team == 1 %>
-                        <span class="px-3 py-1 text-sm font-bold rounded bg-blue-600 text-white">
-                          チーム1
-                        </span>
-                      <% else %>
-                        <span class="px-3 py-1 text-sm font-bold rounded bg-red-600 text-white">
-                          チーム2
-                        </span>
-                      <% end %>
-                    </div>
+                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
+                      記録済み
+                    </span>
                     <% if current_user.is_admin? %>
                       <div class="flex items-center justify-center space-x-2" onclick="event.stopPropagation()">
                         <a href="#match-record-container"
@@ -676,7 +664,9 @@
                   </div>
                 <% elsif index < @rotation.current_match_index %>
                   <div class="flex flex-col items-center space-y-1">
-                    <span class="text-xs text-gray-400">-</span>
+                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
+                      スキップ
+                    </span>
                     <% if current_user.is_admin? %>
                       <div onclick="event.stopPropagation()">
                         <%= button_to "ここに戻る", go_to_match_rotation_path(@rotation, match_index: index), method: :post, class: "text-xs text-gray-500 hover:text-gray-700 underline", form: { data: { turbo: false } } %>
@@ -684,7 +674,9 @@
                     <% end %>
                   </div>
                 <% else %>
-                  <span class="text-sm text-gray-400">-</span>
+                  <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                    未記録
+                  </span>
                 <% end %>
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- ローテーション詳細画面の全試合一覧テーブルから「結果」列を削除
- チーム1・チーム2セルに WIN/LOSE バッジを追加（試合記録がある行のみ）
- チーム1・チーム2セルに WIN/LOSE に応じた背景色を追加（`bg-sky-50/70` / `bg-red-50/70`）
- 管理者用の編集/削除ボタン・「ここに戻る」ボタンを「状態」列に移動
- 対戦履歴一覧（`_match_teams.html.erb`）と同スタイルに統一

## Test plan
- [x] 試合記録済みの行でチーム1に WIN（水色）、チーム2に LOSE（赤）が表示される（チーム1勝利時）
- [x] 試合記録済みの行でチーム2に WIN（水色）、チーム1に LOSE（赤）が表示される（チーム2勝利時）
- [x] 試合記録済みの行でチーム1・チーム2セルに背景色が付く
- [x] 未記録・スキップの行にはバッジ・背景色が表示されない
- [x] 管理者で編集・削除ボタンが「状態」列に表示される
- [x] 管理者でスキップ行に「ここに戻る」ボタンが「状態」列に表示される

Closes #260