### PR TITLE
fix: ローカル環境でプッシュ通知が実ユーザーに送信される問題を修正

### DIFF
--- a/app/jobs/send_push_notification_job.rb
+++ b/app/jobs/send_push_notification_job.rb
@@ -5,6 +5,8 @@ class SendPushNotificationJob < ApplicationJob
   retry_on Net::ReadTimeout, wait: 10.seconds, attempts: 3
 
   def perform(user_id:, title:, body:, path: "/", icon: "/icon-192.png")
+    return unless Rails.env.production?
+
     user = User.find_by(id: user_id)
     return unless user
 


### PR DESCRIPTION
## Summary
- `SendPushNotificationJob` に本番環境ガードがなく、ローカル環境でも実ユーザーへ通知が送信されていた問題を修正

## 原因

- development の `queue_adapter` は未設定（デフォルト `:async`）のため `perform_later` がインプロセスで即時実行される
- `bin/db-pull` で本番 DB をローカルに取り込んだ状態で操作すると、本物の `push_subscriptions` に対して WebPush が呼ばれてしまっていた

## 変更内容

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `SendPushNotificationJob#perform` | 環境チェックなし | 先頭に `return unless Rails.env.production?` を追加 |

## Test plan

- [x] ローカル環境でローテーション次周作成を行い、通知が送信されないことを確認
- [x] 本番環境では引き続き通知が送信されることを確認

Closes #265