### PR TITLE
refactor: 削除ワークフローの責務をserviceに分離

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -106,20 +106,13 @@ class EventsController < ApplicationController
   end
 
   def destroy
-    name = @event.name
+    result = EventDeletionWorkflow.new(event: @event).call
 
-    ActiveRecord::Base.transaction do
-      # イベントに関連する試合のrotation_matchesの参照を解除
-      match_ids = @event.matches.pluck(:id)
-      RotationMatch.where(match_id: match_ids).update_all(match_id: nil) if match_ids.any?
-
-      # イベントを削除（dependent: destroyでmatchesとrotationsも削除される）
-      @event.destroy
+    if result.success?
+      redirect_to events_path, notice: "イベント「#{result.event_name}」を削除しました。"
+    else
+      redirect_to event_path(@event), alert: "削除に失敗しました: #{result.error_message}"
     end
-
-    redirect_to events_path, notice: "イベント「#{name}」を削除しました。"
-  rescue => e
-    redirect_to event_path(@event), alert: "削除に失敗しました: #{e.message}"
   end
 
   private

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -55,38 +55,8 @@ class MatchesController < ApplicationController
   end
 
   def destroy
-    event = @match.event
-    rotation_match = RotationMatch.find_by(match_id: @match.id)
-
-    ActiveRecord::Base.transaction do
-      # rotation_matchesの参照を解除
-      RotationMatch.where(match_id: @match.id).update_all(match_id: nil)
-
-      # 試合を削除
-      @match.destroy
-
-      # ローテーションがある場合、current_match_indexを更新
-      if rotation_match && rotation_match.rotation
-        rotation = rotation_match.rotation
-        next_unrecorded_index = find_next_unrecorded_match_index(rotation)
-        if next_unrecorded_index
-          rotation.update!(current_match_index: next_unrecorded_index)
-        end
-      end
-    end
-
-    # ローテーションページから削除した場合はローテーションページに戻る
-    if rotation_match && rotation_match.rotation
-      redirect_to rotation_path(rotation_match.rotation), notice: "対戦記録を削除しました。"
-    else
-      redirect_to event_path(event), notice: "対戦記録を削除しました。"
-    end
-  rescue => e
-    if rotation_match && rotation_match.rotation
-      redirect_to rotation_path(rotation_match.rotation), alert: "削除に失敗しました: #{e.message}"
-    else
-      redirect_to event_path(event), alert: "削除に失敗しました: #{e.message}"
-    end
+    result = MatchDeletionWorkflow.new(matches: @match).call
+    redirect_after_destroy(result)
   end
 
   def bulk_destroy
@@ -97,29 +67,13 @@ class MatchesController < ApplicationController
       return
     end
 
-    # rotation_matchesの参照を解除してから削除
-    ActiveRecord::Base.transaction do
-      # 影響を受けるローテーションを取得
-      affected_rotations = RotationMatch.where(match_id: match_ids).includes(:rotation).map(&:rotation).compact.uniq
+    result = MatchDeletionWorkflow.new(matches: Match.includes(:event).where(id: match_ids)).call
 
-      # rotation_matchesのmatch_idをnullに設定
-      RotationMatch.where(match_id: match_ids).update_all(match_id: nil)
-
-      # 試合を削除
-      deleted_count = Match.where(id: match_ids).destroy_all.count
-
-      # 影響を受けた各ローテーションのcurrent_match_indexを更新
-      affected_rotations.each do |rotation|
-        next_unrecorded_index = find_next_unrecorded_match_index(rotation)
-        if next_unrecorded_index
-          rotation.update!(current_match_index: next_unrecorded_index)
-        end
-      end
-
-      redirect_to matches_path, notice: "#{deleted_count}件の対戦記録を削除しました。"
+    if result.success?
+      redirect_to matches_path, notice: "#{result.deleted_count}件の対戦記録を削除しました。"
+    else
+      redirect_to matches_path, alert: "削除に失敗しました: #{result.error_message}"
     end
-  rescue => e
-    redirect_to matches_path, alert: "削除に失敗しました: #{e.message}"
   end
 
   private
@@ -153,25 +107,17 @@ class MatchesController < ApplicationController
     params.require(:match).permit(:winning_team, :played_at, :video_timestamp_text, match_players_attributes: [ :id, :user_id, :mobile_suit_id, :team_number, :position ])
   end
 
-  # Find the next unrecorded match starting from current position
-  def find_next_unrecorded_match_index(rotation)
-    rotation_matches = rotation.rotation_matches.includes(:match).order(:match_index)
-
-    # Start searching from the current match index
-    rotation_matches.each do |rm|
-      if rm.match_index > rotation.current_match_index && rm.match.nil?
-        return rm.match_index
+  def redirect_after_destroy(result)
+    if result.success?
+      if result.rotation
+        redirect_to rotation_path(result.rotation), notice: "対戦記録を削除しました。"
+      else
+        redirect_to event_path(result.event), notice: "対戦記録を削除しました。"
       end
+    elsif result.rotation
+      redirect_to rotation_path(result.rotation), alert: "削除に失敗しました: #{result.error_message}"
+    else
+      redirect_to event_path(result.event), alert: "削除に失敗しました: #{result.error_message}"
     end
-
-    # If no unrecorded match found after current position, check from the beginning
-    rotation_matches.each do |rm|
-      if rm.match.nil?
-        return rm.match_index
-      end
-    end
-
-    # All matches are recorded, stay at the last match
-    rotation.rotation_matches.count - 1
   end
 end

--- a/app/models/rotation.rb
+++ b/app/models/rotation.rb
@@ -26,6 +26,27 @@ class Rotation < ApplicationRecord
     player_count == 8 ? 6 : 3
   end
 
+  def next_unrecorded_match_index
+    ordered_matches = rotation_matches.includes(:match).order(:match_index).to_a
+    return 0 if ordered_matches.empty?
+
+    ordered_matches.each do |rotation_match|
+      if rotation_match.match_index > current_match_index && rotation_match.match.nil?
+        return rotation_match.match_index
+      end
+    end
+
+    ordered_matches.each do |rotation_match|
+      return rotation_match.match_index if rotation_match.match.nil?
+    end
+
+    ordered_matches.last.match_index
+  end
+
+  def sync_current_match_index!
+    update!(current_match_index: next_unrecorded_match_index)
+  end
+
   # Calculate statistics for each player
   # rotation_matches_scope: preloaded scope (includes :match) to avoid N+1
   def player_statistics(rotation_matches_scope = nil)

--- a/app/services/event_deletion_workflow.rb
+++ b/app/services/event_deletion_workflow.rb
@@ -1,0 +1,31 @@
+class EventDeletionWorkflow
+  Result = Struct.new(:success?, :event_name, :error_message, keyword_init: true)
+
+  def initialize(event:)
+    @event = event
+  end
+
+  def call
+    event_name = event.name
+
+    ActiveRecord::Base.transaction do
+      unlink_rotation_matches!
+      event.destroy!
+    end
+
+    Result.new(success?: true, event_name: event_name)
+  rescue StandardError => error
+    Result.new(success?: false, event_name: event.name, error_message: error.message)
+  end
+
+  private
+
+  attr_reader :event
+
+  def unlink_rotation_matches!
+    match_ids = event.matches.pluck(:id)
+    return if match_ids.empty?
+
+    RotationMatch.where(match_id: match_ids).update_all(match_id: nil)
+  end
+end

--- a/app/services/match_deletion_workflow.rb
+++ b/app/services/match_deletion_workflow.rb
@@ -1,0 +1,73 @@
+class MatchDeletionWorkflow
+  Result = Struct.new(:success?, :deleted_count, :event, :rotation, :error_message, keyword_init: true)
+
+  def initialize(matches:)
+    @matches = Array(matches).flatten.compact
+  end
+
+  def call
+    deleted_count = 0
+
+    ActiveRecord::Base.transaction do
+      unlink_rotation_matches!
+      deleted_count = destroy_matches!
+      affected_rotations.each(&:sync_current_match_index!)
+    end
+
+    Result.new(
+      success?: true,
+      deleted_count: deleted_count,
+      event: primary_match&.event,
+      rotation: primary_rotation
+    )
+  rescue StandardError => error
+    Result.new(
+      success?: false,
+      deleted_count: 0,
+      event: primary_match&.event,
+      rotation: primary_rotation,
+      error_message: error.message
+    )
+  end
+
+  private
+
+  attr_reader :matches
+
+  def primary_match
+    @primary_match ||= matches.one? ? matches.first : nil
+  end
+
+  def primary_rotation
+    @primary_rotation ||= primary_match && rotation_by_match_id[primary_match.id]
+  end
+
+  def affected_rotations
+    @affected_rotations ||= rotation_by_match_id.values.compact.uniq
+  end
+
+  def rotation_by_match_id
+    @rotation_by_match_id ||= begin
+      RotationMatch.where(match_id: match_ids).includes(:rotation).each_with_object({}) do |rotation_match, mapping|
+        mapping[rotation_match.match_id] = rotation_match.rotation
+      end
+    end
+  end
+
+  def match_ids
+    @match_ids ||= matches.map(&:id)
+  end
+
+  def unlink_rotation_matches!
+    return if match_ids.empty?
+
+    RotationMatch.where(match_id: match_ids).update_all(match_id: nil)
+  end
+
+  def destroy_matches!
+    matches.count do |match|
+      match.destroy!
+      true
+    end
+  end
+end

--- a/app/services/rotation_workflow_manager.rb
+++ b/app/services/rotation_workflow_manager.rb
@@ -83,12 +83,8 @@ class RotationWorkflowManager
       end
 
       rotation_match.update!(match: match)
-
-      next_unrecorded_index = next_unrecorded_match_index(rotation)
-      if next_unrecorded_index
-        rotation.update!(current_match_index: next_unrecorded_index)
-        mark_current_match_started(rotation)
-      end
+      rotation.sync_current_match_index!
+      mark_current_match_started(rotation)
 
       completed = rotation.rotation_matches.where(match_id: nil).none?
       rotation.update!(is_active: false) if completed
@@ -171,20 +167,6 @@ class RotationWorkflowManager
         position: attributes[:position]
       )
     end
-  end
-
-  def next_unrecorded_match_index(target_rotation)
-    ordered_matches = target_rotation.rotation_matches.includes(:match).order(:match_index)
-
-    ordered_matches.each do |rotation_match|
-      return rotation_match.match_index if rotation_match.match_index > target_rotation.current_match_index && rotation_match.match.nil?
-    end
-
-    ordered_matches.each do |rotation_match|
-      return rotation_match.match_index if rotation_match.match.nil?
-    end
-
-    target_rotation.rotation_matches.count - 1
   end
 
   def notify_upcoming_players(target_rotation)


### PR DESCRIPTION
## 概要
- `MatchDeletionWorkflow` / `EventDeletionWorkflow` を追加して削除 transaction を controller から分離
- `Rotation` に未記録 index のドメインメソッドを追加し、削除処理とローテーション進行処理で共通利用
- `MatchesController` / `EventsController` の削除フローを redirect 中心に整理

## 確認
- bundle exec rubocop app/controllers/matches_controller.rb app/controllers/events_controller.rb app/models/rotation.rb app/services/match_deletion_workflow.rb app/services/event_deletion_workflow.rb app/services/rotation_workflow_manager.rb
- bundle exec rails zeitwerk:check
- bundle exec brakeman --no-pager -i .brakeman.ignore

## 関連
- #275