### PR TITLE
refactor: 試合・ローテーション周りの重複ロジックを整理

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -123,7 +123,7 @@ class DashboardController < ApplicationController
     user_suit_stats = Hash.new { |h, k| h[k] = { count: 0, wins: 0 } }
     @all_user_matches.each do |mp|
       user_suit_stats[mp.mobile_suit][:count] += 1
-      user_suit_stats[mp.mobile_suit][:wins] += 1 if mp.match.winning_team == mp.team_number
+      user_suit_stats[mp.mobile_suit][:wins] += 1 if mp.won?
     end
     @user_favorite_suits = user_suit_stats.sort_by { |_, stats| -stats[:count] }
                                           .take(3)
@@ -194,10 +194,7 @@ class DashboardController < ApplicationController
     # 現在のユーザーの次の試合を取得（メモリ内で検索）
     @user_next_rotation_match = @active_rotation.rotation_matches.find do |rm|
       rm.match_index >= @active_rotation.current_match_index &&
-      (rm.team1_player1_id == viewing_as_user.id ||
-       rm.team1_player2_id == viewing_as_user.id ||
-       rm.team2_player1_id == viewing_as_user.id ||
-       rm.team2_player2_id == viewing_as_user.id)
+      rm.includes_player?(viewing_as_user.id)
     end
 
     if @user_next_rotation_match
@@ -207,7 +204,7 @@ class DashboardController < ApplicationController
       @opponent_players = @match_info[:opponents]
 
       # 配信担当かどうか
-      @is_streaming = (@user_next_rotation_match.team1_player1_id == viewing_as_user.id)
+      @is_streaming = @user_next_rotation_match.streaming_for?(viewing_as_user.id)
     end
   end
 
@@ -241,12 +238,12 @@ class DashboardController < ApplicationController
 
     # 直近5試合の勝敗を計算（新しい順）
     @recent_5_results = recent_match_players.take(5).map do |mp|
-      mp.match.winning_team == mp.team_number
+      mp.won?
     end
 
     # 直近10試合の勝率
     recent_10_results = recent_match_players.map do |mp|
-      mp.match.winning_team == mp.team_number
+      mp.won?
     end
 
     if recent_10_results.any?
@@ -268,7 +265,7 @@ class DashboardController < ApplicationController
       next if streak_seen_match_ids.include?(mp.match_id)
       streak_seen_match_ids.add(mp.match_id)
 
-      is_win = mp.match.winning_team == mp.team_number
+      is_win = mp.won?
 
       if @streak_type.nil?
         # 最新の試合で連勝/連敗のタイプを決定
@@ -292,9 +289,8 @@ class DashboardController < ApplicationController
       match = my_mp.match
       my_team = my_mp.team_number
 
-      # 同じチームのパートナーを見つける（既にincludesで読み込み済み）
-      # .to_aで配列化してメモリ内で検索
-      partner_mp = match.match_players.to_a.find { |mp| mp.team_number == my_team && mp.user_id != viewing_as_user.id }
+      # 同じチームのパートナーを取得（既にincludesで読み込み済み）
+      partner_mp = my_mp.partner
       next unless partner_mp
 
       partner_id = partner_mp.user_id
@@ -306,7 +302,7 @@ class DashboardController < ApplicationController
       }
 
       # 勝敗判定
-      is_win = (match.winning_team == my_team)
+      is_win = match.won_by?(my_team)
       partners_stats[partner_id][:wins] += 1 if is_win
       partners_stats[partner_id][:total] += 1
 
@@ -352,7 +348,7 @@ class DashboardController < ApplicationController
 
       suit_stats[suit_id][:usage] += 1
 
-      is_win = (mp.match.winning_team == mp.team_number)
+      is_win = mp.won?
       suit_stats[suit_id][:wins] += 1 if is_win
     end
 
@@ -379,7 +375,7 @@ class DashboardController < ApplicationController
       event_matches = @all_user_matches.select { |mp| mp.match.event_id == event.id }
 
       total = event_matches.size
-      wins = event_matches.count { |mp| mp.match.winning_team == mp.team_number }
+      wins = event_matches.count(&:won?)
 
       stats_mps = event_matches.select(&:has_stats?)
       avg_damage = stats_mps.any? ? (stats_mps.sum { |mp| mp.damage_dealt.to_i }.to_f / stats_mps.size).round(0).to_i : nil
@@ -406,8 +402,7 @@ class DashboardController < ApplicationController
       my_cost = my_mp.mobile_suit.cost
 
       # パートナーのコストを取得（既にincludesで読み込み済み）
-      # .to_aで配列化してメモリ内で検索
-      partner_mp = match.match_players.to_a.find { |mp| mp.team_number == my_team && mp.user_id != viewing_as_user.id }
+      partner_mp = my_mp.partner
       next unless partner_mp
 
       partner_cost = partner_mp.mobile_suit.cost
@@ -418,7 +413,7 @@ class DashboardController < ApplicationController
 
       cost_stats[cost_key][:total] += 1
 
-      is_win = (match.winning_team == my_team)
+      is_win = match.won_by?(my_team)
       cost_stats[cost_key][:wins] += 1 if is_win
     end
 
@@ -514,18 +509,13 @@ class DashboardController < ApplicationController
       my_matches.each do |my_mp|
         match = my_mp.match
         my_team = my_mp.team_number
-        opponent_team = my_team == 1 ? 2 : 1
-
         # 相手チームの機体を取得（既にincludesで読み込み済み）
-        # .to_aで配列化してメモリ内で検索
-        match.match_players.to_a.each do |opp_mp|
-          next unless opp_mp.team_number == opponent_team
-
+        my_mp.opponents.each do |opp_mp|
           opp_suit_id = opp_mp.mobile_suit_id
           opponent_stats[opp_suit_id][:mobile_suit] = opp_mp.mobile_suit
           opponent_stats[opp_suit_id][:total] += 1
 
-          is_win = (match.winning_team == my_team)
+          is_win = match.won_by?(my_team)
           opponent_stats[opp_suit_id][:wins] += 1 if is_win
         end
       end

--- a/app/controllers/mobile_suits_controller.rb
+++ b/app/controllers/mobile_suits_controller.rb
@@ -23,7 +23,7 @@ class MobileSuitsController < ApplicationController
                           .includes(:user, match: { match_players: :mobile_suit })
 
     @total_uses = suit_mps.count
-    wins        = suit_mps.count { |mp| mp.match.winning_team == mp.team_number }
+    wins        = suit_mps.count(&:won?)
     @win_rate   = @total_uses > 0 ? (wins.to_f / @total_uses * 100).round(1) : 0.0
     @dominance  = (@win_rate * @total_uses).round(1)
 
@@ -60,7 +60,7 @@ class MobileSuitsController < ApplicationController
 
     # プレイヤーランキング TOP5
     @player_ranking = suit_mps.group_by(&:user_id).map do |_, mps|
-      wins_n  = mps.count { |mp| mp.match.winning_team == mp.team_number }
+      wins_n  = mps.count(&:won?)
       total_n = mps.count
       {
         user:     mps.first.user,
@@ -72,15 +72,13 @@ class MobileSuitsController < ApplicationController
     # 相方機体別分析
     partner_suit_data = Hash.new { |h, k| h[k] = { mobile_suit: nil, wins: 0, total: 0 } }
     suit_mps.each do |my_mp|
-      partner_mp = my_mp.match.match_players.find do |mp|
-        mp.team_number == my_mp.team_number && mp.mobile_suit_id != @suit.id
-      end
+      partner_mp = my_mp.partner
       next unless partner_mp
 
       pid = partner_mp.mobile_suit_id
       partner_suit_data[pid][:mobile_suit] = partner_mp.mobile_suit
       partner_suit_data[pid][:total] += 1
-      partner_suit_data[pid][:wins] += 1 if my_mp.match.winning_team == my_mp.team_number
+      partner_suit_data[pid][:wins] += 1 if my_mp.won?
     end
 
     @partner_suits = partner_suit_data.map do |_, d|
@@ -96,14 +94,12 @@ class MobileSuitsController < ApplicationController
     # 相方コスト別分析
     partner_cost_data = Hash.new { |h, k| h[k] = { wins: 0, total: 0 } }
     suit_mps.each do |my_mp|
-      partner_mp = my_mp.match.match_players.find do |mp|
-        mp.team_number == my_mp.team_number && mp.mobile_suit_id != @suit.id
-      end
+      partner_mp = my_mp.partner
       next unless partner_mp
 
       cost = partner_mp.mobile_suit.cost
       partner_cost_data[cost][:total] += 1
-      partner_cost_data[cost][:wins] += 1 if my_mp.match.winning_team == my_mp.team_number
+      partner_cost_data[cost][:wins] += 1 if my_mp.won?
     end
 
     @partner_costs = partner_cost_data.map do |cost, d|

--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -19,9 +19,7 @@ class RotationsController < ApplicationController
 
     # プレイヤーのお気に入り機体を N+1 を起こさずまとめてロード
     if @current_match
-      players = [ @current_match.team1_player1, @current_match.team1_player2,
-                  @current_match.team2_player1, @current_match.team2_player2 ].compact
-      ActiveRecord::Associations::Preloader.new(records: players, associations: :user_favorite_suits).call
+      ActiveRecord::Associations::Preloader.new(records: @current_match.players, associations: :user_favorite_suits).call
     end
 
     # Check if we should show completion modal
@@ -170,16 +168,11 @@ class RotationsController < ApplicationController
     )
 
     # Build match players before saving
-    [
-      { user: rotation_match.team1_player1, mobile_suit_id: params[:team1_player1_suit], team: 1, position: 1 },
-      { user: rotation_match.team1_player2, mobile_suit_id: params[:team1_player2_suit], team: 1, position: 2 },
-      { user: rotation_match.team2_player1, mobile_suit_id: params[:team2_player1_suit], team: 2, position: 3 },
-      { user: rotation_match.team2_player2, mobile_suit_id: params[:team2_player2_suit], team: 2, position: 4 }
-    ].each do |mp|
+    rotation_match.match_player_attributes(rotation_match_suit_ids).each do |mp|
       match.match_players.build(
         user: mp[:user],
         mobile_suit_id: mp[:mobile_suit_id],
-        team_number: mp[:team],
+        team_number: mp[:team_number],
         position: mp[:position]
       )
     end
@@ -259,16 +252,11 @@ class RotationsController < ApplicationController
 
     # Update match players
     match.match_players.destroy_all
-    [
-      { user: rotation_match.team1_player1, mobile_suit_id: params[:team1_player1_suit], team: 1, position: 1 },
-      { user: rotation_match.team1_player2, mobile_suit_id: params[:team1_player2_suit], team: 1, position: 2 },
-      { user: rotation_match.team2_player1, mobile_suit_id: params[:team2_player1_suit], team: 2, position: 3 },
-      { user: rotation_match.team2_player2, mobile_suit_id: params[:team2_player2_suit], team: 2, position: 4 }
-    ].each do |mp|
+    rotation_match.match_player_attributes(rotation_match_suit_ids).each do |mp|
       match.match_players.build(
         user: mp[:user],
         mobile_suit_id: mp[:mobile_suit_id],
-        team_number: mp[:team],
+        team_number: mp[:team_number],
         position: mp[:position]
       )
     end
@@ -293,9 +281,7 @@ class RotationsController < ApplicationController
 
     # Re-generate rotation matches with reshuffled player slots so that streaming
     # patterns differ between rounds (same opponents/partners when streaming)
-    player_ids = @rotation.rotation_matches.flat_map { |rm|
-      [ rm.team1_player1_id, rm.team1_player2_id, rm.team2_player1_id, rm.team2_player2_id ]
-    }.uniq.compact
+    player_ids = @rotation.rotation_matches.flat_map(&:player_ids).uniq
     generate_rotation_matches(new_rotation, player_ids)
 
     # Deactivate all rotations for this event
@@ -357,9 +343,7 @@ class RotationsController < ApplicationController
                                .order(:match_index)
 
     # 全プレイヤーのIDを収集
-    all_player_ids = rotation_matches.flat_map do |rm|
-      [ rm.team1_player1_id, rm.team1_player2_id, rm.team2_player1_id, rm.team2_player2_id ]
-    end.compact.uniq
+    all_player_ids = rotation_matches.flat_map(&:player_ids).uniq
 
     # 各プレイヤーの「次の試合」を特定して通知
     all_player_ids.each do |player_id|
@@ -367,10 +351,7 @@ class RotationsController < ApplicationController
       next_match = rotation_matches.find do |rm|
         rm.match_index >= current_index &&
         rm.match_id.nil? &&
-        (rm.team1_player1_id == player_id ||
-         rm.team1_player2_id == player_id ||
-         rm.team2_player1_id == player_id ||
-         rm.team2_player2_id == player_id)
+        rm.includes_player?(player_id)
       end
 
       next unless next_match
@@ -381,7 +362,7 @@ class RotationsController < ApplicationController
       next if matches_until > 2
 
       # 座席情報とパートナーを特定
-      seat_info = determine_seat_info(next_match, player_id)
+      seat_info = next_match.seat_info_for(player_id)
       user = User.find_by(id: player_id)
       next unless user
 
@@ -406,24 +387,18 @@ class RotationsController < ApplicationController
     end
   end
 
-  def determine_seat_info(rotation_match, player_id)
-    case player_id
-    when rotation_match.team1_player1_id
-      { seat: :seat_1, partner: rotation_match.team1_player2 }  # 1番席（配信台）
-    when rotation_match.team1_player2_id
-      { seat: :seat_2, partner: rotation_match.team1_player1 }  # 2番席（配信台の隣）
-    when rotation_match.team2_player1_id
-      { seat: :seat_3, partner: rotation_match.team2_player2 }  # 3番席
-    when rotation_match.team2_player2_id
-      { seat: :seat_4, partner: rotation_match.team2_player1 }  # 4番席
-    else
-      { seat: nil, partner: nil }
-    end
-  end
-
   def mark_current_match_started(rotation)
     rm = rotation.rotation_matches.find_by(match_index: rotation.current_match_index)
     rm&.update!(started_at: Time.current) if rm && rm.started_at.nil?
+  end
+
+  def rotation_match_suit_ids
+    {
+      team1_player1: params[:team1_player1_suit],
+      team1_player2: params[:team1_player2_suit],
+      team2_player1: params[:team2_player1_suit],
+      team2_player2: params[:team2_player2_suit]
+    }
   end
 
   def generate_rotation_matches(rotation, player_ids)

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,4 +1,6 @@
 class StatisticsController < ApplicationController
+  PERSONAL_TABS = %w[overview performance events event_progression mobile_suits opponent_suits partners opponents].freeze
+
   before_action :authenticate_user!
   before_action :set_regular_users
   before_action :set_filters
@@ -8,8 +10,7 @@ class StatisticsController < ApplicationController
     @active_tab = params[:tab] || "overall"
 
     # ゲストユーザー（または管理者がゲスト視点切り替え中）は個人統計タブにアクセス不可
-    personal_tabs = %w[overview performance events event_progression mobile_suits opponent_suits partners opponents]
-    if viewing_as_user.is_guest && personal_tabs.include?(@active_tab)
+    if viewing_as_user.is_guest && PERSONAL_TABS.include?(@active_tab)
       redirect_to statistics_path(tab: "overall"), alert: "ゲストユーザーには個人統計データがありません"
       return
     end
@@ -69,10 +70,10 @@ class StatisticsController < ApplicationController
   end
 
   def set_filters
-    @filter_events = params[:events].present? ? params[:events].map(&:to_i) : []
-    @filter_mobile_suits = params[:mobile_suits].present? ? params[:mobile_suits].map(&:to_i) : []
-    @filter_partners = params[:partners].present? ? params[:partners].map(&:to_i) : []
-    @filter_costs = params[:costs].present? ? params[:costs].map(&:to_i) : []
+    @filter_events = selected_ids(:events)
+    @filter_mobile_suits = selected_ids(:mobile_suits)
+    @filter_partners = selected_ids(:partners)
+    @filter_costs = selected_ids(:costs)
   end
 
   def apply_filters
@@ -98,23 +99,11 @@ class StatisticsController < ApplicationController
 
     # パートナーフィルター
     if @filter_partners.any?
-      # パートナーが参加している試合を取得
-      partner_match_ids = MatchPlayer.where(user_id: @filter_partners)
-                                     .pluck(:match_id)
-                                     .uniq
-
       # ログインユーザーとパートナーが同じチームの試合に絞り込む
       filtered_match_ids = []
       @filtered_matches.each do |my_mp|
-        match = my_mp.match
-        my_team = my_mp.team_number
-
-        # この試合にパートナーが同じチームで参加しているか確認
-        partner_in_same_team = match.match_players.any? do |mp|
-          @filter_partners.include?(mp.user_id) && mp.team_number == my_team
-        end
-
-        filtered_match_ids << match.id if partner_in_same_team
+        partner_mp = my_mp.partner
+        filtered_match_ids << my_mp.match_id if partner_mp && @filter_partners.include?(partner_mp.user_id)
       end
 
       @filtered_matches = @filtered_matches.where(matches: { id: filtered_match_ids.uniq })
@@ -133,7 +122,7 @@ class StatisticsController < ApplicationController
     @total_matches = @filtered_matches.count
 
     wins = @filtered_matches.count do |mp|
-      mp.match.winning_team == mp.team_number
+      mp.won?
     end
     @total_wins = wins
     @win_rate = @total_matches > 0 ? (wins.to_f / @total_matches * 100).round(1) : 0
@@ -159,7 +148,7 @@ class StatisticsController < ApplicationController
     current_streak = 0
 
     all_matches.each do |mp|
-      if mp.match.winning_team == mp.team_number
+      if mp.won?
         current_streak += 1
         max_streak = [ max_streak, current_streak ].max
       else
@@ -184,7 +173,7 @@ class StatisticsController < ApplicationController
       }
 
       events_data[event_id][:total] += 1
-      events_data[event_id][:wins] += 1 if mp.match.winning_team == mp.team_number
+      events_data[event_id][:wins] += 1 if mp.won?
     end
 
     events_data.map do |event_id, data|
@@ -204,15 +193,13 @@ class StatisticsController < ApplicationController
       my_team = my_mp.team_number
       my_cost = my_mp.mobile_suit.cost
 
-      partner_mp = match.match_players.find do |mp|
-        mp.team_number == my_team && mp.user_id != viewing_as_user.id
-      end
+      partner_mp = my_mp.partner
 
       partner_cost = partner_mp&.mobile_suit&.cost
       cost_key = [ my_cost, partner_cost ]
 
       cost_data[cost_key][:total] += 1
-      cost_data[cost_key][:wins] += 1 if match.winning_team == my_team
+      cost_data[cost_key][:wins] += 1 if match.won_by?(my_team)
     end
 
     cost_data.map do |cost_key, data|
@@ -242,7 +229,7 @@ class StatisticsController < ApplicationController
         round_number = match.rotation_match.rotation.round_number
 
         round_data[round_number][:total] += 1
-        round_data[round_number][:wins] += 1 if match.winning_team == my_mp.team_number
+        round_data[round_number][:wins] += 1 if my_mp.won?
       end
     end
 
@@ -270,19 +257,16 @@ class StatisticsController < ApplicationController
 
     @filtered_matches.each do |my_mp|
       match = my_mp.match
-      my_team = my_mp.team_number
 
       # パートナーを見つける
-      partner_mp = match.match_players.find do |mp|
-        mp.team_number == my_team && mp.user_id != viewing_as_user.id
-      end
+      partner_mp = my_mp.partner
 
       next unless partner_mp
 
       partner_id = partner_mp.user_id
       partner_data[partner_id][:user] = partner_mp.user
       partner_data[partner_id][:total] += 1
-      partner_data[partner_id][:wins] += 1 if match.winning_team == my_team
+      partner_data[partner_id][:wins] += 1 if my_mp.won?
 
       # 機体の組み合わせを記録
       combo_key = "#{my_mp.mobile_suit.name} & #{partner_mp.mobile_suit.name}"
@@ -333,17 +317,14 @@ class StatisticsController < ApplicationController
       match = my_mp.match
       my_team = my_mp.team_number
       suit_id = my_mp.mobile_suit_id
-      opponent_team = my_team == 1 ? 2 : 1
 
       # 使用機体の統計
       suit_data[suit_id][:mobile_suit] = my_mp.mobile_suit
       suit_data[suit_id][:total] += 1
-      suit_data[suit_id][:wins] += 1 if match.winning_team == my_team
+      suit_data[suit_id][:wins] += 1 if match.won_by?(my_team)
 
       # パートナーの機体を記録
-      partner_mp = match.match_players.find do |mp|
-        mp.team_number == my_team && mp.user_id != viewing_as_user.id
-      end
+      partner_mp = my_mp.partner
 
       if partner_mp
         suit_data[suit_id][:partner_suits][partner_mp.mobile_suit.name] += 1
@@ -358,11 +339,11 @@ class StatisticsController < ApplicationController
       end
 
       # 対戦機体の統計
-      match.match_players.select { |mp| mp.team_number == opponent_team }.each do |opponent_mp|
+      my_mp.opponents.each do |opponent_mp|
         opp_suit_id = opponent_mp.mobile_suit_id
         opponent_suit_data[opp_suit_id][:mobile_suit] = opponent_mp.mobile_suit
         opponent_suit_data[opp_suit_id][:total] += 1
-        opponent_suit_data[opp_suit_id][:wins] += 1 if match.winning_team == my_team
+        opponent_suit_data[opp_suit_id][:wins] += 1 if match.won_by?(my_team)
 
         # 最終対戦日を更新
         if opponent_suit_data[opp_suit_id][:last_faced_at].nil? || match.played_at > opponent_suit_data[opp_suit_id][:last_faced_at]
@@ -416,13 +397,11 @@ class StatisticsController < ApplicationController
 
       event_data[event_id][:event] = match.event
       event_data[event_id][:total] += 1
-      event_data[event_id][:wins] += 1 if match.winning_team == my_team
+      event_data[event_id][:wins] += 1 if match.won_by?(my_team)
       event_data[event_id][:suits_used][my_mp.mobile_suit.name] += 1
 
       # パートナーを記録
-      partner_mp = match.match_players.find do |mp|
-        mp.team_number == my_team && mp.user_id != viewing_as_user.id
-      end
+      partner_mp = my_mp.partner
 
       if partner_mp
         event_data[event_id][:partners][partner_mp.user.nickname] += 1
@@ -454,15 +433,13 @@ class StatisticsController < ApplicationController
 
     @filtered_matches.each do |my_mp|
       match = my_mp.match
-      my_team = my_mp.team_number
-      opponent_team = my_team == 1 ? 2 : 1
 
       # 対戦相手を取得
-      match.match_players.select { |mp| mp.team_number == opponent_team }.each do |opponent_mp|
+      my_mp.opponents.each do |opponent_mp|
         opponent_id = opponent_mp.user_id
         opponent_data[opponent_id][:user] = opponent_mp.user
         opponent_data[opponent_id][:total] += 1
-        opponent_data[opponent_id][:wins] += 1 if match.winning_team == my_team
+        opponent_data[opponent_id][:wins] += 1 if my_mp.won?
         opponent_data[opponent_id][:suits_used][opponent_mp.mobile_suit.name] += 1
 
         # 最終対戦日を更新
@@ -511,7 +488,7 @@ class StatisticsController < ApplicationController
 
         event_progression_data[event_id][:rotations][rotation_id][:rotation_name] = "#{round_number}周目"
         event_progression_data[event_id][:rotations][rotation_id][:total] += 1
-        event_progression_data[event_id][:rotations][rotation_id][:wins] += 1 if match.winning_team == my_team
+        event_progression_data[event_id][:rotations][rotation_id][:wins] += 1 if match.won_by?(my_team)
         event_progression_data[event_id][:rotations][rotation_id][:matches] << my_mp
       end
     end
@@ -543,7 +520,7 @@ class StatisticsController < ApplicationController
           slice = sorted_matches[start_idx...end_idx]
           next if slice.nil? || slice.empty?
 
-          wins = slice.count { |mp| mp.match.winning_team == mp.team_number }
+          wins = slice.count(&:won?)
           total = slice.size
           {
             rotation_name: "第#{i}ターム",
@@ -558,7 +535,7 @@ class StatisticsController < ApplicationController
       end
 
       all_total = data[:all_matches].size
-      all_wins  = data[:all_matches].count { |mp| mp.match.winning_team == mp.team_number }
+      all_wins  = data[:all_matches].count(&:won?)
 
       {
         event: data[:event],
@@ -573,8 +550,8 @@ class StatisticsController < ApplicationController
 
   def calculate_performance_stats
     stats_mps = @filtered_matches.select(&:has_stats?)
-    win_mps  = stats_mps.select { |mp| mp.match.winning_team == mp.team_number }
-    loss_mps = stats_mps.reject { |mp| mp.match.winning_team == mp.team_number }
+    win_mps  = stats_mps.select(&:won?)
+    loss_mps = stats_mps.reject(&:won?)
 
     # 機体/コストフィルター適用時: フィルターなしの自分の全体平均・同コスト帯平均を算出（比較用）
     if @filter_mobile_suits.any? || @filter_costs.any?
@@ -586,11 +563,11 @@ class StatisticsController < ApplicationController
       all_user_records = all_user_mps.to_a
       all_stats = all_user_records.select(&:has_stats?)
       @user_overall_avg    = calc_perf_stats(all_stats)
-      @user_overall_wins   = calc_perf_stats(all_stats.select { |mp| mp.match.winning_team == mp.team_number })
-      @user_overall_losses = calc_perf_stats(all_stats.reject { |mp| mp.match.winning_team == mp.team_number })
+      @user_overall_wins   = calc_perf_stats(all_stats.select(&:won?))
+      @user_overall_losses = calc_perf_stats(all_stats.reject(&:won?))
 
       # EXバースト活用分析の自己比較用データ（フィルターなし全体）
-      all_loss_stats = all_stats.reject { |mp| mp.match.winning_team == mp.team_number }
+      all_loss_stats = all_stats.reject(&:won?)
       if all_loss_stats.any?
         n = all_loss_stats.size
         @user_overall_ex_remaining_rate  = (all_loss_stats.count { |mp| mp.last_death_ex_available || mp.survive_loss_ex_available } * 100.0 / n).round(1)
@@ -599,8 +576,8 @@ class StatisticsController < ApplicationController
       end
 
       # OL分析の自己比較用データ（フィルターなし全体）
-      all_user_losses_ol = all_user_records.reject { |mp| mp.match.winning_team == mp.team_number }
-      all_user_wins_ol   = all_user_records.select { |mp| mp.match.winning_team == mp.team_number }
+      all_user_losses_ol = all_user_records.reject(&:won?)
+      all_user_wins_ol   = all_user_records.select(&:won?)
       if all_user_losses_ol.any?
         no_ol = all_user_losses_ol.count { |mp|
           flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
@@ -627,12 +604,12 @@ class StatisticsController < ApplicationController
       # 絞り込み済みデータと実質同一になる場合（例: コストのみフィルター）は表示しない
       if same_cost_stats.size != stats_mps.select(&:has_stats?).size
         @user_same_cost_avg    = calc_perf_stats(same_cost_stats)
-        @user_same_cost_wins   = calc_perf_stats(same_cost_stats.select { |mp| mp.match.winning_team == mp.team_number })
-        @user_same_cost_losses = calc_perf_stats(same_cost_stats.reject { |mp| mp.match.winning_team == mp.team_number })
+        @user_same_cost_wins   = calc_perf_stats(same_cost_stats.select(&:won?))
+        @user_same_cost_losses = calc_perf_stats(same_cost_stats.reject(&:won?))
         @same_cost_label = same_costs.sort.reverse.map { |c| "#{c}" }.join("・") + "コスト"
 
         # EXバースト - 同コスト帯
-        sc_loss_stats = same_cost_stats.reject { |mp| mp.match.winning_team == mp.team_number }
+        sc_loss_stats = same_cost_stats.reject(&:won?)
         if sc_loss_stats.any?
           n = sc_loss_stats.size
           @user_same_cost_ex_remaining_rate  = (sc_loss_stats.count { |mp| mp.last_death_ex_available || mp.survive_loss_ex_available } * 100.0 / n).round(1)
@@ -641,8 +618,8 @@ class StatisticsController < ApplicationController
         end
 
         # OL分析 - 同コスト帯
-        sc_losses_ol = same_cost_records.reject { |mp| mp.match.winning_team == mp.team_number }
-        sc_wins_ol   = same_cost_records.select { |mp| mp.match.winning_team == mp.team_number }
+        sc_losses_ol = same_cost_records.reject(&:won?)
+        sc_wins_ol   = same_cost_records.select(&:won?)
         if sc_losses_ol.any?
           no_ol = sc_losses_ol.count { |mp|
             flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
@@ -678,8 +655,8 @@ class StatisticsController < ApplicationController
     @survive_loss_ex_on_loss = loss_mps.count { |mp| mp.survive_loss_ex_available }
 
     # OL分析（全試合対象）
-    all_losses = @filtered_matches.reject { |mp| mp.match.winning_team == mp.team_number }
-    all_wins   = @filtered_matches.select { |mp| mp.match.winning_team == mp.team_number }
+    all_losses = @filtered_matches.reject(&:won?)
+    all_wins   = @filtered_matches.select(&:won?)
 
     @my_team_no_ol_losses = all_losses.count do |mp|
       team_ol = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
@@ -732,7 +709,7 @@ class StatisticsController < ApplicationController
       no_ol_loss_rates    = []
       opp_no_ol_win_rates = []
       ol_mps_all.group_by(&:user_id).each do |_uid, mps|
-        loss_mps = mps.select { |mp| mp.match.winning_team != mp.team_number }
+        loss_mps = mps.reject(&:won?)
         if loss_mps.any?
           no_ol = loss_mps.count { |mp|
             flag = mp.team_number == 1 ? mp.match.team1_ex_overlimit_before_end : mp.match.team2_ex_overlimit_before_end
@@ -740,7 +717,7 @@ class StatisticsController < ApplicationController
           }
           no_ol_loss_rates << (no_ol * 100.0 / loss_mps.size).round(1)
         end
-        win_mps = mps.select { |mp| mp.match.winning_team == mp.team_number }
+        win_mps = mps.select(&:won?)
         if win_mps.any?
           opp_no_ol = win_mps.count { |mp|
             flag = mp.team_number == 1 ? mp.match.team2_ex_overlimit_before_end : mp.match.team1_ex_overlimit_before_end
@@ -828,8 +805,8 @@ class StatisticsController < ApplicationController
       user_losses_list = []
       by_user.each do |_uid, mps|
         overall  = build_perf.call(mps)
-        win_mps  = mps.select { |mp| mp.match.winning_team == mp.team_number }
-        loss_mps = mps.select { |mp| mp.match.winning_team && mp.match.winning_team != mp.team_number }
+        win_mps  = mps.select(&:won?)
+        loss_mps = mps.reject(&:won?).select { |mp| mp.match.winning_team.present? }
         user_perf_list   << overall                    if overall
         user_wins_list   << build_perf.call(win_mps)   if win_mps.any?
         user_losses_list << build_perf.call(loss_mps)  if loss_mps.any?
@@ -1083,7 +1060,7 @@ class StatisticsController < ApplicationController
       suit_id = mp.mobile_suit_id
       suit_stats[suit_id] ||= { wins: 0, total: 0 }
       suit_stats[suit_id][:total] += 1
-      suit_stats[suit_id][:wins] += 1 if mp.match.winning_team == mp.team_number
+      suit_stats[suit_id][:wins] += 1 if mp.won?
     end
 
     @high_winrate_suits = suit_stats
@@ -1105,7 +1082,7 @@ class StatisticsController < ApplicationController
       cost = mp.mobile_suit.cost
       cost_stats[cost] ||= { wins: 0, total: 0 }
       cost_stats[cost][:total] += 1
-      cost_stats[cost][:wins] += 1 if mp.match.winning_team == mp.team_number
+      cost_stats[cost][:wins] += 1 if mp.won?
     end
 
     total_usage = cost_stats.values.sum { |s| s[:total] }
@@ -1155,5 +1132,9 @@ class StatisticsController < ApplicationController
         player_count: player_count
       }
     end
+  end
+
+  def selected_ids(param_key)
+    params[param_key].present? ? params[param_key].map(&:to_i) : []
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -20,6 +20,26 @@ class Match < ApplicationRecord
   validates :winning_team, presence: true, inclusion: { in: [ 1, 2 ] }
   validates :match_players, length: { is: 4 }
 
+  def won_by?(team_number)
+    winning_team == team_number
+  end
+
+  def partner_for(match_player_or_user_id)
+    my_match_player = resolve_match_player(match_player_or_user_id)
+    return unless my_match_player
+
+    team_match_players(my_match_player.team_number).find do |match_player|
+      match_player.user_id != my_match_player.user_id
+    end
+  end
+
+  def opponents_for(match_player_or_user_id)
+    my_match_player = resolve_match_player(match_player_or_user_id)
+    return [] unless my_match_player
+
+    match_players.select { |match_player| match_player.team_number != my_match_player.team_number }
+  end
+
   # イベント内での試合番号を取得（古い順に1から採番）
   def match_number
     event.matches.where("played_at < ?", played_at).count + 1
@@ -80,5 +100,17 @@ class Match < ApplicationRecord
     else
       reactions.where(master_emoji: master_emoji).includes(:user).map { |r| r.user.nickname }
     end
+  end
+
+  private
+
+  def team_match_players(team_number)
+    match_players.select { |match_player| match_player.team_number == team_number }
+  end
+
+  def resolve_match_player(match_player_or_user_id)
+    return match_player_or_user_id if match_player_or_user_id.is_a?(MatchPlayer)
+
+    match_players.find { |match_player| match_player.user_id == match_player_or_user_id }
   end
 end

--- a/app/models/match_player.rb
+++ b/app/models/match_player.rb
@@ -14,4 +14,16 @@ class MatchPlayer < ApplicationRecord
     score.present? || kills.present? || deaths.present? ||
       damage_dealt.present? || damage_received.present? || exburst_damage.present?
   end
+
+  def won?
+    match.won_by?(team_number)
+  end
+
+  def partner
+    match.partner_for(self)
+  end
+
+  def opponents
+    match.opponents_for(self)
+  end
 end

--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -13,13 +13,8 @@ class Rotation < ApplicationRecord
     "#{round_number}周目"
   end
 
-  # Get all unique players in this rotation
   def players
-    player_ids = rotation_matches.flat_map do |rm|
-      [ rm.team1_player1_id, rm.team1_player2_id, rm.team2_player1_id, rm.team2_player2_id ]
-    end.uniq
-
-    User.where(id: player_ids)
+    User.where(id: rotation_matches.flat_map(&:player_ids).uniq)
   end
 
   def player_count
@@ -49,7 +44,7 @@ class Rotation < ApplicationRecord
     end
 
     scope.each do |rm|
-      all_players = [ rm.team1_player1, rm.team1_player2, rm.team2_player1, rm.team2_player2 ]
+      all_players = rm.players
       registered = rm.match.present?
 
       # Update match counts
@@ -60,19 +55,19 @@ class Rotation < ApplicationRecord
       end
 
       # Update streaming seat (team1_player1) counts
-      streamer = rm.team1_player1
+      streamer = rm.team1_players.first
       stats[streamer.id][:streaming_count] += 1
       stats[streamer.id][:registered_streaming_count] += 1 if registered
 
       # Update pair counts
-      [ [ rm.team1_player1, rm.team1_player2 ], [ rm.team2_player1, rm.team2_player2 ] ].each do |pair|
+      [ rm.team1_players, rm.team2_players ].each do |pair|
         stats[pair[0].id][:pair_counts][pair[1].id] += 1
         stats[pair[1].id][:pair_counts][pair[0].id] += 1
       end
 
       # Update opponent counts
-      [ rm.team1_player1, rm.team1_player2 ].each do |team1_player|
-        [ rm.team2_player1, rm.team2_player2 ].each do |team2_player|
+      rm.team1_players.each do |team1_player|
+        rm.team2_players.each do |team2_player|
           stats[team1_player.id][:opponent_counts][team2_player.id] += 1
           stats[team2_player.id][:opponent_counts][team1_player.id] += 1
         end
@@ -96,16 +91,9 @@ class Rotation < ApplicationRecord
 
   # Get player's partner and opponents for a specific match
   def match_info_for_player(rotation_match, player_id)
-    if rotation_match.team1_player1_id == player_id
-      { partner: rotation_match.team1_player2, opponents: [ rotation_match.team2_player1, rotation_match.team2_player2 ] }
-    elsif rotation_match.team1_player2_id == player_id
-      { partner: rotation_match.team1_player1, opponents: [ rotation_match.team2_player1, rotation_match.team2_player2 ] }
-    elsif rotation_match.team2_player1_id == player_id
-      { partner: rotation_match.team2_player2, opponents: [ rotation_match.team1_player1, rotation_match.team1_player2 ] }
-    elsif rotation_match.team2_player2_id == player_id
-      { partner: rotation_match.team2_player1, opponents: [ rotation_match.team1_player1, rotation_match.team1_player2 ] }
-    else
-      nil
-    end
+    seat_info = rotation_match.seat_info_for(player_id)
+    return nil unless seat_info[:seat]
+
+    seat_info.slice(:partner, :opponents)
   end
 end

--- a/app/models/rotation_match.rb
+++ b/app/models/rotation_match.rb
@@ -1,4 +1,43 @@
 class RotationMatch < ApplicationRecord
+  PLAYER_SLOTS = [
+    {
+      player_key: :team1_player1,
+      id_key: :team1_player1_id,
+      team_number: 1,
+      position: 1,
+      seat: :seat_1,
+      partner_key: :team1_player2,
+      opponent_keys: %i[team2_player1 team2_player2]
+    },
+    {
+      player_key: :team1_player2,
+      id_key: :team1_player2_id,
+      team_number: 1,
+      position: 2,
+      seat: :seat_2,
+      partner_key: :team1_player1,
+      opponent_keys: %i[team2_player1 team2_player2]
+    },
+    {
+      player_key: :team2_player1,
+      id_key: :team2_player1_id,
+      team_number: 2,
+      position: 3,
+      seat: :seat_3,
+      partner_key: :team2_player2,
+      opponent_keys: %i[team1_player1 team1_player2]
+    },
+    {
+      player_key: :team2_player2,
+      id_key: :team2_player2_id,
+      team_number: 2,
+      position: 4,
+      seat: :seat_4,
+      partner_key: :team2_player1,
+      opponent_keys: %i[team1_player1 team1_player2]
+    }
+  ].freeze
+
   # Associations
   belongs_to :rotation
   belongs_to :team1_player1, class_name: "User"
@@ -12,8 +51,60 @@ class RotationMatch < ApplicationRecord
   validates :match_index, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :match_index, uniqueness: { scope: :rotation_id }
 
-  # Get all players in this match
   def players
-    [ team1_player1, team1_player2, team2_player1, team2_player2 ]
+    PLAYER_SLOTS.filter_map { |slot| public_send(slot[:player_key]) }
+  end
+
+  def team1_players
+    [ team1_player1, team1_player2 ].compact
+  end
+
+  def team2_players
+    [ team2_player1, team2_player2 ].compact
+  end
+
+  def player_ids
+    PLAYER_SLOTS.filter_map { |slot| public_send(slot[:id_key]) }
+  end
+
+  def includes_player?(player_or_id)
+    player_ids.include?(extract_player_id(player_or_id))
+  end
+
+  def streaming_for?(player_or_id)
+    extract_player_id(player_or_id) == team1_player1_id
+  end
+
+  def seat_info_for(player_or_id)
+    slot = slot_for(player_or_id)
+    return { seat: nil, partner: nil, opponents: [] } unless slot
+
+    {
+      seat: slot[:seat],
+      partner: public_send(slot[:partner_key]),
+      opponents: slot[:opponent_keys].filter_map { |key| public_send(key) }
+    }
+  end
+
+  def match_player_attributes(mobile_suit_ids)
+    PLAYER_SLOTS.map do |slot|
+      {
+        user: public_send(slot[:player_key]),
+        mobile_suit_id: mobile_suit_ids[slot[:player_key]],
+        team_number: slot[:team_number],
+        position: slot[:position]
+      }
+    end
+  end
+
+  private
+
+  def slot_for(player_or_id)
+    player_id = extract_player_id(player_or_id)
+    PLAYER_SLOTS.find { |slot| public_send(slot[:id_key]) == player_id }
+  end
+
+  def extract_player_id(player_or_id)
+    player_or_id.respond_to?(:id) ? player_or_id.id : player_or_id
   end
 end

--- a/app/services/push_notification_service.rb
+++ b/app/services/push_notification_service.rb
@@ -108,9 +108,7 @@ class PushNotificationService
     end
 
     def collect_player_ids(rotation)
-      rotation.rotation_matches.flat_map do |rm|
-        [ rm.team1_player1_id, rm.team1_player2_id, rm.team2_player1_id, rm.team2_player2_id ]
-      end.compact.uniq
+      rotation.rotation_matches.flat_map(&:player_ids).uniq
     end
   end
 end


### PR DESCRIPTION
## Summary
- `Match` / `MatchPlayer` に勝敗判定・パートナー取得・対戦相手取得の共通メソッドを追加
- `RotationMatch` に4席の参加者・座席情報・試合登録用属性生成を集約し、`Rotation` / `RotationsController` / `PushNotificationService` の重複を削減
- `DashboardController` / `StatisticsController` / `MobileSuitsController` の重複した勝敗・パートナー判定ロジックを共通メソッド利用に置き換え

## Test plan
- [x] `RUBOCOP_CACHE_ROOT=/tmp/rubocop_cache bundle exec rubocop app/models/match.rb app/models/match_player.rb app/models/rotation.rb app/models/rotation_match.rb app/controllers/dashboard_controller.rb app/controllers/mobile_suits_controller.rb app/controllers/rotations_controller.rb app/controllers/statistics_controller.rb app/services/push_notification_service.rb`
- [x] `bundle exec rails zeitwerk:check`

Closes #275