### PR TITLE
chore: AGENTS.md を gitignore 対象に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@
 # Ignore Claude Code files
 /claude_conversations.md
 /CLAUDE.md
+/AGENTS.md
 
 # Ignore Kamal secrets (contains credentials)
 /.kamal/secrets


### PR DESCRIPTION
## Summary
- `.gitignore` に `AGENTS.md` を追加
- `CLAUDE.md` と同様に AGENTS.md をローカル専用ファイルとして扱うように統一

## Test plan
- [x] `git status --ignored --short AGENTS.md .gitignore` を実行し、`AGENTS.md` が ignore 対象になることを確認

Closes #273