### PR TITLE
refactor: イベント画面とワークフロー起動の責務を service に分離

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,42 +1,20 @@
 module Api
   class EventsController < BaseController
-    include TimestampParseable
     include MatchStatsImportable
 
     def timestamps
       event = Event.find_by(id: params[:id])
       return render json: { error: "Event not found" }, status: :not_found unless event
 
-      raw_text = params[:timestamps].to_s
-      lines = raw_text.split("\n").map(&:strip)
-      lines.pop while lines.last&.empty?
-
-      matches = event.matches.order(:played_at, :id)
-
-      if lines.size != matches.size
-        error_msg = "行数（#{lines.size}）と試合数（#{matches.size}）が一致しません。"
+      result = EventTimestampBatch.new(event: event).update(params[:timestamps].to_s)
+      unless result.success?
+        error_msg = result.error_message
         PushNotificationService.notify_timestamps_failed(event: event, error: error_msg)
         return render json: { error: error_msg }, status: :unprocessable_entity
       end
 
-      parsed = lines.map.with_index do |line, i|
-        seconds = parse_timestamp(line)
-        unless seconds
-          error_msg = "#{i + 1}行目「#{line}」の形式が不正です。H:MM:SS または MM:SS の形式で入力してください。"
-          PushNotificationService.notify_timestamps_failed(event: event, error: error_msg)
-          return render json: { error: error_msg }, status: :unprocessable_entity
-        end
-        seconds
-      end
-
-      ActiveRecord::Base.transaction do
-        matches.each_with_index do |match, i|
-          match.update!(video_timestamp: parsed[i])
-        end
-      end
-
-      PushNotificationService.notify_timestamps_registered(event: event, count: matches.size)
-      render json: { message: "OK", updated: matches.size }
+      PushNotificationService.notify_timestamps_registered(event: event, count: result.updated_count)
+      render json: { message: "OK", updated: result.updated_count }
     end
 
     def notify_failure

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,4 @@
-require "net/http"
-
 class EventsController < ApplicationController
-  include TimestampParseable
   before_action :authenticate_user!
   before_action :require_admin, only: [ :new, :create, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis, :trigger_scraping, :post_broadcast_to_discord ]
   before_action :set_event, only: [ :show, :edit, :update, :destroy, :edit_timestamps, :update_timestamps, :trigger_analysis, :trigger_scraping, :post_broadcast_to_discord ]
@@ -11,25 +8,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    sort = params[:sort].presence_in(%w[oldest reactions]) || "oldest"
-    @sort = sort
-    @per_page = [ 10, 20, 50 ].include?(params[:per].to_i) ? params[:per].to_i : 20
-
-    base_scope = sort == "reactions" ? @event.matches.by_reactions_oldest : @event.matches.by_oldest
-    @matches = base_scope
-                 .includes(:event, :rotation_match, match_players: [ :user, :mobile_suit ], reactions: :user)
-                 .page(params[:page]).per(@per_page)
-    @rotations = @event.rotations.order(created_at: :asc)
-    @emojis = MasterEmoji.active.ordered
-
-    ordered_ids = @event.matches.order(:played_at, :id).pluck(:id)
-    @match_numbers = ordered_ids.each_with_index.to_h { |id, i| [ id, i + 1 ] }
-
-    @my_favorite_match_ids = if viewing_as_user
-      FavoriteMatch.where(user_id: viewing_as_user.id, match_id: @matches.map(&:id)).pluck(:match_id).to_set
-    else
-      Set.new
-    end
+    assign_view_state(EventMatchListing.new(event: @event, params: params, viewing_as_user: viewing_as_user).to_h)
   end
 
   def new
@@ -58,125 +37,62 @@ class EventsController < ApplicationController
   end
 
   def edit_timestamps
-    @matches = @event.matches.includes(match_players: [ :user, :mobile_suit ]).order(:played_at, :id)
-    existing = @matches.map { |m| format_timestamp(m.video_timestamp) }
-    @timestamps_text = existing.any?(&:present?) ? existing.join("\n") : ""
+    timestamp_batch = EventTimestampBatch.new(event: @event)
+    @matches = timestamp_batch.matches
+    @timestamps_text = timestamp_batch.existing_text
   end
 
   def update_timestamps
-    @matches = @event.matches.includes(match_players: [ :user, :mobile_suit ]).order(:played_at, :id)
-    raw_text = params[:timestamps].to_s
-    lines = raw_text.split("\n").map(&:strip)
+    timestamp_batch = EventTimestampBatch.new(event: @event)
+    @matches = timestamp_batch.matches
+    result = timestamp_batch.update(params[:timestamps].to_s)
 
-    # 末尾の空行を除去
-    lines.pop while lines.last&.empty?
-
-    if lines.size != @matches.size
-      flash.now[:alert] = "行数（#{lines.size}）と試合数（#{@matches.size}）が一致しません。"
-      @timestamps_text = raw_text
+    if result.success?
+      redirect_to event_path(@event), notice: "タイムスタンプを保存しました。"
+    else
+      flash.now[:alert] = result.error_message
+      @timestamps_text = result.timestamps_text
       render :edit_timestamps, status: :unprocessable_entity
-      return
     end
-
-    timestamps = lines.map.with_index do |line, i|
-      if line.blank?
-        flash.now[:alert] = "#{i + 1}行目が空です。すべての行にタイムスタンプを入力してください。"
-        @timestamps_text = raw_text
-        render :edit_timestamps, status: :unprocessable_entity
-        return
-      end
-      seconds = parse_timestamp(line)
-      if seconds.nil?
-        flash.now[:alert] = "#{i + 1}行目「#{line}」の形式が不正です。H:MM:SS または MM:SS の形式で入力してください。"
-        @timestamps_text = raw_text
-        render :edit_timestamps, status: :unprocessable_entity
-        return
-      end
-      seconds
-    end
-
-    ActiveRecord::Base.transaction do
-      @matches.each_with_index do |match, i|
-        match.update!(video_timestamp: timestamps[i])
-      end
-    end
-
-    redirect_to event_path(@event), notice: "タイムスタンプを保存しました。"
   end
 
   def trigger_analysis
-    repo = ENV["GITHUB_REPO"].presence
-    workflow_id = ENV["GITHUB_WORKFLOW_ID"].presence
-    token = ENV["GITHUB_TOKEN"].presence
-
-    if repo.blank? || workflow_id.blank? || token.blank?
-      return redirect_to event_path(@event), alert: "GitHub Actions の設定が不完全です（GITHUB_REPO / GITHUB_WORKFLOW_ID / GITHUB_TOKEN を確認してください）。"
-    end
-
-    uri = URI("https://api.github.com/repos/#{repo}/actions/workflows/#{workflow_id}/dispatches")
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
-
-    req = Net::HTTP::Post.new(uri.path, {
-      "Authorization" => "Bearer #{token}",
-      "Accept" => "application/vnd.github+json",
-      "Content-Type" => "application/json",
-      "X-GitHub-Api-Version" => "2022-11-28"
-    })
-    req.body = {
-      ref: "main",
+    dispatch_result = GithubActionsWorkflowDispatcher.new(
+      repo: ENV["GITHUB_REPO"].presence,
+      workflow_id: ENV["GITHUB_WORKFLOW_ID"].presence,
+      token: ENV["GITHUB_TOKEN"].presence,
       inputs: {
         event_id: @event.id.to_s,
         broadcast_url: @event.broadcast_url
-      }
-    }.to_json
+      },
+      missing_config_message: "GitHub Actions の設定が不完全です（GITHUB_REPO / GITHUB_WORKFLOW_ID / GITHUB_TOKEN を確認してください）。",
+      exception_message_prefix: "解析開始でエラーが発生しました"
+    ).call
 
-    res = http.request(req)
-
-    if res.is_a?(Net::HTTPNoContent)
+    if dispatch_result.success?
       redirect_to event_path(@event), notice: "解析を開始しました。完了後にタイムスタンプが自動登録されます。"
     else
-      redirect_to event_path(@event), alert: "GitHub Actions のトリガーに失敗しました（HTTP #{res.code}）。"
+      redirect_to event_path(@event), alert: dispatch_result.error_message
     end
-  rescue => e
-    redirect_to event_path(@event), alert: "解析開始でエラーが発生しました: #{e.message}"
   end
 
   def trigger_scraping
-    repo        = ENV["SCRAPER_GITHUB_REPO"].presence
-    workflow_id = ENV["SCRAPER_GITHUB_WORKFLOW_ID"].presence
-    token       = ENV["GITHUB_TOKEN"].presence
-
-    if repo.blank? || workflow_id.blank? || token.blank?
-      return redirect_to event_path(@event), alert: "スクレイパーの設定が不完全です（SCRAPER_GITHUB_REPO / SCRAPER_GITHUB_WORKFLOW_ID / GITHUB_TOKEN を確認してください）。"
-    end
-
-    uri = URI("https://api.github.com/repos/#{repo}/actions/workflows/#{workflow_id}/dispatches")
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
-
-    req = Net::HTTP::Post.new(uri.path, {
-      "Authorization" => "Bearer #{token}",
-      "Accept" => "application/vnd.github+json",
-      "Content-Type" => "application/json",
-      "X-GitHub-Api-Version" => "2022-11-28"
-    })
-    req.body = {
-      ref: "main",
+    dispatch_result = GithubActionsWorkflowDispatcher.new(
+      repo: ENV["SCRAPER_GITHUB_REPO"].presence,
+      workflow_id: ENV["SCRAPER_GITHUB_WORKFLOW_ID"].presence,
+      token: ENV["GITHUB_TOKEN"].presence,
       inputs: {
         event_id: @event.id.to_s
-      }
-    }.to_json
+      },
+      missing_config_message: "スクレイパーの設定が不完全です（SCRAPER_GITHUB_REPO / SCRAPER_GITHUB_WORKFLOW_ID / GITHUB_TOKEN を確認してください）。",
+      exception_message_prefix: "スクレイピング開始でエラーが発生しました"
+    ).call
 
-    res = http.request(req)
-
-    if res.is_a?(Net::HTTPNoContent)
+    if dispatch_result.success?
       redirect_to event_path(@event), notice: "統計スクレイピングを開始しました。完了後に統計データが自動登録されます。"
     else
-      redirect_to event_path(@event), alert: "GitHub Actions のトリガーに失敗しました（HTTP #{res.code}）。"
+      redirect_to event_path(@event), alert: dispatch_result.error_message
     end
-  rescue => e
-    redirect_to event_path(@event), alert: "スクレイピング開始でエラーが発生しました: #{e.message}"
   end
 
   def post_broadcast_to_discord
@@ -210,6 +126,12 @@ class EventsController < ApplicationController
 
   def set_event
     @event = Event.find(params[:id])
+  end
+
+  def assign_view_state(attributes)
+    attributes.each do |name, value|
+      instance_variable_set("@#{name}", value)
+    end
   end
 
   def event_params

--- a/app/services/event_match_listing.rb
+++ b/app/services/event_match_listing.rb
@@ -1,0 +1,54 @@
+class EventMatchListing
+  SORT_OPTIONS = %w[oldest reactions].freeze
+  PER_PAGE_OPTIONS = [ 10, 20, 50 ].freeze
+
+  def initialize(event:, params:, viewing_as_user:)
+    @event = event
+    @params = params
+    @viewing_as_user = viewing_as_user
+  end
+
+  def to_h
+    {
+      sort: sort,
+      per_page: per_page,
+      matches: matches,
+      rotations: event.rotations.order(created_at: :asc),
+      emojis: MasterEmoji.active.ordered,
+      match_numbers: match_numbers,
+      my_favorite_match_ids: favorite_match_ids
+    }
+  end
+
+  private
+
+  attr_reader :event, :params, :viewing_as_user
+
+  def sort
+    @sort ||= params[:sort].presence_in(SORT_OPTIONS) || "oldest"
+  end
+
+  def per_page
+    @per_page ||= PER_PAGE_OPTIONS.include?(params[:per].to_i) ? params[:per].to_i : 20
+  end
+
+  def matches
+    @matches ||= match_scope.page(params[:page]).per(per_page)
+  end
+
+  def match_numbers
+    ordered_ids = event.matches.order(:played_at, :id).pluck(:id)
+    ordered_ids.each_with_index.to_h { |id, index| [ id, index + 1 ] }
+  end
+
+  def favorite_match_ids
+    return Set.new unless viewing_as_user
+
+    FavoriteMatch.where(user_id: viewing_as_user.id, match_id: matches.map(&:id)).pluck(:match_id).to_set
+  end
+
+  def match_scope
+    base_scope = sort == "reactions" ? event.matches.by_reactions_oldest : event.matches.by_oldest
+    base_scope.includes(:event, :rotation_match, match_players: [ :user, :mobile_suit ], reactions: :user)
+  end
+end

--- a/app/services/event_timestamp_batch.rb
+++ b/app/services/event_timestamp_batch.rb
@@ -1,0 +1,60 @@
+class EventTimestampBatch
+  include TimestampParseable
+
+  Result = Struct.new(:success?, :error_message, :timestamps_text, :updated_count, keyword_init: true)
+
+  def initialize(event:)
+    @event = event
+  end
+
+  def matches
+    @matches ||= event.matches.includes(match_players: [ :user, :mobile_suit ]).order(:played_at, :id)
+  end
+
+  def existing_text
+    existing = matches.map { |match| format_timestamp(match.video_timestamp) }
+    existing.any?(&:present?) ? existing.join("\n") : ""
+  end
+
+  def update(raw_text)
+    lines = normalized_lines(raw_text)
+
+    return failure_result(raw_text, "行数（#{lines.size}）と試合数（#{matches.size}）が一致しません。") if lines.size != matches.size
+
+    timestamps = parse_lines(lines, raw_text)
+    return timestamps if timestamps.is_a?(Result)
+
+    ActiveRecord::Base.transaction do
+      matches.each_with_index do |match, index|
+        match.update!(video_timestamp: timestamps[index])
+      end
+    end
+
+    Result.new(success?: true, timestamps_text: raw_text, updated_count: matches.size)
+  end
+
+  private
+
+  attr_reader :event
+
+  def normalized_lines(raw_text)
+    lines = raw_text.to_s.split("\n").map(&:strip)
+    lines.pop while lines.last&.empty?
+    lines
+  end
+
+  def parse_lines(lines, raw_text)
+    lines.map.with_index do |line, index|
+      return failure_result(raw_text, "#{index + 1}行目が空です。すべての行にタイムスタンプを入力してください。") if line.blank?
+
+      seconds = parse_timestamp(line)
+      return failure_result(raw_text, "#{index + 1}行目「#{line}」の形式が不正です。H:MM:SS または MM:SS の形式で入力してください。") if seconds.nil?
+
+      seconds
+    end
+  end
+
+  def failure_result(raw_text, message)
+    Result.new(success?: false, error_message: message, timestamps_text: raw_text)
+  end
+end

--- a/app/services/github_actions_workflow_dispatcher.rb
+++ b/app/services/github_actions_workflow_dispatcher.rb
@@ -1,0 +1,58 @@
+require "net/http"
+
+class GithubActionsWorkflowDispatcher
+  Result = Struct.new(:success?, :error_message, keyword_init: true)
+
+  def initialize(repo:, workflow_id:, token:, inputs:, missing_config_message:, exception_message_prefix:, ref: "main")
+    @repo = repo
+    @workflow_id = workflow_id
+    @token = token
+    @inputs = inputs
+    @missing_config_message = missing_config_message
+    @exception_message_prefix = exception_message_prefix
+    @ref = ref
+  end
+
+  def call
+    return Result.new(success?: false, error_message: missing_config_message) if missing_config?
+
+    response = http.request(request)
+    if response.is_a?(Net::HTTPNoContent)
+      Result.new(success?: true)
+    else
+      Result.new(success?: false, error_message: "GitHub Actions のトリガーに失敗しました（HTTP #{response.code}）。")
+    end
+  rescue => error
+    Result.new(success?: false, error_message: "#{exception_message_prefix}: #{error.message}")
+  end
+
+  private
+
+  attr_reader :repo, :workflow_id, :token, :inputs, :missing_config_message, :exception_message_prefix, :ref
+
+  def missing_config?
+    repo.blank? || workflow_id.blank? || token.blank?
+  end
+
+  def http
+    uri = dispatch_uri
+    Net::HTTP.new(uri.host, uri.port).tap do |client|
+      client.use_ssl = true
+    end
+  end
+
+  def request
+    Net::HTTP::Post.new(dispatch_uri.path, {
+      "Authorization" => "Bearer #{token}",
+      "Accept" => "application/vnd.github+json",
+      "Content-Type" => "application/json",
+      "X-GitHub-Api-Version" => "2022-11-28"
+    }).tap do |http_request|
+      http_request.body = { ref: ref, inputs: inputs }.to_json
+    end
+  end
+
+  def dispatch_uri
+    @dispatch_uri ||= URI("https://api.github.com/repos/#{repo}/actions/workflows/#{workflow_id}/dispatches")
+  end
+end


### PR DESCRIPTION
## 概要
- EventsController の show / タイムスタンプ更新 / GitHub Actions 起動の責務を service に分離
- Api::EventsController のタイムスタンプ更新も同じ service を利用して重複を解消

## 変更内容
- EventMatchListing でイベント詳細画面の一覧状態を集約
- EventTimestampBatch でタイムスタンプの表示整形と一括更新を共通化
- GithubActionsWorkflowDispatcher で workflow dispatch を共通化

## 確認
- bundle exec rubocop app/controllers/events_controller.rb app/controllers/api/events_controller.rb app/services/event_match_listing.rb app/services/event_timestamp_batch.rb app/services/github_actions_workflow_dispatcher.rb
- bundle exec rails zeitwerk:check
- bundle exec brakeman --no-pager -i .brakeman.ignore

Refs #275