### PR TITLE
refactor: ダッシュボードと統計の集計ロジックを service に分離

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -13,10 +13,7 @@ class DashboardController < ApplicationController
   private
 
   def render_admin_dashboard
-    # 基本統計
-    @total_matches = Match.count
-    @total_events = Event.count
-    @total_users = User.regular_users.count
+    set_global_totals
 
     # 今日のイベント
     @today_event = Event.where(held_on: Time.zone.today).first
@@ -63,77 +60,20 @@ class DashboardController < ApplicationController
   end
 
   def render_player_dashboard
-    # 基本統計
-    @total_matches = Match.count
-    @total_events = Event.count
-    @total_users = User.regular_users.count
+    set_global_totals
 
     # 全試合データを一度だけ読み込み（Eager Loading）
     load_all_user_matches
 
-    # 個人統計
-    calculate_personal_stats
-
-    # リアルタイム待機状況（今日のイベント）
-    calculate_realtime_status
+    assign_view_state(
+      PlayerDashboardSnapshot.new(user: viewing_as_user, match_players: @all_user_matches).to_h
+    )
+    assign_view_state(
+      PlayerRealtimeStatus.new(user: viewing_as_user).to_h
+    )
 
     # 通知/アラート
     generate_notifications
-
-    # 調子メーター
-    calculate_condition_meter
-
-    # ベストパートナー
-    calculate_best_partners
-
-    # 機体使用トレンド（直近のイベント）—— パーソナルハイライトのフォールバック用
-    calculate_event_mobile_suit_trend
-
-    # 対戦会クイック比較
-    calculate_event_comparison
-
-    # コスト帯分析 —— EXバーストサマリーのフォールバック用
-    calculate_cost_analysis
-
-    # 対面相性マトリクス —— パフォーマンススナップショットのフォールバック用
-    calculate_matchup_matrix
-
-    # パフォーマンス スナップショット（新規）
-    calculate_performance_snapshot
-
-    # パーソナル ハイライト（新規）
-    calculate_personal_highlights
-
-    # EXバースト サマリー（新規）
-    calculate_exburst_summary
-
-    # 最近の試合（キャッシュ済みデータから取得）
-    # IDでユニーク化して順序を保つ
-    seen_match_ids = Set.new
-    @recent_matches = []
-    @all_user_matches.each do |mp|
-      unless seen_match_ids.include?(mp.match_id)
-        seen_match_ids.add(mp.match_id)
-        @recent_matches << mp.match
-        break if @recent_matches.size >= 5
-      end
-    end
-
-    # ユーザーのお気に入り機体（勝率付き）
-    user_suit_stats = Hash.new { |h, k| h[k] = { count: 0, wins: 0 } }
-    @all_user_matches.each do |mp|
-      user_suit_stats[mp.mobile_suit][:count] += 1
-      user_suit_stats[mp.mobile_suit][:wins] += 1 if mp.won?
-    end
-    @user_favorite_suits = user_suit_stats.sort_by { |_, stats| -stats[:count] }
-                                          .take(3)
-                                          .map do |suit, stats|
-                                            win_rate = stats[:count] > 0 ? (stats[:wins].to_f / stats[:count] * 100).round(1) : 0
-                                            suit.tap do |s|
-                                              s.define_singleton_method(:usage_count) { stats[:count] }
-                                              s.define_singleton_method(:win_rate) { win_rate }
-                                            end
-                                          end
 
     @upcoming_events = Event.where("held_on >= ?", Time.zone.today).order(held_on: :asc).limit(3)
 
@@ -155,59 +95,6 @@ class DashboardController < ApplicationController
                                        .to_a # 配列にキャッシュ
   end
 
-  def calculate_personal_stats
-    @user_total_matches = viewing_as_user.match_players.count
-    @user_wins = viewing_as_user.match_players.joins(:match).where(
-      "(matches.winning_team = 1 AND match_players.team_number = 1) OR (matches.winning_team = 2 AND match_players.team_number = 2)"
-    ).count
-    @user_win_rate = @user_total_matches > 0 ? (@user_wins.to_f / @user_total_matches * 100).round(1) : 0
-
-    # パフォーマンスデータのある試合から平均を計算
-    stats_mps = @all_user_matches.select(&:has_stats?)
-    @user_has_stats = stats_mps.any?
-    if @user_has_stats
-      total = stats_mps.size
-      total_kills = stats_mps.sum { |mp| mp.kills.to_i }
-      total_deaths = stats_mps.sum { |mp| mp.deaths.to_i }
-      @user_avg_damage = (stats_mps.sum { |mp| mp.damage_dealt.to_i }.to_f / total).round(0).to_i
-      @user_avg_kd = total_deaths > 0 ? (total_kills.to_f / total_deaths).round(2) : nil
-    end
-  end
-
-  def calculate_realtime_status
-    # 今日のイベントを取得
-    @today_event = Event.where(held_on: Time.zone.today).first
-    return unless @today_event
-
-    # 今日のイベントのアクティブなローテーション表を取得（rotation_matchesを事前ロード）
-    @active_rotation = @today_event.rotations.includes(
-      rotation_matches: [ :team1_player1, :team1_player2, :team2_player1, :team2_player2 ]
-    ).find_by(is_active: true)
-    return unless @active_rotation
-
-    # ローテーション表から情報を取得（既にロード済み）
-    @rotation_matches = @active_rotation.rotation_matches.sort_by(&:match_index)
-    @rotation_total_matches = @rotation_matches.size
-    @rotation_current_match_index = @active_rotation.current_match_index
-    @current_rotation_match = @rotation_matches[@rotation_current_match_index]
-
-    # 現在のユーザーの次の試合を取得（メモリ内で検索）
-    @user_next_rotation_match = @active_rotation.rotation_matches.find do |rm|
-      rm.match_index >= @active_rotation.current_match_index &&
-      rm.includes_player?(viewing_as_user.id)
-    end
-
-    if @user_next_rotation_match
-      @matches_until_user_turn = @user_next_rotation_match.match_index - @active_rotation.current_match_index
-      @match_info = @active_rotation.match_info_for_player(@user_next_rotation_match, viewing_as_user.id)
-      @user_partner = @match_info[:partner]
-      @opponent_players = @match_info[:opponents]
-
-      # 配信担当かどうか
-      @is_streaming = @user_next_rotation_match.streaming_for?(viewing_as_user.id)
-    end
-  end
-
   def generate_notifications
     @notifications = []
 
@@ -224,323 +111,15 @@ class DashboardController < ApplicationController
     @notifications = @notifications.take(3)
   end
 
-  def calculate_condition_meter
-    # キャッシュ済みデータを使用して、ユニークな試合のみを取得
-    seen_match_ids = Set.new
-    recent_match_players = []
-    @all_user_matches.each do |mp|
-      unless seen_match_ids.include?(mp.match_id)
-        seen_match_ids.add(mp.match_id)
-        recent_match_players << mp
-        break if recent_match_players.size >= 10
-      end
-    end
-
-    # 直近5試合の勝敗を計算（新しい順）
-    @recent_5_results = recent_match_players.take(5).map do |mp|
-      mp.won?
-    end
-
-    # 直近10試合の勝率
-    recent_10_results = recent_match_players.map do |mp|
-      mp.won?
-    end
-
-    if recent_10_results.any?
-      recent_10_wins = recent_10_results.count(true)
-      @recent_10_win_rate = (recent_10_wins.to_f / recent_10_results.count * 100).round(1)
-      @recent_10_diff = @recent_10_win_rate - @user_win_rate
-    else
-      @recent_10_win_rate = 0
-      @recent_10_diff = 0
-    end
-
-    # 連勝/連敗状況（最新の試合から順番にカウント）
-    # 全試合データを使用して正確にカウント
-    @current_streak = 0
-    @streak_type = nil
-    streak_seen_match_ids = Set.new
-
-    @all_user_matches.each do |mp|
-      next if streak_seen_match_ids.include?(mp.match_id)
-      streak_seen_match_ids.add(mp.match_id)
-
-      is_win = mp.won?
-
-      if @streak_type.nil?
-        # 最新の試合で連勝/連敗のタイプを決定
-        @streak_type = is_win ? "win" : "lose"
-        @current_streak = 1
-      elsif (@streak_type == "win" && is_win) || (@streak_type == "lose" && !is_win)
-        # 連勝/連敗が続いている
-        @current_streak += 1
-      else
-        # 連勝/連敗が途切れた
-        break
-      end
-    end
+  def set_global_totals
+    @total_matches = Match.count
+    @total_events = Event.count
+    @total_users = User.regular_users.count
   end
 
-  def calculate_best_partners
-    # キャッシュ済みデータを使用してパートナーごとに集計
-    partners_stats = {}
-
-    @all_user_matches.each do |my_mp|
-      match = my_mp.match
-      my_team = my_mp.team_number
-
-      # 同じチームのパートナーを取得（既にincludesで読み込み済み）
-      partner_mp = my_mp.partner
-      next unless partner_mp
-
-      partner_id = partner_mp.user_id
-      partners_stats[partner_id] ||= {
-        user: partner_mp.user,
-        wins: 0,
-        total: 0,
-        suit_combinations: Hash.new(0)
-      }
-
-      # 勝敗判定
-      is_win = match.won_by?(my_team)
-      partners_stats[partner_id][:wins] += 1 if is_win
-      partners_stats[partner_id][:total] += 1
-
-      # 機体の組み合わせを記録
-      combo_key = "#{my_mp.mobile_suit.name} & #{partner_mp.mobile_suit.name}"
-      partners_stats[partner_id][:suit_combinations][combo_key] += 1
-    end
-
-    # 3試合以上のパートナーのみフィルタリングして勝率でソート
-    @best_partners = partners_stats
-                      .select { |_, stats| stats[:total] >= 3 }
-                      .map do |partner_id, stats|
-                        {
-                          user: stats[:user],
-                          win_rate: (stats[:wins].to_f / stats[:total] * 100).round(1),
-                          wins: stats[:wins],
-                          total: stats[:total],
-                          best_combo: stats[:suit_combinations].max_by { |_, count| count }&.first
-                        }
-                      end
-                      .sort_by { |p| -p[:win_rate] }
-                      .take(3)
-  end
-
-  def calculate_event_mobile_suit_trend
-    # 対象イベントを決定（今日のイベントがあればそれ、なければ直近のイベント）
-    target_event = Event.where(held_on: Time.zone.today).first || Event.order(held_on: :desc).first
-
-    return unless target_event
-
-    # キャッシュ済みデータから該当イベントの試合をフィルタ
-    event_matches = @all_user_matches.select { |mp| mp.match.event_id == target_event.id }
-
-    suit_stats = {}
-
-    event_matches.each do |mp|
-      suit_id = mp.mobile_suit_id
-      suit_stats[suit_id] ||= {
-        mobile_suit: mp.mobile_suit,
-        usage: 0,
-        wins: 0
-      }
-
-      suit_stats[suit_id][:usage] += 1
-
-      is_win = mp.won?
-      suit_stats[suit_id][:wins] += 1 if is_win
-    end
-
-    @event_suit_trend = suit_stats.map do |suit_id, stats|
-      win_rate = stats[:usage] > 0 ? (stats[:wins].to_f / stats[:usage] * 100).round(1) : 0
-      {
-        mobile_suit: stats[:mobile_suit],
-        usage: stats[:usage],
-        win_rate: win_rate,
-        recommended: win_rate >= 60
-      }
-    end.sort_by { |s| -s[:usage] }
-
-    @trend_event = target_event
-    @is_today_event = (target_event.held_on == Time.zone.today)
-  end
-
-  def calculate_event_comparison
-    # 直近3イベント
-    recent_events = Event.order(held_on: :desc).limit(3)
-
-    @event_comparison = recent_events.map do |event|
-      # キャッシュ済みデータから該当イベントの試合をフィルタ
-      event_matches = @all_user_matches.select { |mp| mp.match.event_id == event.id }
-
-      total = event_matches.size
-      wins = event_matches.count(&:won?)
-
-      stats_mps = event_matches.select(&:has_stats?)
-      avg_damage = stats_mps.any? ? (stats_mps.sum { |mp| mp.damage_dealt.to_i }.to_f / stats_mps.size).round(0).to_i : nil
-
-      {
-        event: event,
-        total: total,
-        wins: wins,
-        losses: total - wins,
-        win_rate: total > 0 ? (wins.to_f / total * 100).round(1) : 0,
-        is_today: event.held_on == Time.zone.today,
-        avg_damage: avg_damage
-      }
-    end
-  end
-
-  def calculate_cost_analysis
-    # キャッシュ済みデータを使用してコスト組み合わせを集計
-    cost_stats = Hash.new { |h, k| h[k] = { wins: 0, total: 0 } }
-
-    @all_user_matches.each do |my_mp|
-      match = my_mp.match
-      my_team = my_mp.team_number
-      my_cost = my_mp.mobile_suit.cost
-
-      # パートナーのコストを取得（既にincludesで読み込み済み）
-      partner_mp = my_mp.partner
-      next unless partner_mp
-
-      partner_cost = partner_mp.mobile_suit.cost
-
-      # コスト組み合わせのキー（小さい方を先に）
-      costs = [ my_cost, partner_cost ].sort.reverse
-      cost_key = "#{costs[0]}+#{costs[1]}"
-
-      cost_stats[cost_key][:total] += 1
-
-      is_win = match.won_by?(my_team)
-      cost_stats[cost_key][:wins] += 1 if is_win
-    end
-
-    # 3試合以上の組み合わせのみ表示
-    @cost_analysis = cost_stats
-                      .select { |_, stats| stats[:total] >= 3 }
-                      .map do |cost_key, stats|
-                        win_rate = (stats[:wins].to_f / stats[:total] * 100).round(1)
-                        {
-                          cost_combo: cost_key,
-                          wins: stats[:wins],
-                          total: stats[:total],
-                          losses: stats[:total] - stats[:wins],
-                          win_rate: win_rate,
-                          judgment: win_rate >= 60 ? "得意" : (win_rate >= 40 ? "普通" : "苦手")
-                        }
-                      end
-                      .sort_by { |c| -c[:win_rate] }
-  end
-
-  def calculate_performance_snapshot
-    stats_mps = @all_user_matches.select(&:has_stats?)
-    return if stats_mps.empty?
-
-    total = stats_mps.size
-    total_kills = stats_mps.sum { |mp| mp.kills.to_i }
-    total_deaths = stats_mps.sum { |mp| mp.deaths.to_i }
-
-    @performance_snapshot = {
-      avg_score: (stats_mps.sum { |mp| mp.score.to_i }.to_f / total).round(1),
-      avg_damage: (stats_mps.sum { |mp| mp.damage_dealt.to_i }.to_f / total).round(0).to_i,
-      kd_ratio: total_deaths > 0 ? (total_kills.to_f / total_deaths).round(2) : nil,
-      avg_exburst_damage: (stats_mps.sum { |mp| mp.exburst_damage.to_i }.to_f / total).round(0).to_i
-    }
-
-    # コミュニティ平均（ゲスト以外・stats あり）
-    community_base = MatchPlayer.joins(:user).where(users: { is_guest: false }).where.not(damage_dealt: nil)
-    if community_base.exists?
-      @community_snapshot = {
-        avg_score: community_base.average(:score)&.round(1),
-        avg_damage: community_base.average(:damage_dealt)&.round(0)&.to_i,
-        avg_exburst_damage: community_base.average(:exburst_damage)&.round(0)&.to_i
-      }
-    end
-  end
-
-  def calculate_personal_highlights
-    stats_mps = @all_user_matches.select { |mp| mp.has_stats? && mp.damage_dealt.to_i > 0 }
-    return if stats_mps.empty?
-
-    @highlight_best_damage_mp = stats_mps.max_by { |mp| mp.damage_dealt.to_i }
-
-    kd_mps = stats_mps.select { |mp| mp.kills.to_i > 0 || mp.deaths.to_i > 0 }
-    @highlight_best_kd_mp = kd_mps.max_by { |mp| mp.kills.to_f / [ mp.deaths.to_i, 1 ].max } if kd_mps.any?
-  end
-
-  def calculate_exburst_summary
-    ex_mps = @all_user_matches.select { |mp| mp.exburst_count.present? }
-    return if ex_mps.empty?
-
-    total = ex_mps.size
-    total_deaths = ex_mps.sum { |mp| mp.deaths.to_i }
-
-    @exburst_summary = {
-      avg_count: (ex_mps.sum { |mp| mp.exburst_count.to_i }.to_f / total).round(2),
-      avg_damage: (ex_mps.sum { |mp| mp.exburst_damage.to_i }.to_f / total).round(0).to_i,
-      death_rate: total_deaths > 0 ? (ex_mps.sum { |mp| mp.exburst_deaths.to_i }.to_f / total_deaths * 100).round(1) : 0.0
-    }
-
-    # コミュニティ平均
-    community_avg = MatchPlayer.joins(:user).where(users: { is_guest: false }).where.not(exburst_count: nil).average(:exburst_count)
-    @exburst_summary[:community_avg_count] = community_avg&.round(2)
-  end
-
-  def calculate_matchup_matrix
-    # キャッシュ済みデータから使用頻度TOP3の機体を集計
-    suit_usage = Hash.new(0)
-    @all_user_matches.each { |mp| suit_usage[mp.mobile_suit_id] += 1 }
-    top_suits = suit_usage.sort_by { |_, count| -count }.take(3).map { |suit_id, _| suit_id }
-
-    @matchup_matrix = []
-
-    top_suits.each do |my_suit_id|
-      # この機体を使った試合をフィルタ
-      my_matches = @all_user_matches.select { |mp| mp.mobile_suit_id == my_suit_id }
-      next if my_matches.empty?
-
-      my_suit = my_matches.first.mobile_suit
-
-      # 対戦相手の機体ごとに勝率を計算
-      opponent_stats = Hash.new { |h, k| h[k] = { wins: 0, total: 0, mobile_suit: nil } }
-
-      my_matches.each do |my_mp|
-        match = my_mp.match
-        my_team = my_mp.team_number
-        # 相手チームの機体を取得（既にincludesで読み込み済み）
-        my_mp.opponents.each do |opp_mp|
-          opp_suit_id = opp_mp.mobile_suit_id
-          opponent_stats[opp_suit_id][:mobile_suit] = opp_mp.mobile_suit
-          opponent_stats[opp_suit_id][:total] += 1
-
-          is_win = match.won_by?(my_team)
-          opponent_stats[opp_suit_id][:wins] += 1 if is_win
-        end
-      end
-
-      # 2試合以上対戦した機体のみ
-      matchups = opponent_stats
-                  .select { |_, stats| stats[:total] >= 2 }
-                  .map do |opp_suit_id, stats|
-                    win_rate = (stats[:wins].to_f / stats[:total] * 100).round(1)
-                    {
-                      opponent_suit: stats[:mobile_suit],
-                      wins: stats[:wins],
-                      total: stats[:total],
-                      losses: stats[:total] - stats[:wins],
-                      win_rate: win_rate,
-                      compatibility: win_rate >= 60 ? "得意" : (win_rate >= 40 ? "普通" : "苦手")
-                    }
-                  end
-                  .sort_by { |m| -m[:win_rate] }
-                  .take(5)
-
-      @matchup_matrix << {
-        my_suit: my_suit,
-        matchups: matchups
-      } if matchups.any?
+  def assign_view_state(attributes)
+    attributes.each do |name, value|
+      instance_variable_set("@#{name}", value)
     end
   end
 end

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -38,19 +38,7 @@ class StatisticsController < ApplicationController
       calculate_highlights
     end
 
-    # フィルター用のデータ
-    @all_events = Event.order(held_on: :desc)
-    @all_mobile_suits = MobileSuit.order(:name)
-    all_partners = User.regular_users.where.not(id: viewing_as_user.id).order(:nickname)
-    if @filter_events.any?
-      partner_ids_in_events = MatchPlayer.joins(:match)
-                                         .where(matches: { event_id: @filter_events })
-                                         .where.not(user_id: viewing_as_user.id)
-                                         .distinct
-                                         .pluck(:user_id)
-      all_partners = all_partners.where(id: partner_ids_in_events)
-    end
-    @all_partners = all_partners
+    set_filter_options
   end
 
   private
@@ -77,37 +65,13 @@ class StatisticsController < ApplicationController
   end
 
   def apply_filters
-    # ログインユーザーの試合を基準に開始
-    @filtered_matches = MatchPlayer.where(user_id: viewing_as_user.id)
-                                   .joins(:match)
-                                   .includes(:match, :mobile_suit, :user, match: { rotation_match: :rotation })
-
-    # イベントフィルター
-    if @filter_events.any?
-      @filtered_matches = @filtered_matches.where(matches: { event_id: @filter_events })
-    end
-
-    # 機体フィルター（ログインユーザーが使用した機体）
-    if @filter_mobile_suits.any?
-      @filtered_matches = @filtered_matches.where(mobile_suit_id: @filter_mobile_suits)
-    end
-
-    # コストフィルター（ログインユーザーが使用した機体のコスト）
-    if @filter_costs.any?
-      @filtered_matches = @filtered_matches.where(mobile_suit_id: MobileSuit.where(cost: @filter_costs))
-    end
-
-    # パートナーフィルター
-    if @filter_partners.any?
-      # ログインユーザーとパートナーが同じチームの試合に絞り込む
-      filtered_match_ids = []
-      @filtered_matches.each do |my_mp|
-        partner_mp = my_mp.partner
-        filtered_match_ids << my_mp.match_id if partner_mp && @filter_partners.include?(partner_mp.user_id)
-      end
-
-      @filtered_matches = @filtered_matches.where(matches: { id: filtered_match_ids.uniq })
-    end
+    @filtered_matches = StatisticsFilteredMatchPlayersQuery.new(
+      user: viewing_as_user,
+      filter_events: @filter_events,
+      filter_mobile_suits: @filter_mobile_suits,
+      filter_partners: @filter_partners,
+      filter_costs: @filter_costs
+    ).call
   end
 
   # コミュニティ側クエリの基底スコープ（イベントフィルターのみ適用）
@@ -1136,5 +1100,16 @@ class StatisticsController < ApplicationController
 
   def selected_ids(param_key)
     params[param_key].present? ? params[param_key].map(&:to_i) : []
+  end
+
+  def set_filter_options
+    filter_options = StatisticsFilterOptions.new(
+      user: viewing_as_user,
+      filter_events: @filter_events
+    ).to_h
+
+    @all_events = filter_options[:all_events]
+    @all_mobile_suits = filter_options[:all_mobile_suits]
+    @all_partners = filter_options[:all_partners]
   end
 end

--- a/app/services/player_dashboard_snapshot.rb
+++ b/app/services/player_dashboard_snapshot.rb
@@ -1,0 +1,375 @@
+class PlayerDashboardSnapshot
+  def initialize(user:, match_players:)
+    @user = user
+    @match_players = match_players.to_a
+  end
+
+  def to_h
+    personal_stats.merge(
+      recent_matches: recent_matches,
+      user_favorite_suits: user_favorite_suits,
+      recent_5_results: recent_5_results,
+      recent_10_win_rate: recent_10_win_rate,
+      recent_10_diff: recent_10_diff,
+      current_streak: current_streak,
+      streak_type: streak_type,
+      best_partners: best_partners,
+      event_suit_trend: event_suit_trend,
+      trend_event: trend_event,
+      is_today_event: is_today_event,
+      event_comparison: event_comparison,
+      cost_analysis: cost_analysis,
+      performance_snapshot: performance_snapshot,
+      community_snapshot: community_snapshot,
+      highlight_best_damage_mp: highlight_best_damage_mp,
+      highlight_best_kd_mp: highlight_best_kd_mp,
+      exburst_summary: exburst_summary,
+      matchup_matrix: matchup_matrix
+    )
+  end
+
+  private
+
+  attr_reader :user, :match_players
+
+  def personal_stats
+    wins = win_count(match_players)
+    stats_match_players = match_players.select(&:has_stats?)
+    total_deaths = stats_match_players.sum { |match_player| match_player.deaths.to_i }
+
+    {
+      user_total_matches: match_players.size,
+      user_wins: wins,
+      user_win_rate: percentage(wins, match_players.size),
+      user_has_stats: stats_match_players.any?,
+      user_avg_damage: stats_match_players.any? ? average(stats_match_players) { |match_player| match_player.damage_dealt.to_i }.round(0).to_i : nil,
+      user_avg_kd: total_deaths.positive? ? (stats_match_players.sum { |match_player| match_player.kills.to_i }.to_f / total_deaths).round(2) : nil
+    }
+  end
+
+  def recent_matches
+    unique_recent_match_players(limit: 5).map(&:match)
+  end
+
+  def user_favorite_suits
+    suit_stats = Hash.new { |hash, mobile_suit| hash[mobile_suit] = { count: 0, wins: 0 } }
+
+    match_players.each do |match_player|
+      suit_stats[match_player.mobile_suit][:count] += 1
+      suit_stats[match_player.mobile_suit][:wins] += 1 if match_player.won?
+    end
+
+    suit_stats.sort_by { |_, stats| -stats[:count] }
+              .take(3)
+              .map do |mobile_suit, stats|
+                decorate_mobile_suit(mobile_suit, stats)
+              end
+  end
+
+  def recent_5_results
+    recent_unique_match_players(limit: 10).take(5).map(&:won?)
+  end
+
+  def recent_10_win_rate
+    return 0 if recent_10_results.empty?
+
+    percentage(recent_10_results.count(true), recent_10_results.size)
+  end
+
+  def recent_10_diff
+    recent_10_win_rate - personal_stats[:user_win_rate]
+  end
+
+  def current_streak
+    streak_state[:count]
+  end
+
+  def streak_type
+    streak_state[:type]
+  end
+
+  def best_partners
+    partner_stats = {}
+
+    match_players.each do |match_player|
+      partner = match_player.partner
+      next unless partner
+
+      partner_stats[partner.user_id] ||= {
+        user: partner.user,
+        wins: 0,
+        total: 0,
+        suit_combinations: Hash.new(0)
+      }
+
+      partner_stats[partner.user_id][:wins] += 1 if match_player.won?
+      partner_stats[partner.user_id][:total] += 1
+      combo_key = "#{match_player.mobile_suit.name} & #{partner.mobile_suit.name}"
+      partner_stats[partner.user_id][:suit_combinations][combo_key] += 1
+    end
+
+    partner_stats
+      .select { |_, stats| stats[:total] >= 3 }
+      .map do |_, stats|
+        {
+          user: stats[:user],
+          win_rate: percentage(stats[:wins], stats[:total]),
+          wins: stats[:wins],
+          total: stats[:total],
+          best_combo: stats[:suit_combinations].max_by { |_, count| count }&.first
+        }
+      end
+      .sort_by { |partner| -partner[:win_rate] }
+      .take(3)
+  end
+
+  def event_suit_trend
+    return nil unless trend_event
+
+    suit_stats = {}
+
+    event_match_players(trend_event.id).each do |match_player|
+      suit_stats[match_player.mobile_suit_id] ||= {
+        mobile_suit: match_player.mobile_suit,
+        usage: 0,
+        wins: 0
+      }
+
+      suit_stats[match_player.mobile_suit_id][:usage] += 1
+      suit_stats[match_player.mobile_suit_id][:wins] += 1 if match_player.won?
+    end
+
+    suit_stats.map do |_, stats|
+      {
+        mobile_suit: stats[:mobile_suit],
+        usage: stats[:usage],
+        win_rate: percentage(stats[:wins], stats[:usage]),
+        recommended: percentage(stats[:wins], stats[:usage]) >= 60
+      }
+    end.sort_by { |suit| -suit[:usage] }
+  end
+
+  def trend_event
+    @trend_event ||= Event.find_by(held_on: Time.zone.today) || Event.order(held_on: :desc).first
+  end
+
+  def is_today_event
+    trend_event&.held_on == Time.zone.today
+  end
+
+  def event_comparison
+    Event.order(held_on: :desc).limit(3).map do |event|
+      event_match_players = event_match_players(event.id)
+      wins = win_count(event_match_players)
+      stats_match_players = event_match_players.select(&:has_stats?)
+
+      {
+        event: event,
+        total: event_match_players.size,
+        wins: wins,
+        losses: event_match_players.size - wins,
+        win_rate: percentage(wins, event_match_players.size),
+        is_today: event.held_on == Time.zone.today,
+        avg_damage: stats_match_players.any? ? average(stats_match_players) { |match_player| match_player.damage_dealt.to_i }.round(0).to_i : nil
+      }
+    end
+  end
+
+  def cost_analysis
+    cost_stats = Hash.new { |hash, key| hash[key] = { wins: 0, total: 0 } }
+
+    match_players.each do |match_player|
+      partner = match_player.partner
+      next unless partner
+
+      costs = [ match_player.mobile_suit.cost, partner.mobile_suit.cost ].sort.reverse
+      cost_key = "#{costs[0]}+#{costs[1]}"
+
+      cost_stats[cost_key][:total] += 1
+      cost_stats[cost_key][:wins] += 1 if match_player.won?
+    end
+
+    cost_stats
+      .select { |_, stats| stats[:total] >= 3 }
+      .map do |cost_key, stats|
+        win_rate = percentage(stats[:wins], stats[:total])
+        {
+          cost_combo: cost_key,
+          wins: stats[:wins],
+          total: stats[:total],
+          losses: stats[:total] - stats[:wins],
+          win_rate: win_rate,
+          judgment: win_rate >= 60 ? "得意" : (win_rate >= 40 ? "普通" : "苦手")
+        }
+      end
+      .sort_by { |cost| -cost[:win_rate] }
+  end
+
+  def performance_snapshot
+    return nil if stats_match_players.empty?
+
+    total_deaths = stats_match_players.sum { |match_player| match_player.deaths.to_i }
+
+    {
+      avg_score: average(stats_match_players) { |match_player| match_player.score.to_i }.round(1),
+      avg_damage: average(stats_match_players) { |match_player| match_player.damage_dealt.to_i }.round(0).to_i,
+      kd_ratio: total_deaths.positive? ? (stats_match_players.sum { |match_player| match_player.kills.to_i }.to_f / total_deaths).round(2) : nil,
+      avg_exburst_damage: average(stats_match_players) { |match_player| match_player.exburst_damage.to_i }.round(0).to_i
+    }
+  end
+
+  def community_snapshot
+    community_base = MatchPlayer.joins(:user).where(users: { is_guest: false }).where.not(damage_dealt: nil)
+    return nil unless community_base.exists?
+
+    {
+      avg_score: community_base.average(:score)&.round(1),
+      avg_damage: community_base.average(:damage_dealt)&.round(0)&.to_i,
+      avg_exburst_damage: community_base.average(:exburst_damage)&.round(0)&.to_i
+    }
+  end
+
+  def highlight_best_damage_mp
+    positive_damage_match_players.max_by { |match_player| match_player.damage_dealt.to_i }
+  end
+
+  def highlight_best_kd_mp
+    kd_match_players = positive_damage_match_players.select do |match_player|
+      match_player.kills.to_i.positive? || match_player.deaths.to_i.positive?
+    end
+    kd_match_players.max_by { |match_player| match_player.kills.to_f / [ match_player.deaths.to_i, 1 ].max }
+  end
+
+  def exburst_summary
+    exburst_match_players = match_players.select { |match_player| match_player.exburst_count.present? }
+    return nil if exburst_match_players.empty?
+
+    total = exburst_match_players.size
+    total_deaths = exburst_match_players.sum { |match_player| match_player.deaths.to_i }
+
+    {
+      avg_count: average(exburst_match_players) { |match_player| match_player.exburst_count.to_i }.round(2),
+      avg_damage: average(exburst_match_players) { |match_player| match_player.exburst_damage.to_i }.round(0).to_i,
+      death_rate: total_deaths.positive? ? (exburst_match_players.sum { |match_player| match_player.exburst_deaths.to_i }.to_f / total_deaths * 100).round(1) : 0.0,
+      community_avg_count: MatchPlayer.joins(:user).where(users: { is_guest: false }).where.not(exburst_count: nil).average(:exburst_count)&.round(2)
+    }
+  end
+
+  def matchup_matrix
+    top_suit_ids = match_players.each_with_object(Hash.new(0)) do |match_player, usage|
+      usage[match_player.mobile_suit_id] += 1
+    end.sort_by { |_, count| -count }.take(3).map(&:first)
+
+    top_suit_ids.filter_map do |mobile_suit_id|
+      my_matches = match_players.select { |match_player| match_player.mobile_suit_id == mobile_suit_id }
+      next if my_matches.empty?
+
+      opponent_stats = Hash.new { |hash, key| hash[key] = { wins: 0, total: 0, mobile_suit: nil } }
+
+      my_matches.each do |match_player|
+        match_player.opponents.each do |opponent|
+          opponent_stats[opponent.mobile_suit_id][:mobile_suit] = opponent.mobile_suit
+          opponent_stats[opponent.mobile_suit_id][:total] += 1
+          opponent_stats[opponent.mobile_suit_id][:wins] += 1 if match_player.won?
+        end
+      end
+
+      matchups = opponent_stats
+                   .select { |_, stats| stats[:total] >= 2 }
+                   .map do |_, stats|
+                     win_rate = percentage(stats[:wins], stats[:total])
+                     {
+                       opponent_suit: stats[:mobile_suit],
+                       wins: stats[:wins],
+                       total: stats[:total],
+                       losses: stats[:total] - stats[:wins],
+                       win_rate: win_rate,
+                       compatibility: win_rate >= 60 ? "得意" : (win_rate >= 40 ? "普通" : "苦手")
+                     }
+                   end
+                   .sort_by { |matchup| -matchup[:win_rate] }
+                   .take(5)
+
+      next if matchups.empty?
+
+      {
+        my_suit: my_matches.first.mobile_suit,
+        matchups: matchups
+      }
+    end
+  end
+
+  def stats_match_players
+    @stats_match_players ||= match_players.select(&:has_stats?)
+  end
+
+  def positive_damage_match_players
+    @positive_damage_match_players ||= stats_match_players.select { |match_player| match_player.damage_dealt.to_i > 0 }
+  end
+
+  def recent_10_results
+    @recent_10_results ||= unique_recent_match_players(limit: 10).map(&:won?)
+  end
+
+  def streak_state
+    @streak_state ||= begin
+      count = 0
+      type = nil
+
+      unique_recent_match_players.each do |match_player|
+        is_win = match_player.won?
+
+        if type.nil?
+          type = is_win ? "win" : "lose"
+          count = 1
+        elsif (type == "win" && is_win) || (type == "lose" && !is_win)
+          count += 1
+        else
+          break
+        end
+      end
+
+      { count: count, type: type }
+    end
+  end
+
+  def unique_recent_match_players(limit: nil)
+    seen_match_ids = {}
+    unique_match_players = []
+
+    match_players.each do |match_player|
+      next if seen_match_ids[match_player.match_id]
+
+      seen_match_ids[match_player.match_id] = true
+      unique_match_players << match_player
+      break if limit && unique_match_players.size >= limit
+    end
+
+    unique_match_players
+  end
+
+  def event_match_players(event_id)
+    match_players.select { |match_player| match_player.match.event_id == event_id }
+  end
+
+  def win_count(match_players)
+    match_players.count(&:won?)
+  end
+
+  def decorate_mobile_suit(mobile_suit, stats)
+    win_rate = percentage(stats[:wins], stats[:count])
+
+    mobile_suit.tap do |suit|
+      suit.define_singleton_method(:usage_count) { stats[:count] }
+      suit.define_singleton_method(:win_rate) { win_rate }
+    end
+  end
+
+  def average(match_players, &block)
+    match_players.sum(&block).to_f / match_players.size
+  end
+
+  def percentage(numerator, denominator)
+    denominator.positive? ? (numerator.to_f / denominator * 100).round(1) : 0
+  end
+end

--- a/app/services/player_realtime_status.rb
+++ b/app/services/player_realtime_status.rb
@@ -1,0 +1,63 @@
+class PlayerRealtimeStatus
+  def initialize(user:)
+    @user = user
+  end
+
+  def to_h
+    {
+      today_event: today_event,
+      active_rotation: active_rotation,
+      rotation_matches: rotation_matches,
+      rotation_total_matches: rotation_matches.size,
+      rotation_current_match_index: active_rotation&.current_match_index,
+      current_rotation_match: current_rotation_match,
+      user_next_rotation_match: user_next_rotation_match,
+      matches_until_user_turn: matches_until_user_turn,
+      match_info: match_info,
+      user_partner: match_info&.dig(:partner),
+      opponent_players: match_info&.dig(:opponents) || [],
+      is_streaming: user_next_rotation_match&.streaming_for?(user.id) || false
+    }
+  end
+
+  private
+
+  attr_reader :user
+
+  def today_event
+    @today_event ||= Event.find_by(held_on: Time.zone.today)
+  end
+
+  def active_rotation
+    @active_rotation ||= today_event&.rotations&.includes(
+      rotation_matches: [ :team1_player1, :team1_player2, :team2_player1, :team2_player2 ]
+    )&.find_by(is_active: true)
+  end
+
+  def rotation_matches
+    @rotation_matches ||= active_rotation ? active_rotation.rotation_matches.sort_by(&:match_index) : []
+  end
+
+  def current_rotation_match
+    @current_rotation_match ||= rotation_matches[active_rotation.current_match_index] if active_rotation
+  end
+
+  def user_next_rotation_match
+    @user_next_rotation_match ||= if active_rotation
+      rotation_matches.find do |rotation_match|
+        rotation_match.match_index >= active_rotation.current_match_index &&
+          rotation_match.includes_player?(user.id)
+      end
+    end
+  end
+
+  def matches_until_user_turn
+    return unless user_next_rotation_match && active_rotation
+
+    user_next_rotation_match.match_index - active_rotation.current_match_index
+  end
+
+  def match_info
+    @match_info ||= active_rotation&.match_info_for_player(user_next_rotation_match, user.id) if user_next_rotation_match
+  end
+end

--- a/app/services/statistics_filter_options.rb
+++ b/app/services/statistics_filter_options.rb
@@ -1,0 +1,30 @@
+class StatisticsFilterOptions
+  def initialize(user:, filter_events:)
+    @user = user
+    @filter_events = filter_events
+  end
+
+  def to_h
+    {
+      all_events: Event.order(held_on: :desc),
+      all_mobile_suits: MobileSuit.order(:name),
+      all_partners: all_partners
+    }
+  end
+
+  private
+
+  attr_reader :user, :filter_events
+
+  def all_partners
+    partners = User.regular_users.where.not(id: user.id).order(:nickname)
+    return partners unless filter_events.any?
+
+    partner_ids_in_events = MatchPlayer.joins(:match)
+                                       .where(matches: { event_id: filter_events })
+                                       .where.not(user_id: user.id)
+                                       .distinct
+                                       .pluck(:user_id)
+    partners.where(id: partner_ids_in_events)
+  end
+end

--- a/app/services/statistics_filtered_match_players_query.rb
+++ b/app/services/statistics_filtered_match_players_query.rb
@@ -1,0 +1,39 @@
+class StatisticsFilteredMatchPlayersQuery
+  def initialize(user:, filter_events:, filter_mobile_suits:, filter_partners:, filter_costs:)
+    @user = user
+    @filter_events = filter_events
+    @filter_mobile_suits = filter_mobile_suits
+    @filter_partners = filter_partners
+    @filter_costs = filter_costs
+  end
+
+  def call
+    scope = MatchPlayer.where(user_id: user.id)
+                       .joins(:match)
+                       .includes(
+                         :mobile_suit,
+                         :user,
+                         match: [
+                           :event,
+                           { rotation_match: :rotation },
+                           { match_players: [ :user, :mobile_suit ] }
+                         ]
+                       )
+
+    scope = scope.where(matches: { event_id: filter_events }) if filter_events.any?
+    scope = scope.where(mobile_suit_id: filter_mobile_suits) if filter_mobile_suits.any?
+    scope = scope.where(mobile_suit_id: MobileSuit.where(cost: filter_costs)) if filter_costs.any?
+    return scope unless filter_partners.any?
+
+    filtered_match_ids = scope.select do |match_player|
+      partner = match_player.partner
+      partner && filter_partners.include?(partner.user_id)
+    end.map(&:match_id).uniq
+
+    scope.where(matches: { id: filtered_match_ids })
+  end
+
+  private
+
+  attr_reader :user, :filter_events, :filter_mobile_suits, :filter_partners, :filter_costs
+end


### PR DESCRIPTION
## 概要
- DashboardController の個人ダッシュボード集計を service に分離
- StatisticsController のフィルター用データと絞り込みクエリを service に分離
- 既存挙動を維持しつつ、controller の責務を軽くする

## 変更内容
- `PlayerDashboardSnapshot` を追加し、個人ダッシュボードの集計を集約
- `PlayerRealtimeStatus` を追加し、当日イベントの待機状況計算を分離
- `StatisticsFilterOptions` を追加し、統計画面のフィルター候補生成を分離
- `StatisticsFilteredMatchPlayersQuery` を追加し、統計画面の絞り込みクエリを分離
- `DashboardController` / `StatisticsController` から重複した集計ロジックを削減

## 確認
- `RUBOCOP_CACHE_ROOT=/tmp/rubocop_cache bundle exec rubocop app/controllers/dashboard_controller.rb app/controllers/statistics_controller.rb app/services/player_dashboard_snapshot.rb app/services/player_realtime_status.rb app/services/statistics_filter_options.rb app/services/statistics_filtered_match_players_query.rb`
- `bundle exec rails zeitwerk:check`

Refs #275