### PR TITLE
refactor: ローテーション進行と表示状態の責務を service に分離

### DIFF
--- a/app/controllers/rotations_controller.rb
+++ b/app/controllers/rotations_controller.rb
@@ -1,7 +1,7 @@
 class RotationsController < ApplicationController
   before_action :authenticate_user!
   before_action :require_admin, except: [ :index, :show ]
-  before_action :set_rotation, only: [ :show, :edit, :update, :destroy, :activate, :deactivate, :next_match, :record_match, :go_to_match, :update_match_record ]
+  before_action :set_rotation, only: [ :show, :edit, :update, :destroy, :activate, :deactivate, :next_match, :record_match, :go_to_match, :update_match_record, :copy_for_next_round ]
   before_action :set_event, only: [ :new, :create ]
 
   def index
@@ -9,24 +9,12 @@ class RotationsController < ApplicationController
   end
 
   def show
-    @rotation_matches = @rotation.rotation_matches
-                                  .includes(:team1_player1, :team1_player2, :team2_player1, :team2_player2,
-                                            match: { match_players: :mobile_suit })
-                                  .order(:match_index)
-    @current_match = @rotation_matches[@rotation.current_match_index]
-    @player_statistics = @rotation.player_statistics(@rotation_matches)
-    @all_mobile_suits = MobileSuit.order(:name).to_a
-
-    # プレイヤーのお気に入り機体を N+1 を起こさずまとめてロード
-    if @current_match
-      ActiveRecord::Associations::Preloader.new(records: @current_match.players, associations: :user_favorite_suits).call
-    end
-
-    # Check if we should show completion modal
-    if session[:show_completion_modal] == @rotation.id
-      @show_completion_modal = true
-      session.delete(:show_completion_modal)
-    end
+    assign_view_state(
+      RotationShowSnapshot.new(
+        rotation: @rotation,
+        show_completion_modal: consume_completion_modal_flag
+      ).to_h
+    )
   end
 
   def new
@@ -51,9 +39,14 @@ class RotationsController < ApplicationController
     end
 
     if @rotation.save
-      # Generate rotation matches
-      generate_rotation_matches(@rotation, player_ids)
-      redirect_to @rotation, notice: "ローテーションを作成しました。"
+      result = RotationWorkflowManager.new(rotation: @rotation).generate_matches!(player_ids: player_ids)
+      if result.success?
+        redirect_to @rotation, notice: "ローテーションを作成しました。"
+      else
+        @rotation.destroy
+        @rotation.errors.add(:base, result.error_message)
+        render :new, status: :unprocessable_entity
+      end
     else
       render :new, status: :unprocessable_entity
     end
@@ -79,225 +72,59 @@ class RotationsController < ApplicationController
 
   # Activate this rotation
   def activate
-    # Deactivate all rotations for this event
-    @rotation.event.rotations.update_all(is_active: false)
-
-    # Activate this rotation
-    @rotation.update(is_active: true)
-
-    # Record started_at for the current match
-    mark_current_match_started(@rotation)
-
-    # Send push notifications to all players
-    PushNotificationService.notify_rotation_activated(rotation: @rotation)
-
-    # Send upcoming match notifications (1試合目の出番通知含む)
-    notify_upcoming_players(@rotation)
-
-    redirect_to @rotation, notice: "ローテーションをアクティブにしました。"
+    result = RotationWorkflowManager.new(rotation: @rotation).activate!
+    redirect_with_result(@rotation, result, success_notice: "ローテーションをアクティブにしました。")
   end
 
   # Deactivate this rotation
   def deactivate
-    @rotation.update(is_active: false)
-    redirect_to @rotation, notice: "ローテーションを非アクティブにしました。"
+    result = RotationWorkflowManager.new(rotation: @rotation).deactivate!
+    redirect_with_result(@rotation, result, success_notice: "ローテーションを非アクティブにしました。")
   end
 
   # Move to next match
   def next_match
-    if @rotation.current_match_index < @rotation.rotation_matches.count - 1
-      @rotation.increment!(:current_match_index)
-
-      # Record started_at for the current match
-      mark_current_match_started(@rotation)
-
-      # Broadcast update via Action Cable
-      RotationChannel.broadcast_to(@rotation, {
-        type: "rotation_updated",
-        current_match_index: @rotation.current_match_index
-      })
-
-      # Send push notifications to upcoming players
-      notify_upcoming_players(@rotation)
-
-      redirect_to @rotation, notice: "次の試合に進みました。"
-    else
-      redirect_to @rotation, alert: "これが最後の試合です。"
-    end
+    result = RotationWorkflowManager.new(rotation: @rotation).next_match!
+    redirect_with_result(@rotation, result, success_notice: "次の試合に進みました。")
   end
 
   # Go to specific match (for skipped matches)
   def go_to_match
     match_index = params[:match_index].to_i
-
-    if match_index >= 0 && match_index < @rotation.rotation_matches.count
-      @rotation.update!(current_match_index: match_index)
-
-      # Record started_at for the current match
-      mark_current_match_started(@rotation)
-
-      # Broadcast update via Action Cable
-      RotationChannel.broadcast_to(@rotation, {
-        type: "rotation_updated",
-        current_match_index: @rotation.current_match_index
-      })
-
-      redirect_to @rotation, notice: "第#{match_index + 1}試合に戻りました。"
-    else
-      redirect_to @rotation, alert: "無効な試合番号です。"
-    end
+    result = RotationWorkflowManager.new(rotation: @rotation).go_to_match!(match_index: match_index)
+    redirect_with_result(@rotation, result, success_notice: "第#{match_index + 1}試合に戻りました。")
   end
 
   # Record match result
   def record_match
-    Rails.logger.info "=== Record Match Called ==="
-    Rails.logger.info "Params: #{params.inspect}"
-
-    rotation_match = @rotation.rotation_matches.find_by(match_index: @rotation.current_match_index)
-
-    unless rotation_match
-      Rails.logger.error "Rotation match not found for index: #{@rotation.current_match_index}"
-      redirect_to @rotation, alert: "試合が見つかりません。" and return
-    end
-
-    # Create match record
-    match = @rotation.event.matches.build(
-      played_at: Time.current,
+    result = RotationWorkflowManager.new(rotation: @rotation).record_current_match!(
       winning_team: params[:winning_team].to_i,
-      rotation_match: rotation_match
+      suit_ids: rotation_match_suit_ids
     )
 
-    # Build match players before saving
-    rotation_match.match_player_attributes(rotation_match_suit_ids).each do |mp|
-      match.match_players.build(
-        user: mp[:user],
-        mobile_suit_id: mp[:mobile_suit_id],
-        team_number: mp[:team_number],
-        position: mp[:position]
-      )
-    end
-
-    begin
-      if match.save
-        # Link rotation match to match
-        rotation_match.update(match: match)
-
-        # Move to next unrecorded match
-        next_unrecorded_index = find_next_unrecorded_match_index(@rotation)
-        if next_unrecorded_index
-          @rotation.update!(current_match_index: next_unrecorded_index)
-          mark_current_match_started(@rotation)
-        end
-
-        # Broadcast update via Action Cable
-        RotationChannel.broadcast_to(@rotation, {
-          type: "rotation_updated",
-          current_match_index: @rotation.current_match_index
-        })
-
-        # Check if all matches are completed
-        all_completed = @rotation.rotation_matches.all? { |rm| rm.match.present? }
-
-        # Send push notifications to upcoming players
-        notify_upcoming_players(@rotation) unless all_completed
-
-        Rails.logger.info "Match recorded successfully: #{match.id}"
-
-        if all_completed
-          # All matches completed - deactivate this rotation and show modal to create next round
-          @rotation.update!(is_active: false)
-          session[:show_completion_modal] = @rotation.id
-          redirect_to @rotation, notice: "試合を記録しました。"
-        else
-          redirect_to @rotation, notice: "試合を記録しました。"
-        end
-      else
-        Rails.logger.error "Match save failed: #{match.errors.full_messages}"
-        redirect_to @rotation, alert: "試合の記録に失敗しました: #{match.errors.full_messages.join(', ')}"
-      end
-    rescue => e
-      Rails.logger.error "Exception in record_match: #{e.message}"
-      Rails.logger.error e.backtrace.join("\n")
-      redirect_to @rotation, alert: "試合の記録中にエラーが発生しました: #{e.message}"
-    end
+    session[:show_completion_modal] = @rotation.id if result.success? && result.completed
+    redirect_with_result(@rotation, result, success_notice: "試合を記録しました。")
   end
-
-  # Player view for real-time status
-  # DEPRECATED: Player view is now integrated into the dashboard
-  # def player_view
-  #   @current_user_id = viewing_as_user.id
-  #   @next_match = @rotation.next_match_for_player(@current_user_id)
-  #   @player_statistics = @rotation.player_statistics
-  #
-  #   if @next_match
-  #     @match_info = @rotation.match_info_for_player(@next_match, @current_user_id)
-  #     @matches_until_next = @next_match.match_index - @rotation.current_match_index
-  #   end
-  #
-  #   # Real-time updates via Action Cable (no HTTP refresh needed)
-  # end
 
   # Update existing match record without moving rotation
   def update_match_record
-    rotation_match = @rotation.rotation_matches.find_by(match_index: params[:match_index].to_i)
+    result = RotationWorkflowManager.new(rotation: @rotation).update_match_record!(
+      match_index: params[:match_index].to_i,
+      winning_team: params[:winning_team].to_i,
+      suit_ids: rotation_match_suit_ids
+    )
 
-    unless rotation_match && rotation_match.match
-      redirect_to @rotation, alert: "試合が見つかりません。" and return
-    end
-
-    match = rotation_match.match
-
-    # Update match record
-    match.winning_team = params[:winning_team].to_i
-
-    # Update match players
-    match.match_players.destroy_all
-    rotation_match.match_player_attributes(rotation_match_suit_ids).each do |mp|
-      match.match_players.build(
-        user: mp[:user],
-        mobile_suit_id: mp[:mobile_suit_id],
-        team_number: mp[:team_number],
-        position: mp[:position]
-      )
-    end
-
-    if match.save
-      redirect_to @rotation, notice: "試合記録を更新しました。"
-    else
-      redirect_to @rotation, alert: "試合記録の更新に失敗しました: #{match.errors.full_messages.join(', ')}"
-    end
-  rescue => e
-    redirect_to @rotation, alert: "試合記録の更新中にエラーが発生しました: #{e.message}"
+    redirect_with_result(@rotation, result, success_notice: "試合記録を更新しました。")
   end
 
   # Copy rotation for next round
   def copy_for_next_round
-    @rotation = Rotation.find(params[:id])
-
-    new_rotation = @rotation.event.rotations.create!(
-      round_number: @rotation.round_number + 1,
-      base_rotation_id: @rotation.id
-    )
-
-    # Re-generate rotation matches with reshuffled player slots so that streaming
-    # patterns differ between rounds (same opponents/partners when streaming)
-    player_ids = @rotation.rotation_matches.flat_map(&:player_ids).uniq
-    generate_rotation_matches(new_rotation, player_ids)
-
-    # Deactivate all rotations for this event
-    @rotation.event.rotations.update_all(is_active: false)
-
-    # Activate the new rotation
-    new_rotation.update!(is_active: true)
-
-    # Record started_at for the first match
-    mark_current_match_started(new_rotation)
-
-    # Send push notifications for new round
-    PushNotificationService.notify_rotation_activated(rotation: new_rotation)
-    notify_upcoming_players(new_rotation)
-
-    redirect_to new_rotation, notice: "#{new_rotation.round_number}周目のローテーションを作成しました。"
+    result = RotationWorkflowManager.new(rotation: @rotation).copy_for_next_round!
+    if result.success?
+      redirect_to result.new_rotation, notice: "#{result.new_rotation.round_number}周目のローテーションを作成しました。"
+    else
+      redirect_to @rotation, alert: result.error_message
+    end
   end
 
   private
@@ -314,84 +141,6 @@ class RotationsController < ApplicationController
     params.require(:rotation).permit(:round_number)
   end
 
-  # Find the next unrecorded match starting from current position
-  def find_next_unrecorded_match_index(rotation)
-    rotation_matches = rotation.rotation_matches.includes(:match).order(:match_index)
-
-    # Start searching from the current match index
-    rotation_matches.each do |rm|
-      if rm.match_index > rotation.current_match_index && rm.match.nil?
-        return rm.match_index
-      end
-    end
-
-    # If no unrecorded match found after current position, check from the beginning
-    rotation_matches.each do |rm|
-      if rm.match.nil?
-        return rm.match_index
-      end
-    end
-
-    # All matches are recorded, stay at the last match
-    rotation.rotation_matches.count - 1
-  end
-
-  def notify_upcoming_players(rotation)
-    current_index = rotation.current_match_index
-    rotation_matches = rotation.rotation_matches
-                               .includes(:team1_player1, :team1_player2, :team2_player1, :team2_player2)
-                               .order(:match_index)
-
-    # 全プレイヤーのIDを収集
-    all_player_ids = rotation_matches.flat_map(&:player_ids).uniq
-
-    # 各プレイヤーの「次の試合」を特定して通知
-    all_player_ids.each do |player_id|
-      # このプレイヤーの次の試合を探す（current_index以降でまだ記録されていない試合）
-      next_match = rotation_matches.find do |rm|
-        rm.match_index >= current_index &&
-        rm.match_id.nil? &&
-        rm.includes_player?(player_id)
-      end
-
-      next unless next_match
-
-      matches_until = next_match.match_index - current_index
-
-      # 3試合以上先は通知しない
-      next if matches_until > 2
-
-      # 座席情報とパートナーを特定
-      seat_info = next_match.seat_info_for(player_id)
-      user = User.find_by(id: player_id)
-      next unless user
-
-      if matches_until == 0
-        PushNotificationService.notify_match_now(
-          user: user,
-          rotation: rotation,
-          match_number: next_match.match_index + 1,
-          seat_position: seat_info[:seat],
-          partner_name: seat_info[:partner]&.nickname
-        )
-      else
-        PushNotificationService.notify_match_upcoming(
-          user: user,
-          matches_until_turn: matches_until,
-          rotation: rotation,
-          current_match_number: current_index + 1,
-          seat_position: seat_info[:seat],
-          partner_name: seat_info[:partner]&.nickname
-        )
-      end
-    end
-  end
-
-  def mark_current_match_started(rotation)
-    rm = rotation.rotation_matches.find_by(match_index: rotation.current_match_index)
-    rm&.update!(started_at: Time.current) if rm && rm.started_at.nil?
-  end
-
   def rotation_match_suit_ids
     {
       team1_player1: params[:team1_player1_suit],
@@ -401,26 +150,24 @@ class RotationsController < ApplicationController
     }
   end
 
-  def generate_rotation_matches(rotation, player_ids)
-    return unless player_ids.present?
-
-    players = User.where(id: player_ids).to_a
-    return if players.size < 4
-
-    # Use RotationGenerator service to create balanced matches
-    # Shuffle players so slot assignment (A, B, C...) is randomized each time
-    generator = RotationGenerator.new(players.shuffle)
-    matches = generator.generate
-
-    # Create rotation matches from generated data
-    matches.each do |match_data|
-      rotation.rotation_matches.create!(
-        match_index: match_data[:match_index],
-        team1_player1: match_data[:team1_player1],
-        team1_player2: match_data[:team1_player2],
-        team2_player1: match_data[:team2_player1],
-        team2_player2: match_data[:team2_player2]
-      )
+  def assign_view_state(attributes)
+    attributes.each do |name, value|
+      instance_variable_set("@#{name}", value)
     end
+  end
+
+  def redirect_with_result(path, result, success_notice:)
+    if result.success?
+      redirect_to path, notice: success_notice
+    else
+      redirect_to path, alert: result.error_message
+    end
+  end
+
+  def consume_completion_modal_flag
+    return false unless session[:show_completion_modal] == @rotation.id
+
+    session.delete(:show_completion_modal)
+    true
   end
 end

--- a/app/services/rotation_show_snapshot.rb
+++ b/app/services/rotation_show_snapshot.rb
@@ -1,0 +1,48 @@
+class RotationShowSnapshot
+  def initialize(rotation:, show_completion_modal:)
+    @rotation = rotation
+    @show_completion_modal = show_completion_modal
+  end
+
+  def to_h
+    preload_current_match_favorites
+
+    {
+      rotation_matches: rotation_matches,
+      current_match: current_match,
+      player_statistics: rotation.player_statistics(rotation_matches),
+      all_mobile_suits: MobileSuit.order(:name).to_a,
+      show_completion_modal: show_completion_modal
+    }
+  end
+
+  private
+
+  attr_reader :rotation, :show_completion_modal
+
+  def rotation_matches
+    @rotation_matches ||= rotation.rotation_matches
+                                 .includes(
+                                   :team1_player1,
+                                   :team1_player2,
+                                   :team2_player1,
+                                   :team2_player2,
+                                   match: { match_players: :mobile_suit }
+                                 )
+                                 .order(:match_index)
+                                 .to_a
+  end
+
+  def current_match
+    @current_match ||= rotation_matches[rotation.current_match_index]
+  end
+
+  def preload_current_match_favorites
+    return unless current_match
+
+    ActiveRecord::Associations::Preloader.new(
+      records: current_match.players,
+      associations: :user_favorite_suits
+    ).call
+  end
+end

--- a/app/services/rotation_workflow_manager.rb
+++ b/app/services/rotation_workflow_manager.rb
@@ -1,0 +1,274 @@
+class RotationWorkflowManager
+  Result = Struct.new(:success?, :rotation, :new_rotation, :completed, :error_message, keyword_init: true)
+
+  def initialize(rotation:)
+    @rotation = rotation
+  end
+
+  def generate_matches!(player_ids:)
+    return success_result(rotation: rotation) unless player_ids.present?
+
+    players = User.where(id: player_ids).to_a
+    return success_result(rotation: rotation) if players.size < 4
+
+    ActiveRecord::Base.transaction do
+      generate_matches_for_rotation!(rotation, players)
+    end
+
+    success_result(rotation: rotation)
+  rescue StandardError => error
+    failure_result(error.message)
+  end
+
+  def activate!
+    ActiveRecord::Base.transaction do
+      rotation.event.rotations.update_all(is_active: false)
+      rotation.update!(is_active: true)
+      mark_current_match_started(rotation)
+    end
+
+    PushNotificationService.notify_rotation_activated(rotation: rotation)
+    notify_upcoming_players(rotation)
+    success_result(rotation: rotation)
+  rescue StandardError => error
+    failure_result(error.message)
+  end
+
+  def deactivate!
+    rotation.update!(is_active: false)
+    success_result(rotation: rotation)
+  rescue StandardError => error
+    failure_result(error.message)
+  end
+
+  def next_match!
+    return failure_result("これが最後の試合です。") unless next_match_available?
+
+    rotation.increment!(:current_match_index)
+    mark_current_match_started(rotation)
+    broadcast_rotation_update(rotation)
+    notify_upcoming_players(rotation)
+    success_result(rotation: rotation)
+  rescue StandardError => error
+    failure_result(error.message)
+  end
+
+  def go_to_match!(match_index:)
+    return failure_result("無効な試合番号です。") unless valid_match_index?(match_index)
+
+    rotation.update!(current_match_index: match_index)
+    mark_current_match_started(rotation)
+    broadcast_rotation_update(rotation)
+    success_result(rotation: rotation)
+  rescue StandardError => error
+    failure_result(error.message)
+  end
+
+  def record_current_match!(winning_team:, suit_ids:)
+    rotation_match = rotation.rotation_matches.find_by(match_index: rotation.current_match_index)
+    return failure_result("試合が見つかりません。") unless rotation_match
+
+    match = rotation.event.matches.build(
+      played_at: Time.current,
+      winning_team: winning_team,
+      rotation_match: rotation_match
+    )
+    build_match_players(match, rotation_match, suit_ids)
+
+    completed = false
+
+    ActiveRecord::Base.transaction do
+      unless match.save
+        raise ActiveRecord::Rollback
+      end
+
+      rotation_match.update!(match: match)
+
+      next_unrecorded_index = next_unrecorded_match_index(rotation)
+      if next_unrecorded_index
+        rotation.update!(current_match_index: next_unrecorded_index)
+        mark_current_match_started(rotation)
+      end
+
+      completed = rotation.rotation_matches.where(match_id: nil).none?
+      rotation.update!(is_active: false) if completed
+    end
+
+    return failure_result("試合の記録に失敗しました: #{match.errors.full_messages.join(', ')}") if match.errors.any?
+
+    broadcast_rotation_update(rotation)
+    notify_upcoming_players(rotation) unless completed
+    success_result(rotation: rotation, completed: completed)
+  rescue StandardError => error
+    failure_result("試合の記録中にエラーが発生しました: #{error.message}")
+  end
+
+  def update_match_record!(match_index:, winning_team:, suit_ids:)
+    rotation_match = rotation.rotation_matches.find_by(match_index: match_index)
+    return failure_result("試合が見つかりません。") unless rotation_match&.match
+
+    match = rotation_match.match
+
+    ActiveRecord::Base.transaction do
+      match.winning_team = winning_team
+      match.match_players.destroy_all
+      build_match_players(match, rotation_match, suit_ids)
+
+      unless match.save
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    if match.errors.any?
+      failure_result("試合記録の更新に失敗しました: #{match.errors.full_messages.join(', ')}")
+    else
+      success_result(rotation: rotation)
+    end
+  rescue StandardError => error
+    failure_result("試合記録の更新中にエラーが発生しました: #{error.message}")
+  end
+
+  def copy_for_next_round!
+    new_rotation = nil
+
+    ActiveRecord::Base.transaction do
+      new_rotation = rotation.event.rotations.create!(
+        round_number: rotation.round_number + 1,
+        base_rotation_id: rotation.id
+      )
+
+      generate_matches_for_rotation!(new_rotation, player_ids_for_next_round)
+      rotation.event.rotations.update_all(is_active: false)
+      new_rotation.update!(is_active: true)
+      mark_current_match_started(new_rotation)
+    end
+
+    PushNotificationService.notify_rotation_activated(rotation: new_rotation)
+    notify_upcoming_players(new_rotation)
+    success_result(rotation: rotation, new_rotation: new_rotation)
+  rescue StandardError => error
+    failure_result(error.message)
+  end
+
+  private
+
+  attr_reader :rotation
+
+  def next_match_available?
+    rotation.current_match_index < rotation.rotation_matches.count - 1
+  end
+
+  def valid_match_index?(match_index)
+    match_index >= 0 && match_index < rotation.rotation_matches.count
+  end
+
+  def build_match_players(match, rotation_match, suit_ids)
+    rotation_match.match_player_attributes(suit_ids).each do |attributes|
+      match.match_players.build(
+        user: attributes[:user],
+        mobile_suit_id: attributes[:mobile_suit_id],
+        team_number: attributes[:team_number],
+        position: attributes[:position]
+      )
+    end
+  end
+
+  def next_unrecorded_match_index(target_rotation)
+    ordered_matches = target_rotation.rotation_matches.includes(:match).order(:match_index)
+
+    ordered_matches.each do |rotation_match|
+      return rotation_match.match_index if rotation_match.match_index > target_rotation.current_match_index && rotation_match.match.nil?
+    end
+
+    ordered_matches.each do |rotation_match|
+      return rotation_match.match_index if rotation_match.match.nil?
+    end
+
+    target_rotation.rotation_matches.count - 1
+  end
+
+  def notify_upcoming_players(target_rotation)
+    current_index = target_rotation.current_match_index
+    ordered_matches = target_rotation.rotation_matches
+                                   .includes(:team1_player1, :team1_player2, :team2_player1, :team2_player2)
+                                   .order(:match_index)
+                                   .to_a
+
+    ordered_matches.flat_map(&:player_ids).uniq.each do |player_id|
+      next_match = ordered_matches.find do |rotation_match|
+        rotation_match.match_index >= current_index &&
+          rotation_match.match_id.nil? &&
+          rotation_match.includes_player?(player_id)
+      end
+      next unless next_match
+
+      matches_until_turn = next_match.match_index - current_index
+      next if matches_until_turn > 2
+
+      user = User.find_by(id: player_id)
+      next unless user
+
+      seat_info = next_match.seat_info_for(player_id)
+      if matches_until_turn.zero?
+        PushNotificationService.notify_match_now(
+          user: user,
+          rotation: target_rotation,
+          match_number: next_match.match_index + 1,
+          seat_position: seat_info[:seat],
+          partner_name: seat_info[:partner]&.nickname
+        )
+      else
+        PushNotificationService.notify_match_upcoming(
+          user: user,
+          matches_until_turn: matches_until_turn,
+          rotation: target_rotation,
+          current_match_number: current_index + 1,
+          seat_position: seat_info[:seat],
+          partner_name: seat_info[:partner]&.nickname
+        )
+      end
+    end
+  end
+
+  def mark_current_match_started(target_rotation)
+    rotation_match = target_rotation.rotation_matches.find_by(match_index: target_rotation.current_match_index)
+    rotation_match&.update!(started_at: Time.current) if rotation_match&.started_at.nil?
+  end
+
+  def broadcast_rotation_update(target_rotation)
+    RotationChannel.broadcast_to(
+      target_rotation,
+      {
+        type: "rotation_updated",
+        current_match_index: target_rotation.current_match_index
+      }
+    )
+  end
+
+  def player_ids_for_next_round
+    rotation.rotation_matches.flat_map(&:player_ids).uniq
+  end
+
+  def generate_matches_for_rotation!(target_rotation, player_ids)
+    players = player_ids.all? { |player| player.is_a?(User) } ? player_ids : User.where(id: player_ids).to_a
+    return if players.size < 4
+
+    RotationGenerator.new(players.shuffle).generate.each do |match_data|
+      target_rotation.rotation_matches.create!(
+        match_index: match_data[:match_index],
+        team1_player1: match_data[:team1_player1],
+        team1_player2: match_data[:team1_player2],
+        team2_player1: match_data[:team2_player1],
+        team2_player2: match_data[:team2_player2]
+      )
+    end
+  end
+
+  def success_result(rotation:, new_rotation: nil, completed: false)
+    Result.new(success?: true, rotation: rotation, new_rotation: new_rotation, completed: completed)
+  end
+
+  def failure_result(error_message)
+    Result.new(success?: false, rotation: rotation, error_message: error_message)
+  end
+end


### PR DESCRIPTION
## 概要
- RotationsController から show の表示状態生成と進行系コマンドを service に分離
- activate / next_match / go_to_match / record_match / update_match_record / copy_for_next_round の処理を workflow service に集約

## 変更内容
- RotationShowSnapshot を追加し、ローテーション詳細画面の表示状態を集約
- RotationWorkflowManager を追加し、進行・通知・試合記録・次周生成の処理を controller から移動
- RotationsController では redirect と params 整形を中心にして、deprecated なコメントブロックも削除

## 確認
- bundle exec rubocop app/controllers/rotations_controller.rb app/services/rotation_show_snapshot.rb app/services/rotation_workflow_manager.rb
- bundle exec rails zeitwerk:check
- bundle exec brakeman --no-pager -i .brakeman.ignore

Refs #275