### PR TITLE
feat: ローテーションのスロット割り当てランダム化と次周の再生成

### DIFF
--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -291,16 +291,12 @@ class RotationsController < ApplicationController
       base_rotation_id: @rotation.id
     )
 
-    # Copy rotation matches
-    @rotation.rotation_matches.order(:match_index).each do |rm|
-      new_rotation.rotation_matches.create!(
-        match_index: rm.match_index,
-        team1_player1: rm.team1_player1,
-        team1_player2: rm.team1_player2,
-        team2_player1: rm.team2_player1,
-        team2_player2: rm.team2_player2
-      )
-    end
+    # Re-generate rotation matches with reshuffled player slots so that streaming
+    # patterns differ between rounds (same opponents/partners when streaming)
+    player_ids = @rotation.rotation_matches.flat_map { |rm|
+      [ rm.team1_player1_id, rm.team1_player2_id, rm.team2_player1_id, rm.team2_player2_id ]
+    }.uniq.compact
+    generate_rotation_matches(new_rotation, player_ids)
 
     # Deactivate all rotations for this event
     @rotation.event.rotations.update_all(is_active: false)
@@ -437,7 +433,8 @@ class RotationsController < ApplicationController
     return if players.size < 4
 
     # Use RotationGenerator service to create balanced matches
-    generator = RotationGenerator.new(players)
+    # Shuffle players so slot assignment (A, B, C...) is randomized each time
+    generator = RotationGenerator.new(players.shuffle)
     matches = generator.generate
 
     # Create rotation matches from generated data

--- a/app/services/rotation_generator.rb
+++ b/app/services/rotation_generator.rb
@@ -2,7 +2,7 @@ class RotationGenerator
   MAX_MATCHES_PER_ROTATION = 50
 
   def initialize(players)
-    @players = players.sort_by(&:id) # Ensure consistent ordering
+    @players = players
     @player_count = @players.size
     @matches = []
 


### PR DESCRIPTION
## Summary

- `RotationGenerator` からプレイヤーの ID 順ソートを削除し、呼び出し元が渡した順序をそのまま使うよう変更
- ローテーション初回生成時に `players.shuffle` を渡し、スロット（A, B, C...）へのユーザー割り当てをランダム化
- 次周作成（`copy_for_next_round`）でマッチのコピーを廃止し、プレイヤーセットを再シャッフルして再生成することで周毎に配信台パターンが変化するよう修正

## Test plan

- [x] ローテーション新規作成時、毎回異なるスロット割り当てになることを確認
- [x] 次周作成時、前周と異なる配信台パターン（相手・パートナー）になることを確認
- [x] 次周作成後も参加プレイヤーが変わらないことを確認
- [x] 1ローテーション内の配信台回数が平等に保たれることを確認

Closes #264