### PR TITLE
feat: ローテーション詳細の平等性チェックに登録済み試合数・配信台回数を追加

### DIFF
--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -14,7 +14,7 @@ class RotationsController < ApplicationController
                                             match: { match_players: :mobile_suit })
                                   .order(:match_index)
     @current_match = @rotation_matches[@rotation.current_match_index]
-    @player_statistics = @rotation.player_statistics
+    @player_statistics = @rotation.player_statistics(@rotation_matches)
     @all_mobile_suits = MobileSuit.order(:name).to_a
 
     # プレイヤーのお気に入り機体を N+1 を起こさずまとめてロード

--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -32,24 +32,37 @@ class Rotation < ApplicationRecord
   end
 
   # Calculate statistics for each player
-  def player_statistics
+  # rotation_matches_scope: preloaded scope (includes :match) to avoid N+1
+  def player_statistics(rotation_matches_scope = nil)
+    scope = rotation_matches_scope || rotation_matches.includes(:match)
+
     stats = Hash.new do |h, k|
       h[k] = {
         user: nil,
         match_count: 0,
+        registered_match_count: 0,
+        streaming_count: 0,
+        registered_streaming_count: 0,
         pair_counts: Hash.new(0),
         opponent_counts: Hash.new(0)
       }
     end
 
-    rotation_matches.each do |rm|
+    scope.each do |rm|
       all_players = [ rm.team1_player1, rm.team1_player2, rm.team2_player1, rm.team2_player2 ]
+      registered = rm.match.present?
 
       # Update match counts
       all_players.each do |player|
         stats[player.id][:user] = player
         stats[player.id][:match_count] += 1
+        stats[player.id][:registered_match_count] += 1 if registered
       end
+
+      # Update streaming seat (team1_player1) counts
+      streamer = rm.team1_player1
+      stats[streamer.id][:streaming_count] += 1
+      stats[streamer.id][:registered_streaming_count] += 1 if registered
 
       # Update pair counts
       [ [ rm.team1_player1, rm.team1_player2 ], [ rm.team2_player1, rm.team2_player2 ] ].each do |pair|

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -692,7 +692,7 @@
       <div class="flex items-center justify-between">
         <div>
           <h3 class="text-lg font-semibold text-gray-900">プレイヤー統計（平等性チェック）</h3>
-          <p class="mt-1 text-sm text-gray-500">各プレイヤーの試合数、ペア回数、対戦相手回数が均等に配分されているか確認できます</p>
+          <p class="mt-1 text-sm text-gray-500">各プレイヤーの試合数（記録済 / 計画）、ペア回数、対戦相手回数が均等に配分されているか確認できます</p>
         </div>
         <span class="text-xs text-gray-500" title="試合数の偏りがないか確認">ℹ️ 公平性</span>
       </div>
@@ -705,7 +705,10 @@
               プレイヤー
             </th>
             <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-              試合数
+              試合数<br><span class="normal-case font-normal">(記録済 / 計画)</span>
+            </th>
+            <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+              配信台回数<br><span class="normal-case font-normal">(記録済 / 計画)</span>
             </th>
             <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               最もペアを組んだ相手
@@ -729,7 +732,12 @@
                 </div>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-center">
-                <span class="text-sm font-semibold text-gray-900"><%= stats[:match_count] %></span>
+                <span class="text-sm font-semibold text-gray-900"><%= stats[:registered_match_count] %></span>
+                <span class="text-xs text-gray-400"> / <%= stats[:match_count] %></span>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-center">
+                <span class="text-sm font-semibold text-gray-900"><%= stats[:registered_streaming_count] %></span>
+                <span class="text-xs text-gray-400"> / <%= stats[:streaming_count] %></span>
               </td>
               <td class="px-6 py-4">
                 <div class="text-sm text-gray-700">


### PR DESCRIPTION
## Summary
- `Rotation#player_statistics` に `registered_match_count`・`streaming_count`・`registered_streaming_count` を追加
- コントローラで preload 済みの `@rotation_matches` を渡すことで N+1 クエリを回避
- 平等性チェックテーブルの「試合数」列を「記録済 / 計画」形式に変更
- 「配信台回数 (記録済 / 計画)」列を新規追加

## Test plan
- [x] ローテーション詳細画面の平等性チェックテーブルで「試合数」が「記録済 / 計画」形式で表示される
- [x] 「配信台回数」列が表示され、配信台に立った回数が正しくカウントされる（`team1_player1` の集計）
- [x] 試合を1件記録した後、対象プレイヤーの記録済みカウントが増加する
- [x] 未記録の状態では記録済みカウントが 0 になる

Closes #262