### PR TITLE
refactor: イベント別Discord Webhook設定を廃止しDiscord設定ページのリマインドWebhookに統一

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -213,6 +213,6 @@ class EventsController < ApplicationController
   end
 
   def event_params
-    params.require(:event).permit(:name, :held_on, :description, :broadcast_url, :discord_thread_url, :discord_channel_webhook_url)
+    params.require(:event).permit(:name, :held_on, :description, :broadcast_url, :discord_thread_url)
   end
 end

--- a/app/jobs/event_reminder_job.rb
+++ b/app/jobs/event_reminder_job.rb
@@ -15,11 +15,8 @@ class EventReminderJob < ApplicationJob
         message = build_message(event, label)
         DiscordWebhookService.post(purpose: :reminder, message: message)
 
-        if days == 1 && event.discord_channel_webhook_url.present?
-          DiscordWebhookService.post_to_webhook_url(
-            url: event.discord_channel_webhook_url,
-            message: build_preparation_message
-          )
+        if days == 1
+          DiscordWebhookService.post(purpose: :reminder, message: build_preparation_message)
         end
       end
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,6 @@ class Event < ApplicationRecord
   validates :held_on, presence: true
   validates :broadcast_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
   validates :discord_thread_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
-  validates :discord_channel_webhook_url, format: { with: /\Ahttps?:\/\//i, message: "は http:// または https:// で始まる URL を入力してください" }, allow_blank: true
 
   # Associations
   has_many :matches, dependent: :destroy

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -37,12 +37,6 @@
     <p class="mt-1 text-sm text-gray-500">設定するとDiscordリマインドメッセージにスレッドリンクが含まれます</p>
   </div>
 
-  <div>
-    <%= form.label :discord_channel_webhook_url, "DiscordチャンネルWebhook URL（任意）", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= form.url_field :discord_channel_webhook_url, placeholder: "https://discord.com/api/webhooks/...", class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
-    <p class="mt-1 text-sm text-gray-500">設定すると前日リマインド時にこのチャンネルへ事前準備メッセージを投稿します</p>
-  </div>
-
   <div class="flex justify-end space-x-3">
     <%= link_to "キャンセル", events_path, class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
     <%= form.submit event.new_record? ? "作成" : "更新", class: "px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700" %>

--- a/db/migrate/20260404120000_remove_discord_channel_webhook_url_from_events.rb
+++ b/db/migrate/20260404120000_remove_discord_channel_webhook_url_from_events.rb
@@ -1,0 +1,5 @@
+class RemoveDiscordChannelWebhookUrlFromEvents < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :events, :discord_channel_webhook_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_30_130613) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_04_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## Summary

- イベント作成フォームから `DiscordチャンネルWebhook URL` 入力項目を削除
- `events.discord_channel_webhook_url` カラムを削除するマイグレーションを追加
- `EventReminderJob` の前日事前準備メッセージの投稿先を、per-event URL から Discord設定ページの `reminder` Webhook に変更
- `Event` モデルのバリデーションおよびコントローラーの permitted params からも除外

## Test plan

- [x] イベント作成・編集フォームに Webhook URL 入力欄が表示されないことを確認
- [x] `EventReminderJob` を手動実行し、前日対象イベントがあるとき `reminder` Webhook に一般リマインドと事前準備メッセージの両方が投稿されることを確認
- [x] `reminder` Webhook 未設定の場合にエラーが発生しないことを確認

Closes #268