### PR TITLE
style: イベント詳細画面の管理者用ボタン名称を改善する

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -29,9 +29,9 @@
           <%= link_to "ローテーション作成", new_event_rotation_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <% if @event.broadcast_url.present? %>
             <%= link_to "タイムスタンプ一括設定", edit_timestamps_event_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
-            <%= button_to "解析開始", trigger_analysis_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で動画解析を開始しますか？完了後にタイムスタンプが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+            <%= button_to "タイムスタンプ解析開始", trigger_analysis_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で動画解析を開始しますか？完了後にタイムスタンプが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <% end %>
-          <%= button_to "統計スクレイピング開始", trigger_scraping_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で統計スクレイピングを開始しますか？完了後に統計データが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+          <%= button_to "統計取得開始", trigger_scraping_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で統計スクレイピングを開始しますか？完了後に統計データが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= link_to "編集", edit_event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
           <%= button_to "削除", event_path(@event), method: :delete, data: { turbo_confirm: "イベント「#{@event.name}」を削除してもよろしいですか？関連する試合やローテーションもすべて削除されます。" }, class: "bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
         </div>


### PR DESCRIPTION
## Summary
- 「解析開始」→「タイムスタンプ解析開始」：動画解析でタイムスタンプを登録する機能であることを明示
- 「統計スクレイピング開始」→「統計取得開始」：文字数を削減しつつ意味を保持

## Test plan
- [x] 管理者ユーザーでイベント詳細画面を開き、ボタンラベルが変更されていることを確認
- [x] 「タイムスタンプ解析開始」ボタンが broadcast_url 設定済みイベントのみ表示されることを確認
- [x] 各ボタン押下時に確認ダイアログが表示されることを確認
- [x] 一般ユーザーにはボタンが表示されないことを確認

Closes #270