### PR TITLE
refactor: 機体統計の集計責務を service に分離

### DIFF
--- a/app/controllers/admin/mobile_suits_controller.rb
+++ b/app/controllers/admin/mobile_suits_controller.rb
@@ -3,7 +3,7 @@ module Admin
     before_action :set_mobile_suit, only: [ :edit, :update, :destroy ]
 
     def index
-      @mobile_suits = MobileSuit.all.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
+      @mobile_suits = MobileSuit.catalog_order
     end
 
     def new

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -134,7 +134,7 @@ class MatchesController < ApplicationController
 
   def load_form_options
     @users = User.regular_users.order(:nickname)
-    @mobile_suits = MobileSuit.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC"))
+    @mobile_suits = MobileSuit.catalog_order
   end
 
   def assign_view_state(attributes)

--- a/app/controllers/mobile_suits_controller.rb
+++ b/app/controllers/mobile_suits_controller.rb
@@ -6,198 +6,20 @@ class MobileSuitsController < ApplicationController
   def index
     @counts_by_cost = MobileSuit.group(:cost).count
     @selected_cost = params[:cost].to_i.in?(COSTS) ? params[:cost].to_i : nil
-    @suits = @selected_cost ? MobileSuit.where(cost: @selected_cost).order(:position) : MobileSuit.all.order(:position)
+    @suits = @selected_cost ? MobileSuit.where(cost: @selected_cost).position_order : MobileSuit.position_order
     @search_query = params[:q].to_s.strip
   end
 
   def show
     @suit = MobileSuit.find(params[:id])
-    calculate_global_stats
+    assign_view_state(MobileSuitStatisticsSnapshot.new(mobile_suit: @suit).to_h)
   end
 
   private
 
-  def calculate_global_stats
-    suit_mps = MatchPlayer.where(mobile_suit_id: @suit.id)
-                          .joins(:match)
-                          .includes(:user, match: { match_players: :mobile_suit })
-
-    @total_uses = suit_mps.count
-    wins        = suit_mps.count(&:won?)
-    @win_rate   = @total_uses > 0 ? (wins.to_f / @total_uses * 100).round(1) : 0.0
-    @dominance  = (@win_rate * @total_uses).round(1)
-
-    # ランキング用: SQLで全機体の使用回数・勝利数を一括取得
-    all_suit_counts = MatchPlayer.joins(:match).group(:mobile_suit_id).count
-    all_suit_wins   = MatchPlayer.joins(:match)
-                                 .where("matches.winning_team = match_players.team_number")
-                                 .group(:mobile_suit_id)
-                                 .count
-
-    all_ids      = MobileSuit.pluck(:id)
-    @total_suits = all_ids.size  # 全登録機体数（未使用含む）
-
-    # 使用回数ランキング: 全機体対象（未使用 = 0）
-    counts_for_rank = all_ids.index_with { |id| all_suit_counts[id] || 0 }
-    @rank_uses = value_rank(counts_for_rank, @suit.id, :desc)
-
-    # 環境支配度ランキング: 全機体対象（未使用 = 0）
-    dominance_for_rank = all_ids.index_with do |id|
-      total  = all_suit_counts[id] || 0
-      wins_n = all_suit_wins[id] || 0
-      wr     = total > 0 ? (wins_n.to_f / total * 100) : 0.0
-      (wr * total).round(1)
+  def assign_view_state(attributes)
+    attributes.each do |name, value|
+      instance_variable_set("@#{name}", value)
     end
-    @rank_dominance = value_rank(dominance_for_rank, @suit.id, :desc)
-
-    # 勝率ランキング: 使用実績のある機体のみ対象（未使用機体を含めると不公平なため）
-    win_rates_for_rank = all_suit_counts.each_with_object({}) do |(sid, total), h|
-      wins_n = all_suit_wins[sid] || 0
-      h[sid] = (wins_n.to_f / total * 100).round(1)
-    end
-    @rank_win_rate        = value_rank(win_rates_for_rank, @suit.id, :desc)
-    @total_suits_with_uses = win_rates_for_rank.size
-
-    # プレイヤーランキング TOP5
-    @player_ranking = suit_mps.group_by(&:user_id).map do |_, mps|
-      wins_n  = mps.count(&:won?)
-      total_n = mps.count
-      {
-        user:     mps.first.user,
-        uses:     total_n,
-        win_rate: total_n > 0 ? (wins_n.to_f / total_n * 100).round(1) : 0.0
-      }
-    end.sort_by { |d| -d[:uses] }.first(5)
-
-    # 相方機体別分析
-    partner_suit_data = Hash.new { |h, k| h[k] = { mobile_suit: nil, wins: 0, total: 0 } }
-    suit_mps.each do |my_mp|
-      partner_mp = my_mp.partner
-      next unless partner_mp
-
-      pid = partner_mp.mobile_suit_id
-      partner_suit_data[pid][:mobile_suit] = partner_mp.mobile_suit
-      partner_suit_data[pid][:total] += 1
-      partner_suit_data[pid][:wins] += 1 if my_mp.won?
-    end
-
-    @partner_suits = partner_suit_data.map do |_, d|
-      total = d[:total]
-      {
-        mobile_suit: d[:mobile_suit],
-        total:       total,
-        ratio:       @total_uses > 0 ? (total.to_f / @total_uses * 100).round(1) : 0.0,
-        win_rate:    total > 0 ? (d[:wins].to_f / total * 100).round(1) : 0.0
-      }
-    end.sort_by { |d| -d[:total] }
-
-    # 相方コスト別分析
-    partner_cost_data = Hash.new { |h, k| h[k] = { wins: 0, total: 0 } }
-    suit_mps.each do |my_mp|
-      partner_mp = my_mp.partner
-      next unless partner_mp
-
-      cost = partner_mp.mobile_suit.cost
-      partner_cost_data[cost][:total] += 1
-      partner_cost_data[cost][:wins] += 1 if my_mp.won?
-    end
-
-    @partner_costs = partner_cost_data.map do |cost, d|
-      total = d[:total]
-      {
-        cost:     cost,
-        total:    total,
-        ratio:    @total_uses > 0 ? (total.to_f / @total_uses * 100).round(1) : 0.0,
-        win_rate: total > 0 ? (d[:wins].to_f / total * 100).round(1) : 0.0
-      }
-    end.sort_by { |d| -d[:total] }
-
-    # パフォーマンス統計（has_stats? の試合のみ）
-    stats_mps   = suit_mps.select(&:has_stats?)
-    @global_perf = build_perf(stats_mps)
-
-    # プレイヤー別パフォーマンス（stats持ち試合があるプレイヤーのみ）
-    @player_perf = stats_mps.group_by(&:user_id).filter_map do |_, mps|
-      build_perf(mps)&.merge(user: mps.first.user)
-    end.sort_by { |d| -d[:stats_count] }
-  end
-
-  # 同率考慮ランキング: 自分より strict に上位の件数 + 1
-  def value_rank(hash, target_id, direction)
-    target_val = hash[target_id]
-    return nil if target_val.nil?
-
-    better_count = if direction == :desc
-      hash.count { |_, v| v > target_val }
-    else
-      hash.count { |_, v| v < target_val }
-    end
-    better_count + 1
-  end
-
-  def build_perf(mps)
-    return nil if mps.empty?
-
-    deaths_total         = mps.sum { |mp| mp.deaths.to_i }
-    exburst_deaths_total = mps.sum { |mp| mp.exburst_deaths.to_i }
-
-    {
-      stats_count:         mps.size,
-      avg_score:           avg_stat(mps, :score),
-      avg_kills:           avg_stat(mps, :kills),
-      avg_deaths:          avg_stat(mps, :deaths),
-      avg_damage_dealt:    avg_stat(mps, :damage_dealt),
-      avg_damage_recv:     avg_stat(mps, :damage_received),
-      avg_exburst_count:   avg_stat(mps, :exburst_count),
-      avg_exburst_damage:  avg_stat(mps, :exburst_damage),
-      avg_exburst_deaths:  avg_stat(mps, :exburst_deaths),
-      exburst_death_ratio: deaths_total > 0 ? (exburst_deaths_total.to_f / deaths_total * 100).round(1) : nil,
-      ol_rate:             bool_rate(mps, :ex_overlimit_activated),
-      survival_stats:      calc_survival_stats(mps)
-    }
-  end
-
-  def avg_stat(mps, attr)
-    values = mps.map(&attr).compact
-    values.any? ? (values.sum.to_f / values.size).round(1) : nil
-  end
-
-  def bool_rate(mps, attr)
-    values = mps.map(&attr).compact
-    return nil if values.empty?
-
-    (values.count(&:itself) * 100.0 / values.size).round(1)
-  end
-
-  def calc_survival_stats(mps)
-    mps_with_st = mps.select { |mp| (mp.survival_times || []).any? }
-    return [] if mps_with_st.empty?
-
-    max_lives = mps_with_st.map { |mp| mp.survival_times.size }.max
-
-    max_lives.times.map do |i|
-      mps_with_life = mps_with_st.select { |mp| mp.survival_times.size > i }
-
-      # survival_times.size > deaths.to_i のとき最終ライフが生存で終わった
-      survived = mps_with_life.select do |mp|
-        mp.survival_times.size == i + 1 && mp.survival_times.size > mp.deaths.to_i
-      end
-      died = mps_with_life - survived
-
-      {
-        life:           i + 1,
-        survived_cs:    avg_cs_value(survived, i),
-        survived_count: survived.size,
-        died_cs:        avg_cs_value(died, i),
-        died_count:     died.size
-      }
-    end
-  end
-
-  def avg_cs_value(mps, life_index)
-    values = mps.filter_map { |mp| mp.survival_times[life_index] }
-    return nil if values.empty?
-
-    (values.sum.to_f / values.size).round(0).to_i
   end
 end

--- a/app/controllers/my_page_controller.rb
+++ b/app/controllers/my_page_controller.rb
@@ -9,7 +9,7 @@ class MyPageController < ApplicationController
                                      .index_by(&:slot)
     @selected_suit_ids = (0..11).filter_map { |s| @favorites_by_slot[s]&.mobile_suit_id }
 
-    @all_suits      = MobileSuit.all.order(:position)
+    @all_suits      = MobileSuit.position_order
     @costs          = COSTS
     @counts_by_cost = MobileSuit.group(:cost).count
 

--- a/app/models/mobile_suit.rb
+++ b/app/models/mobile_suit.rb
@@ -1,4 +1,7 @@
 class MobileSuit < ApplicationRecord
+  scope :catalog_order, -> { order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC")) }
+  scope :position_order, -> { order(:position) }
+
   # Validations
   validates :name, presence: true
   validates :series, presence: true

--- a/app/services/matches_filter_options.rb
+++ b/app/services/matches_filter_options.rb
@@ -6,7 +6,7 @@ class MatchesFilterOptions
   def to_h
     {
       all_events: Event.order(held_on: :desc),
-      all_mobile_suits: MobileSuit.order(Arel.sql("position IS NULL, position ASC, cost DESC, name ASC")),
+      all_mobile_suits: MobileSuit.catalog_order,
       all_users: all_users
     }
   end

--- a/app/services/mobile_suit_statistics_snapshot.rb
+++ b/app/services/mobile_suit_statistics_snapshot.rb
@@ -1,0 +1,256 @@
+class MobileSuitStatisticsSnapshot
+  def initialize(mobile_suit:)
+    @mobile_suit = mobile_suit
+  end
+
+  def to_h
+    {
+      total_uses: total_uses,
+      win_rate: win_rate,
+      dominance: dominance,
+      total_suits: all_suit_ids.size,
+      rank_uses: rank_uses,
+      rank_dominance: rank_dominance,
+      rank_win_rate: rank_win_rate,
+      total_suits_with_uses: win_rates_for_rank.size,
+      player_ranking: player_ranking,
+      partner_suits: partner_suits,
+      partner_costs: partner_costs,
+      global_perf: global_perf,
+      player_perf: player_perf
+    }
+  end
+
+  private
+
+  attr_reader :mobile_suit
+
+  def suit_match_players
+    @suit_match_players ||= MatchPlayer.where(mobile_suit_id: mobile_suit.id)
+                                       .joins(:match)
+                                       .includes(:user, match: { match_players: :mobile_suit })
+                                       .to_a
+  end
+
+  def total_uses
+    @total_uses ||= suit_match_players.size
+  end
+
+  def wins
+    @wins ||= suit_match_players.count(&:won?)
+  end
+
+  def win_rate
+    @win_rate ||= percentage(wins, total_uses)
+  end
+
+  def dominance
+    @dominance ||= (win_rate * total_uses).round(1)
+  end
+
+  def all_suit_ids
+    @all_suit_ids ||= MobileSuit.ids
+  end
+
+  def all_suit_counts
+    @all_suit_counts ||= MatchPlayer.joins(:match).group(:mobile_suit_id).count
+  end
+
+  def all_suit_wins
+    @all_suit_wins ||= MatchPlayer.joins(:match)
+                                  .where("matches.winning_team = match_players.team_number")
+                                  .group(:mobile_suit_id)
+                                  .count
+  end
+
+  def counts_for_rank
+    @counts_for_rank ||= all_suit_ids.index_with { |id| all_suit_counts[id] || 0 }
+  end
+
+  def dominance_for_rank
+    @dominance_for_rank ||= all_suit_ids.index_with do |id|
+      total = all_suit_counts[id] || 0
+      wins_count = all_suit_wins[id] || 0
+      (percentage(wins_count, total) * total).round(1)
+    end
+  end
+
+  def win_rates_for_rank
+    @win_rates_for_rank ||= all_suit_counts.each_with_object({}) do |(suit_id, total), result|
+      wins_count = all_suit_wins[suit_id] || 0
+      result[suit_id] = percentage(wins_count, total)
+    end
+  end
+
+  def rank_uses
+    value_rank(counts_for_rank, mobile_suit.id)
+  end
+
+  def rank_dominance
+    value_rank(dominance_for_rank, mobile_suit.id)
+  end
+
+  def rank_win_rate
+    value_rank(win_rates_for_rank, mobile_suit.id)
+  end
+
+  def player_ranking
+    suit_match_players.group_by(&:user_id)
+                     .map do |_, match_players|
+      {
+        user: match_players.first.user,
+        uses: match_players.size,
+        win_rate: percentage(match_players.count(&:won?), match_players.size)
+      }
+    end
+                     .sort_by { |data| -data[:uses] }
+                     .first(5)
+  end
+
+  def partner_suits
+    partner_stats_by_suit.map do |_, data|
+      total = data[:total]
+      {
+        mobile_suit: data[:mobile_suit],
+        total: total,
+        ratio: percentage(total, total_uses),
+        win_rate: percentage(data[:wins], total)
+      }
+    end.sort_by { |data| -data[:total] }
+  end
+
+  def partner_costs
+    partner_stats_by_cost.map do |cost, data|
+      total = data[:total]
+      {
+        cost: cost,
+        total: total,
+        ratio: percentage(total, total_uses),
+        win_rate: percentage(data[:wins], total)
+      }
+    end.sort_by { |data| -data[:total] }
+  end
+
+  def partner_stats_by_suit
+    @partner_stats_by_suit ||= begin
+      stats = Hash.new { |hash, key| hash[key] = { mobile_suit: nil, wins: 0, total: 0 } }
+
+      suit_match_players.each do |match_player|
+        partner = match_player.partner
+        next unless partner
+
+        stats[partner.mobile_suit_id][:mobile_suit] = partner.mobile_suit
+        stats[partner.mobile_suit_id][:total] += 1
+        stats[partner.mobile_suit_id][:wins] += 1 if match_player.won?
+      end
+
+      stats
+    end
+  end
+
+  def partner_stats_by_cost
+    @partner_stats_by_cost ||= begin
+      stats = Hash.new { |hash, key| hash[key] = { wins: 0, total: 0 } }
+
+      suit_match_players.each do |match_player|
+        partner = match_player.partner
+        next unless partner
+
+        stats[partner.mobile_suit.cost][:total] += 1
+        stats[partner.mobile_suit.cost][:wins] += 1 if match_player.won?
+      end
+
+      stats
+    end
+  end
+
+  def stats_match_players
+    @stats_match_players ||= suit_match_players.select(&:has_stats?)
+  end
+
+  def global_perf
+    build_perf(stats_match_players)
+  end
+
+  def player_perf
+    stats_match_players.group_by(&:user_id)
+                       .filter_map do |_, match_players|
+      build_perf(match_players)&.merge(user: match_players.first.user)
+    end
+                       .sort_by { |data| -data[:stats_count] }
+  end
+
+  def build_perf(match_players)
+    return nil if match_players.empty?
+
+    deaths_total = match_players.sum { |match_player| match_player.deaths.to_i }
+    exburst_deaths_total = match_players.sum { |match_player| match_player.exburst_deaths.to_i }
+
+    {
+      stats_count: match_players.size,
+      avg_score: average_stat(match_players, :score),
+      avg_kills: average_stat(match_players, :kills),
+      avg_deaths: average_stat(match_players, :deaths),
+      avg_damage_dealt: average_stat(match_players, :damage_dealt),
+      avg_damage_recv: average_stat(match_players, :damage_received),
+      avg_exburst_count: average_stat(match_players, :exburst_count),
+      avg_exburst_damage: average_stat(match_players, :exburst_damage),
+      avg_exburst_deaths: average_stat(match_players, :exburst_deaths),
+      exburst_death_ratio: deaths_total.positive? ? (exburst_deaths_total.to_f / deaths_total * 100).round(1) : nil,
+      ol_rate: bool_rate(match_players, :ex_overlimit_activated),
+      survival_stats: survival_stats(match_players)
+    }
+  end
+
+  def average_stat(match_players, attribute)
+    values = match_players.map(&attribute).compact
+    values.any? ? (values.sum.to_f / values.size).round(1) : nil
+  end
+
+  def bool_rate(match_players, attribute)
+    values = match_players.map(&attribute).compact
+    return nil if values.empty?
+
+    (values.count(&:itself) * 100.0 / values.size).round(1)
+  end
+
+  def survival_stats(match_players)
+    match_players_with_survival = match_players.select { |match_player| (match_player.survival_times || []).any? }
+    return [] if match_players_with_survival.empty?
+
+    max_lives = match_players_with_survival.map { |match_player| match_player.survival_times.size }.max
+
+    max_lives.times.map do |life_index|
+      match_players_with_life = match_players_with_survival.select { |match_player| match_player.survival_times.size > life_index }
+      survived, died = match_players_with_life.partition do |match_player|
+        match_player.survival_times.size == life_index + 1 && match_player.survival_times.size > match_player.deaths.to_i
+      end
+
+      {
+        life: life_index + 1,
+        survived_cs: average_cs_value(survived, life_index),
+        survived_count: survived.size,
+        died_cs: average_cs_value(died, life_index),
+        died_count: died.size
+      }
+    end
+  end
+
+  def average_cs_value(match_players, life_index)
+    values = match_players.filter_map { |match_player| match_player.survival_times[life_index] }
+    return nil if values.empty?
+
+    (values.sum.to_f / values.size).round(0).to_i
+  end
+
+  def value_rank(values_by_id, target_id)
+    target_value = values_by_id[target_id]
+    return nil if target_value.nil?
+
+    values_by_id.count { |_, value| value > target_value } + 1
+  end
+
+  def percentage(numerator, denominator)
+    denominator.positive? ? (numerator.to_f / denominator * 100).round(1) : 0.0
+  end
+end


### PR DESCRIPTION
## 概要
- MobileSuitsController の機体統計集計を service に分離
- MobileSuit の並び順指定を model scope に寄せる
- 既存画面の表示内容を維持しつつ controller の責務を軽くする

## 変更内容
- `MobileSuitStatisticsSnapshot` を追加し、機体詳細画面の集計ロジックを集約
- `MobileSuitsController#show` から大きな集計メソッド群を削除
- `MobileSuit` に `catalog_order` / `position_order` を追加
- 機体並び順を使う複数 controller で新しい scope を利用するよう整理

## 確認
- `RUBOCOP_CACHE_ROOT=/var/folders/wf/jsp91t4d0b167ccn_p5gd7lm0000gn/T/rubocop_cache bundle exec rubocop app/models/mobile_suit.rb app/controllers/mobile_suits_controller.rb app/controllers/admin/mobile_suits_controller.rb app/controllers/matches_controller.rb app/controllers/my_page_controller.rb app/services/matches_filter_options.rb app/services/mobile_suit_statistics_snapshot.rb`
- `bundle exec rails zeitwerk:check`
- `bundle exec brakeman --no-pager -i .brakeman.ignore`

Refs #275