### PR TITLE
feat: 共通デザイン基盤と app shell を再設計

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,37 +1,697 @@
 @import "tailwindcss";
 
+:root {
+  --page-bg: #eef2ff;
+  --page-bg-strong: #f8f9ff;
+  --surface-base: rgba(255, 255, 255, 0.78);
+  --surface-raised: rgba(255, 255, 255, 0.94);
+  --surface-muted: #eef2ff;
+  --surface-contrast: #16182d;
+  --surface-contrast-strong: #242855;
+  --text-primary: #182034;
+  --text-secondary: #52607b;
+  --text-muted: #7c879f;
+  --text-on-dark: rgba(255, 255, 255, 0.94);
+  --border-soft: rgba(94, 108, 153, 0.18);
+  --border-strong: rgba(79, 57, 246, 0.24);
+  --accent: #4f39f6;
+  --accent-strong: #3f29d9;
+  --accent-soft: rgba(79, 57, 246, 0.12);
+  --accent-soft-strong: rgba(79, 57, 246, 0.18);
+  --success-soft: rgba(12, 166, 120, 0.14);
+  --warning-soft: rgba(217, 119, 6, 0.14);
+  --danger-soft: rgba(220, 38, 38, 0.14);
+  --shadow-soft: 0 18px 40px rgba(15, 23, 42, 0.08);
+  --shadow-panel: 0 24px 64px rgba(15, 23, 42, 0.14);
+  --radius-lg: 1.5rem;
+  --radius-md: 1rem;
+  --radius-sm: 0.875rem;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body.app-body {
+  color: var(--text-primary);
+  background:
+    radial-gradient(circle at top left, rgba(79, 57, 246, 0.16), transparent 28%),
+    radial-gradient(circle at top right, rgba(15, 23, 42, 0.08), transparent 24%),
+    linear-gradient(180deg, var(--page-bg-strong) 0%, var(--page-bg) 100%);
+}
+
+a {
+  color: inherit;
+}
+
 /* ============================================================
-   ページレイアウト共通クラス
+   App shell / layout
    ============================================================ */
 
-/* ページコンテナ: 全ページ共通の最大幅・中央寄せ・水平パディング */
+.app-shell {
+  min-height: 100vh;
+}
+
+.app-with-sidebar {
+  min-height: 100vh;
+}
+
+@media (min-width: 1024px) {
+  .app-with-sidebar {
+    padding-left: 18rem;
+  }
+}
+
 .page-container {
-  max-width: 1536px; /* max-w-screen-2xl 相当 */
+  max-width: 1440px;
   margin-left: auto;
   margin-right: auto;
-  padding-left: 1rem;   /* px-4 */
+  padding-left: 1rem;
   padding-right: 1rem;
 }
+
 @media (min-width: 640px) {
   .page-container {
-    padding-left: 1.5rem; /* sm:px-6 */
+    padding-left: 1.5rem;
     padding-right: 1.5rem;
   }
 }
+
 @media (min-width: 1024px) {
   .page-container {
-    padding-left: 2rem; /* lg:px-8 */
+    padding-left: 2rem;
     padding-right: 2rem;
   }
 }
 
-/* ページヘッダー: タイトルとアクションボタンを横並びにするレイアウト */
+.app-shell-content {
+  padding-bottom: 3rem;
+}
+
+.app-main,
+.app-public-main {
+  padding-top: 1rem;
+  padding-bottom: 3rem;
+}
+
+.flash-stack {
+  padding-top: 1rem;
+}
+
+.app-sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: 18rem;
+  padding: 1rem;
+  z-index: 40;
+}
+
+.app-sidebar__panel {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 2rem);
+  border-radius: calc(var(--radius-lg) + 0.25rem);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text-on-dark);
+  background:
+    radial-gradient(circle at top right, rgba(129, 140, 248, 0.35), transparent 26%),
+    linear-gradient(180deg, #181b2f 0%, #20244a 42%, #242855 100%);
+  box-shadow: var(--shadow-panel);
+  overflow: hidden;
+}
+
+.app-sidebar__brand {
+  padding: 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.app-sidebar__scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+}
+
+.app-sidebar__scroll::-webkit-scrollbar {
+  width: 5px;
+}
+
+.app-sidebar__scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.app-sidebar__scroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+}
+
+.app-sidebar__footer {
+  padding: 1.1rem 1.25rem 1.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.app-topbar-wrap {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  padding-top: 0.9rem;
+}
+
+.app-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 4.5rem;
+  border: 1px solid var(--border-soft);
+  border-radius: calc(var(--radius-lg) - 0.1rem);
+  background: rgba(255, 255, 255, 0.74);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-soft);
+  padding: 0.85rem 1rem;
+}
+
+.app-topbar__start,
+.app-topbar__end {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  min-width: 0;
+}
+
+.app-topbar__end {
+  margin-left: auto;
+}
+
+.app-topbar__eyebrow {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.app-topbar__title {
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-mobile-menu-button,
+.app-mobile-close-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: transform 0.16s ease, border-color 0.16s ease, background-color 0.16s ease;
+}
+
+.app-mobile-menu-button:hover,
+.app-mobile-close-button:hover {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+}
+
+.app-mobile-nav-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 45;
+  background: rgba(15, 23, 42, 0.32);
+  backdrop-filter: blur(8px);
+  transition: opacity 0.18s ease;
+}
+
+.app-mobile-nav-panel {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 50;
+  display: flex;
+  align-items: stretch;
+  padding: 0.75rem;
+  width: min(24rem, calc(100vw - 0.75rem));
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+.app-mobile-nav-panel__surface {
+  width: 100%;
+  height: calc(100vh - 1.5rem);
+  overflow-y: auto;
+  border-radius: calc(var(--radius-lg) + 0.15rem);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--text-on-dark);
+  background:
+    radial-gradient(circle at top right, rgba(129, 140, 248, 0.34), transparent 28%),
+    linear-gradient(180deg, #181b2f 0%, #20244a 42%, #242855 100%);
+  box-shadow: var(--shadow-panel);
+  padding: 1.2rem;
+}
+
+@media (min-width: 640px) {
+  .app-topbar {
+    padding-inline: 1.25rem;
+  }
+
+  .app-mobile-nav-panel__surface {
+    padding: 1.35rem;
+  }
+
+  .app-topbar__title {
+    white-space: nowrap;
+  }
+}
+
+.app-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.app-brand__media {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.app-brand__copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.app-brand__title {
+  font-size: 0.95rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  line-height: 1.2;
+}
+
+.app-brand__caption {
+  margin-top: 0.15rem;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.app-brand--compact .app-brand__title {
+  font-size: 0.9rem;
+}
+
+.app-nav-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.54);
+}
+
+.app-nav-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  border: 0;
+  padding: 0.88rem 1rem;
+  border-radius: 1rem;
+  background: transparent;
+  font-size: 0.93rem;
+  font-weight: 600;
+  text-align: left;
+  color: rgba(255, 255, 255, 0.84);
+  cursor: pointer;
+  transition: transform 0.16s ease, background-color 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.app-nav-link:hover {
+  transform: translateX(2px);
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+.app-nav-link.is-active {
+  background: rgba(255, 255, 255, 0.98);
+  color: var(--surface-contrast);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.22);
+}
+
+.app-nav-link--compact {
+  padding: 0.76rem 0.88rem;
+  font-size: 0.89rem;
+}
+
+.app-nav-link--logout {
+  color: #ffd6de;
+}
+
+.app-nav-link--logout:hover {
+  color: #fff0f3;
+}
+
+.app-nav-link__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.22);
+  transition: transform 0.16s ease, background-color 0.16s ease;
+}
+
+.app-nav-link.is-active .app-nav-link__dot {
+  background: var(--accent);
+  transform: scale(1.1);
+}
+
+.app-account-card {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.95rem 1rem;
+  border-radius: 1.2rem;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.app-account-card__name {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.app-account-card__meta {
+  margin-top: 0.18rem;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.app-avatar,
+.app-inline-user__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.08));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  font-size: 0.82rem;
+  font-weight: 800;
+  color: #fff;
+}
+
+.app-inline-user {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+  padding: 0.35rem 0.45rem 0.35rem 0.35rem;
+  border-radius: 999px;
+  background: rgba(79, 57, 246, 0.08);
+  color: var(--text-primary);
+}
+
+.app-inline-user__avatar {
+  width: 2.15rem;
+  height: 2.15rem;
+  background: linear-gradient(135deg, rgba(79, 57, 246, 0.92), rgba(79, 57, 246, 0.66));
+  border-color: rgba(79, 57, 246, 0.18);
+}
+
+.app-inline-user__name {
+  font-size: 0.86rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.app-inline-user__meta {
+  margin-top: 0.12rem;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.app-switcher {
+  position: relative;
+}
+
+.app-switcher__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-height: 2.7rem;
+  padding: 0.5rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.app-switcher__meta {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.app-switcher__value {
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.app-switcher__menu {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  right: 0;
+  width: min(19rem, calc(100vw - 2rem));
+  border: 1px solid var(--border-soft);
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: var(--shadow-panel);
+  overflow: hidden;
+  z-index: 20;
+}
+
+.app-switcher__menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  text-align: left;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  transition: background-color 0.16s ease;
+}
+
+.app-switcher__menu-item:hover {
+  background: rgba(79, 57, 246, 0.06);
+}
+
+.app-switcher__menu-item--accent {
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.app-switcher__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 999px;
+  background: rgba(79, 57, 246, 0.1);
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.app-switcher__avatar--accent {
+  background: rgba(79, 57, 246, 0.14);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.status-pill--inverted {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.status-pill__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.75;
+}
+
+/* ============================================================
+   Shared UI primitives
+   ============================================================ */
+
+.surface-card,
+.surface-card-muted,
+.empty-state {
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.surface-card {
+  background: var(--surface-raised);
+}
+
+.surface-card-muted {
+  background: rgba(246, 247, 255, 0.92);
+}
+
+.ui-button-primary,
+.ui-button-secondary,
+.ui-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 2.75rem;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  transition: transform 0.16s ease, background-color 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.ui-button-primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 14px 26px rgba(79, 57, 246, 0.24);
+}
+
+.ui-button-primary:hover {
+  transform: translateY(-1px);
+  background: var(--accent-strong);
+}
+
+.ui-button-secondary,
+.ui-chip {
+  border: 1px solid var(--border-soft);
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--text-primary);
+}
+
+.ui-button-secondary:hover,
+.ui-chip:hover {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+}
+
+.empty-state {
+  padding: 1.4rem;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.empty-state__title {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.empty-state__description {
+  margin-top: 0.35rem;
+  color: var(--text-secondary);
+}
+
+/* ============================================================
+   Flash messages
+   ============================================================ */
+
+.flash-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-soft);
+}
+
+.flash-banner__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.flash-banner__icon--info {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.flash-banner__icon--success {
+  background: var(--success-soft);
+  color: #0f766e;
+}
+
+.flash-banner__icon--danger {
+  background: var(--danger-soft);
+  color: #b91c1c;
+}
+
+.flash-banner__icon--warning,
+.flash-banner__icon--neutral {
+  background: var(--warning-soft);
+  color: #b45309;
+}
+
+.flash-banner__title {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.flash-banner__message {
+  margin-top: 0.18rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* ============================================================
+   Existing shared layout classes
+   ============================================================ */
+
 .page-header {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  margin-bottom: 1.5rem; /* mb-6 */
+  margin-bottom: 1.75rem;
 }
+
 @media (min-width: 640px) {
   .page-header {
     flex-direction: row;
@@ -40,10 +700,10 @@
   }
 }
 
-/* モバイル・デスクトップ表示切り替え（768px 境界） */
-.mobile-only-view  { display: block !important; }
-.desktop-only-view { display: none  !important; }
+.mobile-only-view { display: block !important; }
+.desktop-only-view { display: none !important; }
+
 @media (min-width: 768px) {
-  .mobile-only-view  { display: none  !important; }
+  .mobile-only-view { display: none !important; }
   .desktop-only-view { display: block !important; }
 }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 :root {
+  --sidebar-shell-width: 18rem;
   --page-bg: #eef2ff;
   --page-bg-strong: #f8f9ff;
   --surface-base: rgba(255, 255, 255, 0.78);
@@ -55,11 +56,19 @@ a {
 
 .app-with-sidebar {
   min-height: 100vh;
+  min-width: 0;
 }
 
 @media (min-width: 1024px) {
+  .app-shell {
+    display: grid;
+    grid-template-columns: var(--sidebar-shell-width) minmax(0, 1fr);
+    align-items: start;
+  }
+
   .app-with-sidebar {
-    padding-left: 18rem;
+    width: 100%;
+    margin-left: 0;
   }
 }
 
@@ -95,6 +104,148 @@ a {
   padding-bottom: 3rem;
 }
 
+.app-public-shell {
+  min-height: 100vh;
+}
+
+.app-public-main {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.auth-layout {
+  width: min(100%, 30rem);
+  margin-inline: auto;
+}
+
+.auth-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+  border-radius: calc(var(--radius-lg) + 0.15rem);
+  box-shadow: var(--shadow-panel);
+  padding: 1.6rem;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: blur(18px);
+}
+
+@media (min-width: 640px) {
+  .auth-card {
+    padding: 2rem;
+  }
+}
+
+.auth-card__eyebrow {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.auth-card__logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  margin-bottom: 1.15rem;
+  padding: 0.35rem 0;
+  pointer-events: none;
+  user-select: none;
+}
+
+.auth-card__title {
+  font-weight: 800;
+  line-height: 1.08;
+  margin-top: 0.85rem;
+  font-size: clamp(1.9rem, 3vw, 2.3rem);
+  color: var(--text-primary);
+  letter-spacing: -0.03em;
+}
+
+.auth-form {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.4rem;
+}
+
+.auth-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.auth-label {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.auth-input {
+  width: 100%;
+  min-height: 3rem;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--border-soft);
+  border-radius: 1rem;
+  background: rgba(248, 250, 255, 0.94);
+  color: var(--text-primary);
+  transition: border-color 0.16s ease, box-shadow 0.16s ease, background-color 0.16s ease;
+}
+
+.auth-input::placeholder {
+  color: var(--text-muted);
+}
+
+.auth-input:focus {
+  outline: none;
+  border-color: var(--border-strong);
+  background: #fff;
+  box-shadow: 0 0 0 4px rgba(79, 57, 246, 0.12);
+}
+
+.auth-remember {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+}
+
+.auth-checkbox {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.35rem;
+  border-color: var(--border-soft);
+  color: var(--accent);
+}
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-top: 1.25rem;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border-soft);
+}
+
+.auth-card__footnote {
+  margin-top: 0.95rem;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  color: var(--text-muted);
+}
+
 .flash-stack {
   padding-top: 1rem;
 }
@@ -102,14 +253,27 @@ a {
 .app-sidebar {
   position: fixed;
   inset: 0 auto 0 0;
-  width: 18rem;
+  box-sizing: border-box;
+  width: var(--sidebar-shell-width);
   padding: 1rem;
   z-index: 40;
+}
+
+@media (min-width: 1024px) {
+  .app-sidebar {
+    position: sticky;
+    top: 0;
+    inset: auto;
+    width: auto;
+    height: 100vh;
+    padding: 1rem 0 1rem 1rem;
+  }
 }
 
 .app-sidebar__panel {
   display: flex;
   flex-direction: column;
+  width: 100%;
   height: calc(100vh - 2rem);
   border-radius: calc(var(--radius-lg) + 0.25rem);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -206,7 +370,6 @@ a {
 
 .app-mobile-menu-button,
 .app-mobile-close-button {
-  display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 2.75rem;
@@ -219,30 +382,58 @@ a {
   transition: transform 0.16s ease, border-color 0.16s ease, background-color 0.16s ease;
 }
 
+.app-mobile-menu-button {
+  display: inline-flex;
+}
+
+.app-mobile-close-button {
+  display: inline-flex;
+}
+
 .app-mobile-menu-button:hover,
 .app-mobile-close-button:hover {
   transform: translateY(-1px);
   border-color: var(--border-strong);
 }
 
+@media (min-width: 1024px) {
+  .app-mobile-menu-button {
+    display: none;
+  }
+}
+
 .app-mobile-nav-backdrop {
+  display: none;
   position: fixed;
   inset: 0;
   z-index: 45;
   background: rgba(15, 23, 42, 0.32);
   backdrop-filter: blur(8px);
   transition: opacity 0.18s ease;
+  pointer-events: none;
+}
+
+.app-mobile-nav-backdrop:not(.hidden) {
+  display: block;
+  pointer-events: auto;
 }
 
 .app-mobile-nav-panel {
+  display: none;
   position: fixed;
   inset: 0 auto 0 0;
+  box-sizing: border-box;
   z-index: 50;
-  display: flex;
   align-items: stretch;
   padding: 0.75rem;
   width: min(24rem, calc(100vw - 0.75rem));
   transition: transform 0.18s ease, opacity 0.18s ease;
+  pointer-events: none;
+}
+
+.app-mobile-nav-panel:not(.hidden) {
+  display: flex;
+  pointer-events: auto;
 }
 
 .app-mobile-nav-panel__surface {
@@ -286,6 +477,16 @@ a {
   min-width: 0;
 }
 
+.app-brand__media--plate {
+  padding: 0.75rem 1rem;
+  border-radius: 1.15rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(239, 243, 255, 0.94));
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    0 16px 32px rgba(15, 23, 42, 0.18);
+}
+
 .app-brand__copy {
   display: flex;
   flex-direction: column;
@@ -314,6 +515,11 @@ a {
   width: 100%;
 }
 
+.app-brand--image-only .app-brand__media--plate {
+  width: 100%;
+  justify-content: center;
+}
+
 .app-nav-label {
   font-size: 0.72rem;
   font-weight: 700;
@@ -337,11 +543,10 @@ a {
   text-align: left;
   color: rgba(255, 255, 255, 0.84);
   cursor: pointer;
-  transition: transform 0.16s ease, background-color 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+  transition: background-color 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
 }
 
 .app-nav-link:hover {
-  transform: translateX(2px);
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
 }
@@ -587,8 +792,14 @@ a {
   transition: transform 0.16s ease, background-color 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
 }
 
+.ui-button--sm {
+  min-height: 2.5rem;
+  padding: 0.55rem 0.95rem;
+  font-size: 0.85rem;
+}
+
 .ui-button-primary {
-  background: var(--accent);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
   color: #fff;
   box-shadow: 0 14px 26px rgba(79, 57, 246, 0.24);
 }
@@ -609,6 +820,31 @@ a {
 .ui-chip:hover {
   transform: translateY(-1px);
   border-color: var(--border-strong);
+}
+
+.ui-chip--accent {
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(79, 57, 246, 0.22);
+}
+
+.ui-chip--accent:hover {
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--accent-strong), #3522c5);
+  color: #fff;
+}
+
+.ui-chip--muted {
+  border: 1px solid var(--border-soft);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-primary);
+}
+
+.ui-chip--muted:hover {
+  border-color: var(--border-strong);
+  background: rgba(79, 57, 246, 0.08);
+  color: var(--accent-strong);
 }
 
 .empty-state {
@@ -685,6 +921,75 @@ a {
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--text-primary);
+}
+
+.app-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 1rem 1.05rem;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-soft);
+}
+
+.app-notice__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.app-notice__icon--info,
+.app-notice--info .app-notice__icon {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.app-notice__icon--success,
+.app-notice--success .app-notice__icon {
+  background: var(--success-soft);
+  color: #0f766e;
+}
+
+.app-notice__icon--warning,
+.app-notice--warning .app-notice__icon {
+  background: var(--warning-soft);
+  color: #b45309;
+}
+
+.app-notice__icon--danger,
+.app-notice--danger .app-notice__icon {
+  background: var(--danger-soft);
+  color: #b91c1c;
+}
+
+.app-notice__title {
+  font-size: 0.84rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.app-notice__message {
+  margin-top: 0.2rem;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--text-primary);
+}
+
+.app-notice__list {
+  margin-top: 0.5rem;
+  display: grid;
+  gap: 0.3rem;
+  padding-left: 1rem;
+  color: var(--text-primary);
+  font-size: 0.9rem;
 }
 
 /* ============================================================

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -309,6 +309,11 @@ a {
   font-size: 0.9rem;
 }
 
+.app-brand--image-only {
+  justify-content: center;
+  width: 100%;
+}
+
 .app-nav-label {
   font-size: 0.72rem;
   font-weight: 700;
@@ -527,8 +532,9 @@ a {
   gap: 0.5rem;
   padding: 0.5rem 0.85rem;
   border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent-strong);
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(79, 57, 246, 0.18);
   font-size: 0.82rem;
   font-weight: 700;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -159,4 +159,20 @@ module ApplicationHelper
       "案内"
     end
   end
+
+  def app_notice_classes(tone = :info)
+    class_names("app-notice", "app-notice--#{tone.to_sym}")
+  end
+
+  def app_notice_icon_classes(tone = :info)
+    class_names("app-notice__icon", "app-notice__icon--#{tone.to_sym}")
+  end
+
+  def app_button_classes(variant: :primary, size: :md, full_width: false)
+    class_names(
+      (variant.to_sym == :primary ? "ui-button-primary" : "ui-button-secondary"),
+      ("ui-button--sm" if size.to_sym == :sm),
+      ("w-full" if full_width)
+    )
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,4 +78,85 @@ module ApplicationHelper
       cost_badge(costs[1].to_i)
     ])
   end
+
+  def app_primary_navigation_items
+    [
+      { label: "ダッシュボード", path: dashboard_path, active: current_page?(dashboard_path) || current_page?(root_path) },
+      { label: "イベント", path: events_path, active: current_page?(events_path) },
+      { label: "ローテーション", path: rotations_path, active: current_page?(rotations_path) },
+      { label: "対戦履歴", path: matches_path, active: current_page?(matches_path) },
+      { label: "統計", path: statistics_path, active: current_page?(statistics_path) },
+      { label: "機体一覧", path: mobile_suits_path, active: current_page?(mobile_suits_path) }
+    ]
+  end
+
+  def app_admin_navigation_items
+    return [] unless current_user&.is_admin?
+
+    [
+      { label: "お知らせ管理", path: admin_announcements_path, active: current_page?(admin_announcements_path) },
+      { label: "Discord設定", path: admin_discord_channels_path, active: current_page?(admin_discord_channels_path) },
+      { label: "機体マスタ", path: admin_mobile_suits_path, active: current_page?(admin_mobile_suits_path) },
+      { label: "スタンプマスタ", path: admin_master_emojis_path, active: current_page?(admin_master_emojis_path) },
+      { label: "ユーザー管理", path: admin_users_path, active: current_page?(admin_users_path) }
+    ]
+  end
+
+  def app_account_navigation_items
+    items = []
+    items << { label: "マイページ", path: my_page_path, active: current_page?(my_page_path) } unless current_user&.is_guest?
+    items << { label: "設定", path: edit_profile_path, active: current_page?(edit_profile_path) } unless current_user&.username == "guest"
+    items
+  end
+
+  def app_nav_link_classes(active: false, compact: false, accent: nil)
+    class_names(
+      "app-nav-link",
+      ("app-nav-link--compact" if compact),
+      ("is-active" if active),
+      ("app-nav-link--#{accent}" if accent.present?)
+    )
+  end
+
+  def user_avatar_initial(user)
+    user&.nickname.to_s.strip.first&.upcase.presence || "?"
+  end
+
+  def flash_banner_tone(type)
+    case type.to_s
+    when "notice"
+      :info
+    when "success"
+      :success
+    when "alert", "error"
+      :danger
+    when "warning"
+      :warning
+    else
+      :neutral
+    end
+  end
+
+  def flash_banner_classes(type)
+    class_names("flash-banner", "flash-banner--#{flash_banner_tone(type)}")
+  end
+
+  def flash_banner_icon_classes(type)
+    class_names("flash-banner__icon", "flash-banner__icon--#{flash_banner_tone(type)}")
+  end
+
+  def flash_banner_title(type)
+    case flash_banner_tone(type)
+    when :success
+      "完了"
+    when :danger
+      "注意"
+    when :warning
+      "確認"
+    when :info
+      "お知らせ"
+    else
+      "案内"
+    end
+  end
 end

--- a/app/javascript/controllers/mobile_nav_controller.js
+++ b/app/javascript/controllers/mobile_nav_controller.js
@@ -5,7 +5,9 @@ export default class extends Controller {
 
   connect() {
     this._keydownHandler = this._handleKeydown.bind(this)
+    this._resizeHandler = this._handleResize.bind(this)
     this._closeTimer = null
+    window.addEventListener("resize", this._resizeHandler)
   }
 
   toggle() {
@@ -43,6 +45,7 @@ export default class extends Controller {
     clearTimeout(this._closeTimer)
     document.body.classList.remove("overflow-hidden")
     document.removeEventListener("keydown", this._keydownHandler)
+    window.removeEventListener("resize", this._resizeHandler)
   }
 
   isOpen() {
@@ -51,6 +54,10 @@ export default class extends Controller {
 
   _handleKeydown(event) {
     if (event.key === "Escape") this.close()
+  }
+
+  _handleResize() {
+    if (window.innerWidth >= 1024 && this.isOpen()) this.close()
   }
 
   _setExpanded(expanded) {

--- a/app/javascript/controllers/mobile_nav_controller.js
+++ b/app/javascript/controllers/mobile_nav_controller.js
@@ -1,0 +1,64 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["backdrop", "panel", "toggleButton", "openIcon", "closeIcon"]
+
+  connect() {
+    this._keydownHandler = this._handleKeydown.bind(this)
+    this._closeTimer = null
+  }
+
+  toggle() {
+    this.isOpen() ? this.close() : this.open()
+  }
+
+  open() {
+    if (!this.hasPanelTarget || !this.hasBackdropTarget) return
+
+    clearTimeout(this._closeTimer)
+    this.backdropTarget.classList.remove("hidden", "opacity-0")
+    this.panelTarget.classList.remove("hidden", "opacity-0", "-translate-x-6")
+    this._setExpanded(true)
+    document.body.classList.add("overflow-hidden")
+    document.addEventListener("keydown", this._keydownHandler)
+  }
+
+  close() {
+    if (!this.hasPanelTarget || !this.hasBackdropTarget) return
+
+    this.backdropTarget.classList.add("opacity-0")
+    this.panelTarget.classList.add("opacity-0", "-translate-x-6")
+    this._setExpanded(false)
+    document.body.classList.remove("overflow-hidden")
+    document.removeEventListener("keydown", this._keydownHandler)
+
+    clearTimeout(this._closeTimer)
+    this._closeTimer = window.setTimeout(() => {
+      this.backdropTarget.classList.add("hidden")
+      this.panelTarget.classList.add("hidden")
+    }, 180)
+  }
+
+  disconnect() {
+    clearTimeout(this._closeTimer)
+    document.body.classList.remove("overflow-hidden")
+    document.removeEventListener("keydown", this._keydownHandler)
+  }
+
+  isOpen() {
+    return this.hasPanelTarget && !this.panelTarget.classList.contains("hidden")
+  }
+
+  _handleKeydown(event) {
+    if (event.key === "Escape") this.close()
+  }
+
+  _setExpanded(expanded) {
+    if (this.hasToggleButtonTarget) {
+      this.toggleButtonTarget.setAttribute("aria-expanded", expanded ? "true" : "false")
+    }
+
+    if (this.hasOpenIconTarget) this.openIconTarget.classList.toggle("hidden", expanded)
+    if (this.hasCloseIconTarget) this.closeIconTarget.classList.toggle("hidden", !expanded)
+  }
+}

--- a/app/views/admin/announcements/_form.html.erb
+++ b/app/views/admin/announcements/_form.html.erb
@@ -1,11 +1,19 @@
 <%= form_with model: [:admin, announcement], class: "space-y-6" do |form| %>
   <% if announcement.errors.any? %>
-    <div class="bg-red-50 border border-red-200 rounded-md p-4">
-      <ul class="list-disc list-inside text-sm text-red-600">
+    <div class="<%= app_notice_classes(:danger) %>">
+      <div class="<%= app_notice_icon_classes(:danger) %>">
+        <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+        </svg>
+      </div>
+      <div class="min-w-0">
+        <p class="app-notice__title">入力内容を確認してください</p>
+        <ul class="app-notice__list">
         <% announcement.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
-      </ul>
+        </ul>
+      </div>
     </div>
   <% end %>
 

--- a/app/views/admin/announcements/index.html.erb
+++ b/app/views/admin/announcements/index.html.erb
@@ -4,7 +4,7 @@
       <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">お知らせ管理</h1>
       <p class="mt-2 text-sm text-gray-600">アプリ起動時に表示されるお知らせを管理できます</p>
     </div>
-    <%= link_to "新規作成", new_admin_announcement_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+    <%= link_to "新規作成", new_admin_announcement_path, class: app_button_classes(size: :sm) %>
   </div>
 
   <% if @announcements.any? %>

--- a/app/views/admin/imports/new.html.erb
+++ b/app/views/admin/imports/new.html.erb
@@ -6,8 +6,11 @@
   <h1 class="text-3xl font-bold text-gray-900 mb-6">試合データCSVインポート</h1>
 
   <% if alert %>
-    <div class="mb-4 p-4 bg-red-100 border border-red-400 text-red-700 rounded">
-      <%= alert %>
+    <div class="mb-4">
+      <%= render "shared/app_notice",
+          tone: :danger,
+          title: "インポートに失敗しました",
+          message: alert %>
     </div>
   <% end %>
 
@@ -35,10 +38,11 @@
 
   <%= form_with url: admin_imports_path, multipart: true, class: "space-y-6" do |form| %>
     <div class="bg-white shadow sm:rounded-lg p-6">
-      <div class="mb-4 p-4 bg-blue-50 border border-blue-200 rounded">
-        <p class="text-sm text-blue-800">
-          <strong>自動イベント作成:</strong> CSVの日付列から自動的にイベントを作成します。同じ日付のイベントが既に存在する場合は、そのイベントに試合を追加します。
-        </p>
+      <div class="mb-4">
+        <%= render "shared/app_notice",
+            tone: :info,
+            title: "自動イベント作成",
+            message: "CSVの日付列から自動的にイベントを作成します。同じ日付のイベントが既に存在する場合は、そのイベントに試合を追加します。" %>
       </div>
 
       <div>

--- a/app/views/admin/master_emojis/index.html.erb
+++ b/app/views/admin/master_emojis/index.html.erb
@@ -6,7 +6,7 @@
     </div>
     <% if current_user.is_admin? %>
       <div class="flex flex-wrap gap-2">
-        <%= link_to "新規登録", new_admin_master_emoji_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
+        <%= link_to "新規登録", new_admin_master_emoji_path, class: app_button_classes %>
       </div>
     <% end %>
   </div>
@@ -108,4 +108,3 @@
     </div>
   <% end %>
 </div>
-

--- a/app/views/admin/mobile_suits/index.html.erb
+++ b/app/views/admin/mobile_suits/index.html.erb
@@ -6,8 +6,8 @@
     </div>
     <% if current_user.is_admin? %>
       <div class="flex flex-wrap gap-2">
-        <%= link_to "新規登録", new_admin_mobile_suit_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
-        <%= link_to "CSVインポート", new_mobile_suits_admin_imports_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
+        <%= link_to "新規登録", new_admin_mobile_suit_path, class: app_button_classes %>
+        <%= link_to "CSVインポート", new_mobile_suits_admin_imports_path, class: app_button_classes(variant: :secondary) %>
       </div>
     <% end %>
   </div>
@@ -66,4 +66,3 @@
     全 <%= @mobile_suits.count %> 機体
   </div>
 </div>
-

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -5,7 +5,7 @@
       <p class="mt-2 text-sm text-gray-600">ユーザーの作成・編集・削除ができます</p>
     </div>
     <div class="flex flex-wrap gap-2">
-      <%= link_to "新規作成", new_admin_user_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
+      <%= link_to "新規作成", new_admin_user_path, class: app_button_classes %>
     </div>
   </div>
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -3,36 +3,18 @@
     <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">ダッシュボード</h1>
     <p class="mt-2 text-sm text-gray-600">ようこそ、<%= viewing_as_user.nickname %>さん</p>
     <% if viewing_as_user.is_guest %>
-      <div class="mt-4 bg-amber-50 border-l-4 border-amber-400 p-4">
-        <div class="flex">
-          <div class="flex-shrink-0">
-            <svg class="h-5 w-5 text-amber-400" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-            </svg>
-          </div>
-          <div class="ml-3">
-            <p class="text-sm text-amber-700">
-              <span class="font-medium">ゲストアカウントでログイン中：</span>
-              個人戦績などの機能を利用するには、管理者にアカウント発行を依頼してください。
-            </p>
-          </div>
-        </div>
+      <div class="mt-4">
+        <%= render "shared/app_notice",
+            tone: :warning,
+            title: "ゲストアカウントでログイン中",
+            message: "個人戦績などの機能を利用するには、管理者にアカウント発行を依頼してください。" %>
       </div>
     <% elsif @user_total_matches == 0 %>
-      <div class="mt-4 bg-blue-50 border-l-4 border-blue-400 p-4">
-        <div class="flex">
-          <div class="flex-shrink-0">
-            <svg class="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
-              <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
-            </svg>
-          </div>
-          <div class="ml-3">
-            <p class="text-sm text-blue-700">
-              <span class="font-medium">初めての方へ：</span>
-              対戦会でイベントが作成されたら、ローテーション表から試合に参加しましょう。試合結果を記録すると、ここに統計情報が表示されます。
-            </p>
-          </div>
-        </div>
+      <div class="mt-4">
+        <%= render "shared/app_notice",
+            tone: :info,
+            title: "初めての方へ",
+            message: "対戦会でイベントが作成されたら、ローテーション表から試合に参加しましょう。試合結果を記録すると、ここに統計情報が表示されます。" %>
       </div>
     <% end %>
   </div>
@@ -524,14 +506,10 @@
       <% if @notifications.any? %>
         <div class="space-y-3">
           <% @notifications.each do |notif| %>
-            <div class="<%= notif[:type] == 'warning' ? 'bg-amber-50 border-amber-300' : 'bg-blue-50 border-blue-300' %> border rounded-lg p-4">
-              <div class="flex items-start">
-                <span class="text-2xl mr-3"><%= notif[:icon] %></span>
-                <p class="text-sm <%= notif[:type] == 'warning' ? 'text-amber-800' : 'text-blue-800' %> font-medium">
-                  <%= notif[:message] %>
-                </p>
-              </div>
-            </div>
+            <%= render "shared/app_notice",
+                tone: (notif[:type] == "warning" ? :warning : :info),
+                title: (notif[:type] == "warning" ? "注意" : "お知らせ"),
+                message: "#{notif[:icon]} #{notif[:message]}" %>
           <% end %>
         </div>
       <% end %>
@@ -890,4 +868,3 @@
 
 
 </div>
-

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,48 +1,48 @@
-<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-  <div class="max-w-md w-full space-y-8">
-    <div class="text-center">
-      <img src="/logo-login.png" alt="VS.Mobile for KGY" class="mx-auto max-h-48 sm:max-h-60 w-auto">
-    </div>
+<% content_for :title, "ログイン | VS.Mobile for KGY" %>
 
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "mt-8 space-y-6" }) do |f| %>
+<div class="auth-layout">
+  <section class="auth-card">
+    <div class="auth-card__logo">
+      <img src="/logo-login.png" alt="VS.Mobile for KGY" class="max-h-36 w-auto sm:max-h-40">
+    </div>
+    <p class="auth-card__eyebrow">VS.Mobile for KGY</p>
+    <h1 class="auth-card__title">ログイン</h1>
+
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "auth-form" }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
-      <div class="rounded-md shadow-sm -space-y-px">
-        <div>
-          <%= f.label :username, "ユーザー名", class: "sr-only" %>
-          <%= f.text_field :username, autofocus: true, autocomplete: "username", placeholder: "ユーザー名", class: "appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm" %>
-        </div>
-        <div>
-          <%= f.label :password, "パスワード", class: "sr-only" %>
-          <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワード", class: "appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm" %>
-        </div>
+      <div class="auth-field">
+        <%= f.label :username, "ユーザー名", class: "auth-label" %>
+        <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "auth-input" %>
+      </div>
+
+      <div class="auth-field">
+        <%= f.label :password, "パスワード", class: "auth-label" %>
+        <%= f.password_field :password, autocomplete: "current-password", class: "auth-input" %>
       </div>
 
       <% if devise_mapping.rememberable? %>
-        <div class="flex items-center">
-          <%= f.check_box :remember_me, class: "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded" %>
-          <%= f.label :remember_me, "ログイン状態を保持", class: "ml-2 block text-sm text-gray-900" %>
-        </div>
+        <label class="auth-remember">
+          <%= f.check_box :remember_me, class: "auth-checkbox" %>
+          <span>ログイン状態を保持</span>
+        </label>
       <% end %>
 
-      <div>
-        <%= f.submit "ログイン", class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
-      </div>
+      <%= f.submit "ログイン", class: app_button_classes(full_width: true) %>
     <% end %>
 
-    <div class="mt-4">
-      <div class="relative">
-        <div class="absolute inset-0 flex items-center">
-          <div class="w-full border-t border-gray-300"></div>
-        </div>
-        <div class="relative flex justify-center text-sm">
-          <span class="px-2 bg-gray-50 text-gray-500">または</span>
-        </div>
-      </div>
-
-      <div class="mt-4">
-        <%= button_to "ゲストとしてログイン", guest_login_path, method: :post, data: { turbo: false }, class: "group relative w-full flex justify-center py-2 px-4 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
-      </div>
+    <div class="auth-divider">
+      <span>ゲストログイン</span>
     </div>
-  </div>
+
+    <%= button_to "ゲストとしてログイン", guest_login_path,
+        method: :post,
+        data: { turbo: false },
+        class: app_button_classes(variant: :secondary, full_width: true),
+        form_class: "mt-4 w-full" %>
+
+    <p class="auth-card__footnote">
+      ゲストでは閲覧中心の機能を試せます。個人戦績などの機能を使う場合は、管理者にアカウント発行を依頼してください。
+    </p>
+  </section>
 </div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,22 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
+  <div id="error_explanation" class="<%= app_notice_classes(:danger) %>" data-turbo-cache="false">
+    <div class="<%= app_notice_icon_classes(:danger) %>">
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+      </svg>
+    </div>
+
+    <div class="min-w-0">
+      <p class="app-notice__title">
+        <%= I18n.t("errors.messages.not_saved",
+                   count: resource.errors.count,
+                   resource: resource.class.model_name.human.downcase) %>
+      </p>
+      <ul class="app-notice__list">
+        <% resource.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
   </div>
 <% end %>

--- a/app/views/events/edit_timestamps.html.erb
+++ b/app/views/events/edit_timestamps.html.erb
@@ -7,8 +7,11 @@
   <h2 class="text-lg font-medium text-gray-700 mb-6">タイムスタンプ一括設定</h2>
 
   <% if flash[:alert] %>
-    <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
-      <p class="text-sm text-red-700"><%= flash[:alert] %></p>
+    <div class="mb-4">
+      <%= render "shared/app_notice",
+          tone: :danger,
+          title: "入力内容を確認してください",
+          message: flash[:alert] %>
     </div>
   <% end %>
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,7 +6,7 @@
     </div>
     <% if current_user.is_admin? %>
       <div class="flex flex-wrap gap-2">
-        <%= link_to "新規作成", new_event_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded" %>
+        <%= link_to "新規作成", new_event_path, class: app_button_classes %>
       </div>
     <% end %>
   </div>
@@ -131,4 +131,3 @@
     </div>
   <% end %>
 </div>
-

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -7,13 +7,13 @@
     remote:        data-remote
 -%>
 <% if current_page.first? %>
-  <span class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-400 bg-gray-100 border border-gray-200 rounded-lg cursor-not-allowed">
+  <span class="ui-chip min-h-0 cursor-not-allowed border-gray-200 bg-gray-100 px-3 py-2 text-sm font-medium text-gray-400 shadow-none">
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
     </svg>
   </span>
 <% else %>
-  <%= link_to url, remote: remote, class: "inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out", title: "最初のページ" do %>
+  <%= link_to url, remote: remote, class: "ui-chip ui-chip--muted px-3 py-2 text-sm font-medium", title: "最初のページ" do %>
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
     </svg>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -7,13 +7,13 @@
     remote:        data-remote
 -%>
 <% if current_page.last? %>
-  <span class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-400 bg-gray-100 border border-gray-200 rounded-lg cursor-not-allowed">
+  <span class="ui-chip min-h-0 cursor-not-allowed border-gray-200 bg-gray-100 px-3 py-2 text-sm font-medium text-gray-400 shadow-none">
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
     </svg>
   </span>
 <% else %>
-  <%= link_to url, remote: remote, class: "inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out", title: "最後のページ" do %>
+  <%= link_to url, remote: remote, class: "ui-chip ui-chip--muted px-3 py-2 text-sm font-medium", title: "最後のページ" do %>
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
     </svg>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,13 +7,13 @@
     remote:        data-remote
 -%>
 <% if current_page.last? %>
-  <span class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-400 bg-gray-100 border border-gray-200 rounded-lg cursor-not-allowed" title="次へ">
+  <span class="ui-chip min-h-0 cursor-not-allowed border-gray-200 bg-gray-100 px-3 py-2 text-sm font-medium text-gray-400 shadow-none" title="次へ">
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
     </svg>
   </span>
 <% else %>
-  <%= link_to url, rel: 'next', remote: remote, class: "inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out", title: "次へ" do %>
+  <%= link_to url, rel: 'next', remote: remote, class: "ui-chip ui-chip--muted px-3 py-2 text-sm font-medium", title: "次へ" do %>
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
     </svg>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,9 +8,9 @@
     remote:        data-remote
 -%>
 <% if page.current? %>
-  <span class="inline-flex items-center px-4 py-2 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg">
+  <span class="ui-chip ui-chip--accent px-4 py-2 text-sm">
     <%= page %>
   </span>
 <% else %>
-  <%= link_to page, url, remote: remote, rel: page.rel, class: "inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
+  <%= link_to page, url, remote: remote, rel: page.rel, class: "ui-chip ui-chip--muted px-4 py-2 text-sm font-medium" %>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,13 +7,13 @@
     remote:        data-remote
 -%>
 <% if current_page.first? %>
-  <span class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-400 bg-gray-100 border border-gray-200 rounded-lg cursor-not-allowed" title="前へ">
+  <span class="ui-chip min-h-0 cursor-not-allowed border-gray-200 bg-gray-100 px-3 py-2 text-sm font-medium text-gray-400 shadow-none" title="前へ">
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
     </svg>
   </span>
 <% else %>
-  <%= link_to url, rel: 'prev', remote: remote, class: "inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out", title: "前へ" do %>
+  <%= link_to url, rel: 'prev', remote: remote, class: "ui-chip ui-chip--muted px-3 py-2 text-sm font-medium", title: "前へ" do %>
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
     </svg>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html style="scrollbar-gutter: stable;">
+<html class="h-full" style="scrollbar-gutter: stable;">
   <head>
     <title><%= content_for(:title) || "VS.Mobile for KGY" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -32,471 +32,44 @@
     </script>
   </head>
 
-  <body class="bg-gray-50">
-    <!-- サイドバーナビゲーション（PC/iPad Landscape用：1024px以上で表示） -->
+  <body class="app-body">
     <% if user_signed_in? %>
-      <aside class="sidebar-nav fixed inset-y-0 left-0 w-64 shadow-lg z-40 flex flex-col">
-        <!-- ロゴ部分（白背景） -->
-        <div class="flex-shrink-0 px-4 py-4 bg-white border-b border-gray-200">
-          <%= link_to root_path do %>
-            <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.Mobile for KGY" class="h-12">
-          <% end %>
-        </div>
+      <div class="app-shell" data-controller="mobile-nav">
+        <%= render "shared/app_sidebar" %>
 
-        <!-- メイン部分（インディゴ背景） -->
-        <div class="flex flex-col flex-1 overflow-y-auto bg-[#4F39F6]">
-          <!-- メインナビゲーション -->
-          <nav class="flex-1 px-3 py-4 space-y-1">
-            <%= link_to "ダッシュボード", dashboard_path, class: "sidebar-nav-item #{current_page?(dashboard_path) || current_page?(root_path) ? 'active' : ''}" %>
-            <%= link_to "イベント", events_path, class: "sidebar-nav-item #{current_page?(events_path) ? 'active' : ''}" %>
-            <%= link_to "ローテーション", rotations_path, class: "sidebar-nav-item #{current_page?(rotations_path) ? 'active' : ''}" %>
-            <%= link_to "対戦履歴", matches_path, class: "sidebar-nav-item #{current_page?(matches_path) ? 'active' : ''}" %>
-            <%= link_to "統計", statistics_path, class: "sidebar-nav-item #{current_page?(statistics_path) ? 'active' : ''}" %>
-            <%= link_to "機体一覧", mobile_suits_path, class: "sidebar-nav-item #{current_page?(mobile_suits_path) ? 'active' : ''}" %>
+        <div class="app-with-sidebar">
+          <%= render "shared/app_topbar" %>
+          <%= render "shared/app_mobile_menu" %>
 
-            <% if current_user.is_admin? %>
-              <!-- 管理者メニューセパレーター -->
-              <div class="pt-4 mt-4 border-t border-indigo-400">
-                <div class="px-3 py-2 text-xs font-semibold text-indigo-200 uppercase tracking-wider">
-                  管理者メニュー
-                </div>
-              </div>
-
-              <%= link_to "お知らせ管理", admin_announcements_path, class: "sidebar-nav-item #{current_page?(admin_announcements_path) ? 'active' : ''}" %>
-              <%= link_to "Discord設定", admin_discord_channels_path, class: "sidebar-nav-item #{current_page?(admin_discord_channels_path) ? 'active' : ''}" %>
-              <%= link_to "機体マスタ", admin_mobile_suits_path, class: "sidebar-nav-item #{current_page?(admin_mobile_suits_path) ? 'active' : ''}" %>
-              <%= link_to "スタンプマスタ", admin_master_emojis_path, class: "sidebar-nav-item #{current_page?(admin_master_emojis_path) ? 'active' : ''}" %>
-              <%= link_to "ユーザー管理", admin_users_path, class: "sidebar-nav-item #{current_page?(admin_users_path) ? 'active' : ''}" %>
-            <% end %>
-          </nav>
-        </div>
-
-        <!-- 下部セクション（固定・インディゴ背景） -->
-        <div class="flex-shrink-0 border-t border-indigo-400 p-4 bg-[#4F39F6]">
-          <!-- ユーザー情報（管理者はクリックで視点切り替えドロップダウン） -->
-          <% if current_user.is_admin? %>
-            <div class="relative mb-3" data-controller="user-switcher">
-              <button type="button" data-action="click->user-switcher#toggle" class="w-full flex items-center rounded-lg px-2 py-2 transition-colors <%= viewing_as_someone_else? ? 'bg-white/20 hover:bg-white/25 ring-1 ring-white/50' : 'hover:bg-white/10' %>">
-                <div class="flex-shrink-0">
-                  <div class="h-9 w-9 rounded-full flex items-center justify-center <%= viewing_as_someone_else? ? 'bg-white/35' : 'bg-white/20' %>">
-                    <span class="text-white font-medium text-sm"><%= viewing_as_user.nickname[0] %></span>
-                  </div>
-                </div>
-                <div class="ml-3 flex-1 text-left min-w-0">
-                  <div class="text-sm font-medium text-white truncate">
-                    <% if viewing_as_someone_else? %>
-                      <span class="text-indigo-100 text-xs font-normal">視点切り替え中</span><br>
-                      <%= viewing_as_user.nickname %>
-                    <% else %>
-                      <%= current_user.nickname %>
-                    <% end %>
-                  </div>
-                  <div class="text-xs text-indigo-200 truncate">
-                    <% if viewing_as_someone_else? %>
-                      <%= viewing_as_user.username %>
-                    <% else %>
-                      <%= current_user.username %>
-                    <% end %>
-                  </div>
-                </div>
-                <div class="flex-shrink-0 ml-2">
-                  <svg class="w-4 h-4 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
-                  </svg>
-                </div>
-              </button>
-
-              <!-- ドロップダウン（上方向に展開） -->
-              <div data-user-switcher-target="dropdown" class="hidden absolute bottom-full left-0 right-0 mb-2 bg-white rounded-lg shadow-xl border border-gray-200 overflow-hidden z-50">
-                <% if viewing_as_someone_else? %>
-                  <button type="button" data-action="click->user-switcher#clearView" class="w-full flex items-center px-4 py-3 text-sm font-medium text-indigo-700 hover:bg-indigo-50 border-b border-gray-100 transition-colors">
-                    <svg class="w-4 h-4 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
-                    </svg>
-                    管理者視点に戻す
-                  </button>
-                <% end %>
-                <div class="max-h-48 overflow-y-auto py-1">
-                  <% User.where(is_admin: false).order(:nickname).each do |user| %>
-                    <% next if viewing_as_someone_else? && user.id == viewing_as_user.id %>
-                    <button type="button" data-action="click->user-switcher#switchView" data-user-id="<%= user.id %>" class="w-full flex items-center px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
-                      <div class="h-7 w-7 rounded-full bg-indigo-100 flex items-center justify-center mr-3 flex-shrink-0">
-                        <span class="text-indigo-600 font-medium text-xs"><%= user.nickname[0] %></span>
-                      </div>
-                      <span class="truncate"><%= user.nickname %></span>
-                    </button>
-                  <% end %>
-                </div>
-              </div>
+          <div class="app-shell-content">
+            <div id="flash-messages" class="page-container flash-stack">
+              <% flash.each do |type, message| %>
+                <%= render "shared/flash_message", type: type, message: message %>
+              <% end %>
             </div>
-          <% else %>
-            <!-- 一般ユーザー: 通常のユーザー情報表示 -->
-            <div class="flex items-center mb-3 px-2">
-              <div class="flex-shrink-0">
-                <div class="h-9 w-9 rounded-full bg-white/20 flex items-center justify-center">
-                  <span class="text-white font-medium text-sm"><%= current_user.nickname[0] %></span>
-                </div>
-              </div>
-              <div class="ml-3 min-w-0">
-                <div class="text-sm font-medium text-white truncate"><%= current_user.nickname %></div>
-                <div class="text-xs text-indigo-200 truncate"><%= current_user.username %></div>
-              </div>
-            </div>
-          <% end %>
 
-          <!-- マイページ・設定・ログアウト -->
-          <div class="space-y-1">
-            <% unless current_user.is_guest? %>
-              <%= link_to "マイページ", my_page_path, class: "sidebar-nav-item-small #{current_page?(my_page_path) ? 'active' : ''}" %>
-            <% end %>
-            <% unless current_user.username == 'guest' %>
-              <%= link_to "設定", edit_profile_path, class: "sidebar-nav-item-small" %>
-            <% end %>
-            <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "sidebar-nav-item-small w-full text-left" %>
+            <main class="page-container app-main">
+              <%= yield %>
+            </main>
           </div>
         </div>
-      </aside>
+      </div>
+    <% else %>
+      <div class="app-public-shell">
+        <div id="flash-messages" class="page-container flash-stack pt-6">
+          <% flash.each do |type, message| %>
+            <%= render "shared/flash_message", type: type, message: message %>
+          <% end %>
+        </div>
+
+        <main class="page-container app-public-main">
+          <%= yield %>
+        </main>
+      </div>
     <% end %>
 
-    <!-- モバイルヘッダーナビゲーション（1024px未満で表示） -->
-    <nav class="mobile-header-nav bg-white shadow-sm">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
-          <!-- ロゴとデスクトップメニュー -->
-          <div class="flex">
-            <div class="flex-shrink-0 flex items-center">
-              <%= link_to root_path do %>
-                <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.Mobile for KGY" class="h-12 sm:h-14">
-              <% end %>
-            </div>
-            <% if user_signed_in? %>
-              <!-- デスクトップナビゲーション（768px以上で表示） -->
-              <div class="desktop-menu ml-6 space-x-4 lg:space-x-8">
-                <%= link_to "ダッシュボード", dashboard_path, class: "inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-900 border-b-2 #{current_page?(dashboard_path) || current_page?(root_path) ? 'border-indigo-500' : 'border-transparent hover:border-gray-300'}" %>
-                <%= link_to "イベント", events_path, class: "inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-900 border-b-2 #{current_page?(events_path) ? 'border-indigo-500' : 'border-transparent hover:border-gray-300'}" %>
-                <%= link_to "ローテーション", rotations_path, class: "inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-900 border-b-2 #{current_page?(rotations_path) ? 'border-indigo-500' : 'border-transparent hover:border-gray-300'}" %>
-                <%= link_to "対戦履歴", matches_path, class: "inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-900 border-b-2 #{current_page?(matches_path) ? 'border-indigo-500' : 'border-transparent hover:border-gray-300'}" %>
-                <%= link_to "統計", statistics_path, class: "inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-900 border-b-2 #{current_page?(statistics_path) ? 'border-indigo-500' : 'border-transparent hover:border-gray-300'}" %>
-                <% if current_user.is_admin? %>
-                  <%= link_to "機体マスタ", admin_mobile_suits_path, class: "inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-900 border-b-2 #{current_page?(admin_mobile_suits_path) ? 'border-indigo-500' : 'border-transparent hover:border-gray-300'}" %>
-                  <%= link_to "スタンプマスタ", admin_master_emojis_path, class: "inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-900 border-b-2 #{current_page?(admin_master_emojis_path) ? 'border-indigo-500' : 'border-transparent hover:border-gray-300'}" %>
-                  <%= link_to "ユーザー管理", admin_users_path, class: "inline-flex items-center px-1 pt-1 text-sm font-medium text-gray-900 border-b-2 #{current_page?(admin_users_path) ? 'border-indigo-500' : 'border-transparent hover:border-gray-300'}" %>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
-
-          <!-- 右側：ユーザー情報とハンバーガーボタン -->
-          <div class="flex items-center">
-            <% if user_signed_in? %>
-              <!-- デスクトップ用ユーザー情報（768px以上で表示） -->
-              <div class="desktop-menu items-center space-x-4">
-                <!-- 管理者用: ユーザー視点切り替え -->
-                <% if current_user.is_admin? %>
-                  <div class="flex items-center space-x-2">
-                    <select onchange="if(this.value) switchUserView(this.value);" class="text-sm border border-gray-300 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500 <%= viewing_as_someone_else? ? 'bg-indigo-50 border-indigo-300' : '' %>">
-                      <% if viewing_as_someone_else? %>
-                        <option value=""><%= viewing_as_user.nickname %>の視点 ▼</option>
-                        <option value="clear">--- 管理者視点に戻す ---</option>
-                      <% else %>
-                        <option value="">視点切り替え...</option>
-                      <% end %>
-                      <% User.where(is_admin: false).order(:nickname).each do |user| %>
-                        <% unless viewing_as_someone_else? && user.id == viewing_as_user.id %>
-                          <option value="<%= user.id %>"><%= user.nickname %></option>
-                        <% end %>
-                      <% end %>
-                    </select>
-                  </div>
-                <% end %>
-
-                <span class="text-sm text-gray-700"><%= current_user.nickname %></span>
-                <% unless current_user.username == 'guest' %>
-                  <%= link_to "設定", edit_profile_path, class: "text-sm text-gray-700 hover:text-gray-900" %>
-                <% end %>
-                <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-sm text-gray-700 hover:text-gray-900" %>
-              </div>
-
-              <!-- モバイル用ハンバーガーボタン（768px未満で表示） -->
-              <div class="mobile-menu-btn items-center">
-                <button type="button" onclick="toggleMobileMenu()" class="inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500" aria-controls="mobile-menu" aria-expanded="false">
-                  <span class="sr-only">メニューを開く</span>
-                  <!-- ハンバーガーアイコン（テキストベース） -->
-                  <span id="menu-icon-open" class="text-2xl font-bold leading-none">☰</span>
-                  <!-- 閉じるアイコン -->
-                  <span id="menu-icon-close" class="hidden text-2xl font-bold leading-none">✕</span>
-                </button>
-              </div>
-            <% else %>
-              <%= link_to "ログイン", new_user_session_path, class: "text-sm text-gray-700 hover:text-gray-900" %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-
-      <style>
-        /* === サイドバーとモバイルヘッダーの表示制御 === */
-        /* モバイル・タブレット（1024px未満）: サイドバー非表示、モバイルヘッダー表示 */
-        .sidebar-nav { display: none !important; }
-        .mobile-header-nav { display: block !important; }
-        .main-content-with-sidebar { margin-left: 0; }
-
-        /* デスクトップ・iPad Landscape（1024px以上）: サイドバー表示、モバイルヘッダー非表示 */
-        @media (min-width: 1024px) {
-          .sidebar-nav { display: flex !important; }
-          .mobile-header-nav { display: none !important; }
-          .main-content-with-sidebar { margin-left: 16rem; /* w-64 = 256px = 16rem */ }
-        }
-
-        /* === モバイルヘッダー内のメニュー表示制御 === */
-        /* 1024px未満: ハンバーガーメニューのみ表示、デスクトップメニュー非表示 */
-        .desktop-menu { display: none !important; }
-        .mobile-menu-btn { display: flex !important; }
-
-        /* === サイドバーのスクロール制御 === */
-        .sidebar-nav {
-          overflow: hidden; /* サイドバー全体はスクロールしない */
-        }
-
-        .sidebar-nav > div.overflow-y-auto {
-          overscroll-behavior: contain; /* スクロールがメイン画面に伝播しない */
-          -webkit-overflow-scrolling: touch; /* iOS用スムーススクロール */
-          scrollbar-width: thin; /* Firefox: 細いスクロールバー */
-          scrollbar-color: rgba(255, 255, 255, 0.25) transparent; /* Firefox: 半透明白 */
-        }
-
-        /* Webkit系（Chrome / Safari / Edge）: 細くて目立たないスクロールバー */
-        .sidebar-nav > div.overflow-y-auto::-webkit-scrollbar {
-          width: 4px;
-        }
-
-        .sidebar-nav > div.overflow-y-auto::-webkit-scrollbar-track {
-          background: transparent;
-        }
-
-        .sidebar-nav > div.overflow-y-auto::-webkit-scrollbar-thumb {
-          background: rgba(255, 255, 255, 0.25);
-          border-radius: 9999px;
-        }
-
-        .sidebar-nav > div.overflow-y-auto::-webkit-scrollbar-thumb:hover {
-          background: rgba(255, 255, 255, 0.4);
-        }
-
-        /* === サイドバーナビアイテムのスタイル（インディゴ背景用） === */
-        .sidebar-nav-item {
-          display: flex;
-          align-items: center;
-          padding: 0.75rem 1rem;
-          border-radius: 0.5rem;
-          font-size: 0.875rem;
-          font-weight: 500;
-          color: rgba(255, 255, 255, 0.9); /* 白（少し透過） */
-          transition: background-color 0.15s ease-in-out;
-        }
-
-        .sidebar-nav-item:hover {
-          background-color: rgba(255, 255, 255, 0.1); /* 白の10%透過 */
-          color: #ffffff;
-        }
-
-        .sidebar-nav-item.active {
-          background-color: rgba(255, 255, 255, 0.2); /* 白の20%透過 */
-          color: #ffffff;
-          font-weight: 600;
-        }
-
-        .sidebar-nav-item-small {
-          display: flex;
-          align-items: center;
-          padding: 0.5rem 0.75rem;
-          border-radius: 0.375rem;
-          font-size: 0.875rem;
-          color: rgba(255, 255, 255, 0.8); /* 白（少し透過） */
-          transition: background-color 0.15s ease-in-out;
-        }
-
-        .sidebar-nav-item-small:hover {
-          background-color: rgba(255, 255, 255, 0.1); /* 白の10%透過 */
-          color: #ffffff;
-        }
-
-        /* === モバイルメニューアイテムのスタイル（インディゴ背景用） === */
-        .mobile-menu-item {
-          display: block;
-          padding: 0.75rem 1rem;
-          border-radius: 0.5rem;
-          font-size: 1rem;
-          font-weight: 500;
-          color: rgba(255, 255, 255, 0.9);
-          transition: background-color 0.15s ease-in-out;
-        }
-
-        .mobile-menu-item:hover {
-          background-color: rgba(255, 255, 255, 0.1);
-          color: #ffffff;
-        }
-
-        .mobile-menu-item.active {
-          background-color: rgba(255, 255, 255, 0.2);
-          color: #ffffff;
-          font-weight: 600;
-        }
-
-        .mobile-menu-item-small {
-          display: block;
-          padding: 0.75rem 1rem;
-          border-radius: 0.375rem;
-          font-size: 1rem;
-          color: rgba(255, 255, 255, 0.8);
-          transition: background-color 0.15s ease-in-out;
-        }
-
-        .mobile-menu-item-small:hover {
-          background-color: rgba(255, 255, 255, 0.1);
-          color: #ffffff;
-        }
-      </style>
-
-      <!-- モバイルメニュー（デフォルトは非表示） -->
-      <% if user_signed_in? %>
-        <div class="hidden" id="mobile-menu">
-          <!-- ナビゲーション部分（インディゴ背景） -->
-          <div class="pt-2 pb-3 space-y-1 bg-[#4F39F6] px-4">
-            <%= link_to "ダッシュボード", dashboard_path, class: "mobile-menu-item #{current_page?(dashboard_path) || current_page?(root_path) ? 'active' : ''}" %>
-            <%= link_to "イベント", events_path, class: "mobile-menu-item #{current_page?(events_path) ? 'active' : ''}" %>
-            <%= link_to "ローテーション", rotations_path, class: "mobile-menu-item #{current_page?(rotations_path) ? 'active' : ''}" %>
-            <%= link_to "対戦履歴", matches_path, class: "mobile-menu-item #{current_page?(matches_path) ? 'active' : ''}" %>
-            <%= link_to "統計", statistics_path, class: "mobile-menu-item #{current_page?(statistics_path) ? 'active' : ''}" %>
-            <%= link_to "機体一覧", mobile_suits_path, class: "mobile-menu-item #{current_page?(mobile_suits_path) ? 'active' : ''}" %>
-            <% if current_user.is_admin? %>
-              <div class="border-t border-indigo-400 mt-3 pt-3">
-                <div class="px-4 py-2 text-xs font-semibold text-indigo-200 uppercase tracking-wider">管理者メニュー</div>
-                <%= link_to "お知らせ管理", admin_announcements_path, class: "mobile-menu-item #{current_page?(admin_announcements_path) ? 'active' : ''}" %>
-                <%= link_to "Discord設定", admin_discord_channels_path, class: "mobile-menu-item #{current_page?(admin_discord_channels_path) ? 'active' : ''}" %>
-                <%= link_to "機体マスタ", admin_mobile_suits_path, class: "mobile-menu-item #{current_page?(admin_mobile_suits_path) ? 'active' : ''}" %>
-                <%= link_to "スタンプマスタ", admin_master_emojis_path, class: "mobile-menu-item #{current_page?(admin_master_emojis_path) ? 'active' : ''}" %>
-                <%= link_to "ユーザー管理", admin_users_path, class: "mobile-menu-item #{current_page?(admin_users_path) ? 'active' : ''}" %>
-              </div>
-            <% end %>
-          </div>
-          <!-- ユーザー情報セクション（インディゴ背景） -->
-          <div class="pt-4 pb-3 border-t border-indigo-400 bg-[#4F39F6] px-4">
-            <!-- ユーザー情報（管理者はクリックで視点切り替えドロップダウン） -->
-            <% if current_user.is_admin? %>
-              <div class="relative" data-controller="user-switcher">
-                <button type="button" data-action="click->user-switcher#toggle" class="w-full flex items-center rounded-lg px-3 py-2 transition-colors <%= viewing_as_someone_else? ? 'bg-white/20 hover:bg-white/25 ring-1 ring-white/50' : 'hover:bg-white/10' %>">
-                  <div class="flex-shrink-0">
-                    <div class="h-10 w-10 rounded-full flex items-center justify-center <%= viewing_as_someone_else? ? 'bg-white/35' : 'bg-white/20' %>">
-                      <span class="text-white font-medium text-sm"><%= viewing_as_user.nickname[0] %></span>
-                    </div>
-                  </div>
-                  <div class="ml-3 flex-1 text-left min-w-0">
-                    <div class="text-base font-medium text-white truncate">
-                      <% if viewing_as_someone_else? %>
-                        <span class="text-indigo-100 text-xs font-normal">視点切り替え中</span><br>
-                        <%= viewing_as_user.nickname %>
-                      <% else %>
-                        <%= current_user.nickname %>
-                      <% end %>
-                    </div>
-                    <div class="text-sm text-indigo-200 truncate">
-                      <%= viewing_as_someone_else? ? viewing_as_user.username : current_user.username %>
-                    </div>
-                  </div>
-                  <div class="flex-shrink-0 ml-2">
-                    <svg class="w-4 h-4 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l4-4 4 4m0 6l-4 4-4-4"/>
-                    </svg>
-                  </div>
-                </button>
-
-                <!-- ドロップダウン（下方向に展開） -->
-                <div data-user-switcher-target="dropdown" class="hidden absolute top-full left-0 right-0 mt-2 bg-white rounded-lg shadow-xl border border-gray-200 overflow-hidden z-50">
-                  <% if viewing_as_someone_else? %>
-                    <button type="button" data-action="click->user-switcher#clearView" class="w-full flex items-center px-4 py-3 text-sm font-medium text-indigo-700 hover:bg-indigo-50 border-b border-gray-100 transition-colors">
-                      <svg class="w-4 h-4 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/>
-                      </svg>
-                      管理者視点に戻す
-                    </button>
-                  <% end %>
-                  <div class="max-h-48 overflow-y-auto py-1">
-                    <% User.where(is_admin: false).order(:nickname).each do |user| %>
-                      <% next if viewing_as_someone_else? && user.id == viewing_as_user.id %>
-                      <button type="button" data-action="click->user-switcher#switchView" data-user-id="<%= user.id %>" class="w-full flex items-center px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
-                        <div class="h-7 w-7 rounded-full bg-indigo-100 flex items-center justify-center mr-3 flex-shrink-0">
-                          <span class="text-indigo-600 font-medium text-xs"><%= user.nickname[0] %></span>
-                        </div>
-                        <span class="truncate"><%= user.nickname %></span>
-                      </button>
-                    <% end %>
-                  </div>
-                </div>
-              </div>
-            <% else %>
-              <div class="flex items-center px-3">
-                <div class="flex-shrink-0">
-                  <div class="h-10 w-10 rounded-full bg-white/20 flex items-center justify-center">
-                    <span class="text-white font-medium text-sm"><%= current_user.nickname[0] %></span>
-                  </div>
-                </div>
-                <div class="ml-3">
-                  <div class="text-base font-medium text-white"><%= current_user.nickname %></div>
-                  <div class="text-sm text-indigo-200"><%= current_user.username %></div>
-                </div>
-              </div>
-            <% end %>
-
-            <div class="mt-3 space-y-1">
-              <% unless current_user.is_guest? %>
-                <%= link_to "マイページ", my_page_path, class: "mobile-menu-item-small #{current_page?(my_page_path) ? 'active' : ''}" %>
-              <% end %>
-              <% unless current_user.username == 'guest' %>
-                <%= link_to "設定", edit_profile_path, class: "mobile-menu-item-small" %>
-              <% end %>
-              <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "mobile-menu-item-small w-full text-left" %>
-            </div>
-          </div>
-        </div>
-      <% end %>
-
-      <script>
-        function toggleMobileMenu() {
-          const menu = document.getElementById('mobile-menu');
-          const iconOpen = document.getElementById('menu-icon-open');
-          const iconClose = document.getElementById('menu-icon-close');
-
-          if (menu.classList.contains('hidden')) {
-            menu.classList.remove('hidden');
-            iconOpen.classList.add('hidden');
-            iconClose.classList.remove('hidden');
-          } else {
-            menu.classList.add('hidden');
-            iconOpen.classList.remove('hidden');
-            iconClose.classList.add('hidden');
-          }
-        }
-      </script>
-    </nav>
-
-    <!-- フラッシュメッセージ -->
-    <div id="flash-messages" class="<%= 'main-content-with-sidebar' if user_signed_in? %> page-container">
-      <% flash.each do |type, message| %>
-        <%= render "shared/flash_message", type: type, message: message %>
-      <% end %>
-    </div>
-
-    <main class="<%= 'main-content-with-sidebar' if user_signed_in? %>">
-      <div class="page-container">
-        <%= yield %>
-      </div>
-    </main>
-
-    <%# お知らせモーダル %>
     <% if @unread_announcement %>
       <%= render "announcements/modal", announcement: @unread_announcement %>
     <% end %>
-
   </body>
 </html>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -8,9 +8,9 @@
     <% if current_user.is_admin? %>
       <div class="flex flex-wrap gap-2">
         <% if @latest_event %>
-          <%= link_to "新規登録", new_event_match_path(@latest_event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded", data: { turbo_frame: "_top" } %>
+          <%= link_to "新規登録", new_event_match_path(@latest_event), class: app_button_classes, data: { turbo_frame: "_top" } %>
         <% end %>
-        <%= link_to "CSVインポート", new_admin_import_path, class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded", data: { turbo_frame: "_top" } %>
+        <%= link_to "CSVインポート", new_admin_import_path, class: app_button_classes(variant: :secondary), data: { turbo_frame: "_top" } %>
       </div>
     <% end %>
   </div>

--- a/app/views/rotations/new.html.erb
+++ b/app/views/rotations/new.html.erb
@@ -7,13 +7,20 @@
   <div class="bg-white shadow sm:rounded-lg p-6">
     <%= form_with model: @rotation, url: event_rotations_path(@event), local: true do |f| %>
       <% if @rotation.errors.any? %>
-        <div class="mb-4 bg-red-50 border border-red-200 text-red-800 rounded-lg p-4">
-          <h3 class="font-semibold mb-2"><%= pluralize(@rotation.errors.count, "件のエラー") %>があります:</h3>
-          <ul class="list-disc list-inside">
-            <% @rotation.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
+        <div class="mb-4 <%= app_notice_classes(:danger) %>">
+          <div class="<%= app_notice_icon_classes(:danger) %>">
+            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+            </svg>
+          </div>
+          <div class="min-w-0">
+            <p class="app-notice__title"><%= pluralize(@rotation.errors.count, "件のエラー") %>があります</p>
+            <ul class="app-notice__list">
+              <% @rotation.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
         </div>
       <% end %>
 
@@ -56,15 +63,21 @@
   </div>
 
   <!-- Help Section -->
-  <div class="mt-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
-    <h3 class="text-sm font-semibold text-blue-900 mb-2">ローテーション表について</h3>
-    <ul class="text-sm text-blue-800 space-y-1">
-      <li>• <strong>平等性重視:</strong> 各プレイヤーが全プレイヤーと対戦・ペアを組む回数が均等になるように生成されます</li>
-      <li>• <strong>試合数上限:</strong> 1つのローテーション表あたり最大50試合程度に制限されます</li>
-      <li>• <strong>リアルタイム確認:</strong> 参加者はスマホから「プレイヤー画面」で自分の次の出番を確認できます</li>
-      <li>• <strong>通知機能:</strong> 出番が近づくとブラウザ通知が送信されます（2〜3試合前）</li>
-      <li>• <strong>統計表示:</strong> 詳細ページで各プレイヤーの試合数、ペア回数、対戦回数を確認できます</li>
-      <li>• <strong>周回コピー:</strong> 同じ組み合わせで次の周回を作成できます</li>
-    </ul>
+  <div class="mt-6 <%= app_notice_classes(:info) %>">
+    <div class="<%= app_notice_icon_classes(:info) %>">
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
+      </svg>
+    </div>
+    <div class="min-w-0">
+      <p class="app-notice__title">ローテーション表について</p>
+      <ul class="app-notice__list">
+        <li>各プレイヤーが全プレイヤーと対戦・ペアを組む回数が均等になるように生成されます。</li>
+        <li>1つのローテーション表あたり最大50試合程度に制限されます。</li>
+        <li>参加者はスマホからプレイヤー画面で自分の次の出番を確認できます。</li>
+        <li>出番が近づくとブラウザ通知が送信されます。</li>
+        <li>詳細ページで試合数、ペア回数、対戦回数を確認できます。</li>
+      </ul>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_account_actions.html.erb
+++ b/app/views/shared/_account_actions.html.erb
@@ -1,0 +1,10 @@
+<% compact = local_assigns.fetch(:compact, false) %>
+
+<div class="space-y-1.5">
+  <%= render "shared/app_nav_links", items: app_account_navigation_items, compact: compact %>
+  <%= button_to "ログアウト",
+      destroy_user_session_path,
+      method: :delete,
+      form_class: "contents",
+      class: app_nav_link_classes(compact: compact, accent: :logout) %>
+</div>

--- a/app/views/shared/_app_logo.html.erb
+++ b/app/views/shared/_app_logo.html.erb
@@ -1,0 +1,14 @@
+<% compact = local_assigns.fetch(:compact, false) %>
+<% brand_classes = class_names("app-brand", ("app-brand--compact" if compact)) %>
+
+<%= link_to root_path, class: brand_classes do %>
+  <span class="app-brand__media">
+    <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.Mobile for KGY" class="h-10 w-auto sm:h-11">
+  </span>
+  <span class="app-brand__copy">
+    <span class="app-brand__title">VS.Mobile for KGY</span>
+    <% unless compact %>
+      <span class="app-brand__caption">対戦ログと進行を、見やすくひとつに。</span>
+    <% end %>
+  </span>
+<% end %>

--- a/app/views/shared/_app_logo.html.erb
+++ b/app/views/shared/_app_logo.html.erb
@@ -1,9 +1,10 @@
 <% compact = local_assigns.fetch(:compact, false) %>
 <% image_only = local_assigns.fetch(:image_only, false) %>
 <% brand_classes = class_names("app-brand", ("app-brand--compact" if compact), ("app-brand--image-only" if image_only)) %>
+<% media_classes = class_names("app-brand__media", ("app-brand__media--plate" if compact || image_only)) %>
 
 <%= link_to root_path, class: brand_classes do %>
-  <span class="app-brand__media">
+  <span class="<%= media_classes %>">
     <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.Mobile for KGY" class="h-10 w-auto sm:h-11">
   </span>
   <% unless image_only %>

--- a/app/views/shared/_app_logo.html.erb
+++ b/app/views/shared/_app_logo.html.erb
@@ -1,14 +1,17 @@
 <% compact = local_assigns.fetch(:compact, false) %>
-<% brand_classes = class_names("app-brand", ("app-brand--compact" if compact)) %>
+<% image_only = local_assigns.fetch(:image_only, false) %>
+<% brand_classes = class_names("app-brand", ("app-brand--compact" if compact), ("app-brand--image-only" if image_only)) %>
 
 <%= link_to root_path, class: brand_classes do %>
   <span class="app-brand__media">
     <img src="/logo-header.png" srcset="/logo-header.png 2x" alt="VS.Mobile for KGY" class="h-10 w-auto sm:h-11">
   </span>
-  <span class="app-brand__copy">
-    <span class="app-brand__title">VS.Mobile for KGY</span>
-    <% unless compact %>
-      <span class="app-brand__caption">対戦ログと進行を、見やすくひとつに。</span>
-    <% end %>
-  </span>
+  <% unless image_only %>
+    <span class="app-brand__copy">
+      <span class="app-brand__title">VS.Mobile for KGY</span>
+      <% unless compact %>
+        <span class="app-brand__caption">対戦ログと進行を、見やすくひとつに。</span>
+      <% end %>
+    </span>
+  <% end %>
 <% end %>

--- a/app/views/shared/_app_mobile_menu.html.erb
+++ b/app/views/shared/_app_mobile_menu.html.erb
@@ -7,7 +7,7 @@
      class="app-mobile-nav-panel hidden opacity-0 -translate-x-6 lg:hidden">
   <div class="app-mobile-nav-panel__surface">
     <div class="flex items-start justify-between gap-4">
-      <%= render "shared/app_logo", compact: true %>
+      <%= render "shared/app_logo", image_only: true %>
 
       <button type="button" class="app-mobile-close-button" data-action="mobile-nav#close">
         <span class="sr-only">メニューを閉じる</span>

--- a/app/views/shared/_app_mobile_menu.html.erb
+++ b/app/views/shared/_app_mobile_menu.html.erb
@@ -1,0 +1,54 @@
+<div data-mobile-nav-target="backdrop"
+     class="app-mobile-nav-backdrop hidden opacity-0 lg:hidden"
+     data-action="click->mobile-nav#close"></div>
+
+<div id="mobile-navigation-panel"
+     data-mobile-nav-target="panel"
+     class="app-mobile-nav-panel hidden opacity-0 -translate-x-6 lg:hidden">
+  <div class="app-mobile-nav-panel__surface">
+    <div class="flex items-start justify-between gap-4">
+      <%= render "shared/app_logo", compact: true %>
+
+      <button type="button" class="app-mobile-close-button" data-action="mobile-nav#close">
+        <span class="sr-only">メニューを閉じる</span>
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 6 12 12M18 6 6 18"/>
+        </svg>
+      </button>
+    </div>
+
+    <div class="mt-8 space-y-7">
+      <section class="space-y-2">
+        <p class="app-nav-label">Main</p>
+        <%= render "shared/app_nav_links", items: app_primary_navigation_items, compact: true %>
+      </section>
+
+      <% if app_admin_navigation_items.any? %>
+        <section class="space-y-2">
+          <p class="app-nav-label">Admin</p>
+          <%= render "shared/app_nav_links", items: app_admin_navigation_items, compact: true %>
+        </section>
+      <% end %>
+
+      <section>
+        <div class="app-account-card">
+          <span class="app-avatar"><%= user_avatar_initial(current_user) %></span>
+          <div class="min-w-0">
+            <p class="app-account-card__name"><%= current_user.nickname %></p>
+            <p class="app-account-card__meta"><%= current_user.username %></p>
+          </div>
+        </div>
+
+        <% if current_user.is_admin? %>
+          <div class="mt-4">
+            <%= render "shared/user_switcher_menu" %>
+          </div>
+        <% end %>
+
+        <div class="mt-4">
+          <%= render "shared/account_actions", compact: true %>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_app_nav_links.html.erb
+++ b/app/views/shared/_app_nav_links.html.erb
@@ -1,0 +1,10 @@
+<% compact = local_assigns.fetch(:compact, false) %>
+
+<div class="space-y-1.5">
+  <% items.each do |item| %>
+    <%= link_to item[:path], class: app_nav_link_classes(active: item[:active], compact: compact) do %>
+      <span><%= item[:label] %></span>
+      <span class="app-nav-link__dot" aria-hidden="true"></span>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/shared/_app_notice.html.erb
+++ b/app/views/shared/_app_notice.html.erb
@@ -1,0 +1,29 @@
+<% tone = local_assigns.fetch(:tone, :info).to_sym %>
+
+<div class="<%= app_notice_classes(tone) %>">
+  <div class="<%= app_notice_icon_classes(tone) %>">
+    <% case tone %>
+    <% when :success, :info %>
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+      </svg>
+    <% when :danger %>
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+      </svg>
+    <% else %>
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+      </svg>
+    <% end %>
+  </div>
+
+  <div class="min-w-0">
+    <% if local_assigns[:title].present? %>
+      <p class="app-notice__title"><%= title %></p>
+    <% end %>
+    <% if local_assigns[:message].present? %>
+      <p class="app-notice__message"><%= message %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_app_sidebar.html.erb
+++ b/app/views/shared/_app_sidebar.html.erb
@@ -1,0 +1,42 @@
+<aside class="app-sidebar hidden lg:block">
+  <div class="app-sidebar__panel">
+    <div class="app-sidebar__brand">
+      <%= render "shared/app_logo" %>
+    </div>
+
+    <div class="app-sidebar__scroll">
+      <section class="space-y-2">
+        <p class="app-nav-label">Main</p>
+        <%= render "shared/app_nav_links", items: app_primary_navigation_items %>
+      </section>
+
+      <% if app_admin_navigation_items.any? %>
+        <section class="mt-8 space-y-2">
+          <p class="app-nav-label">Admin</p>
+          <%= render "shared/app_nav_links", items: app_admin_navigation_items %>
+        </section>
+      <% end %>
+    </div>
+
+    <div class="app-sidebar__footer">
+      <div class="app-account-card">
+        <span class="app-avatar"><%= user_avatar_initial(current_user) %></span>
+        <div class="min-w-0">
+          <p class="app-account-card__name"><%= current_user.nickname %></p>
+          <p class="app-account-card__meta"><%= current_user.username %></p>
+        </div>
+      </div>
+
+      <% if viewing_as_someone_else? %>
+        <div class="status-pill status-pill--inverted mt-3">
+          <span class="status-pill__dot" aria-hidden="true"></span>
+          <span><%= viewing_as_user.nickname %>の視点で表示中</span>
+        </div>
+      <% end %>
+
+      <div class="mt-4">
+        <%= render "shared/account_actions", compact: true %>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/app/views/shared/_app_sidebar.html.erb
+++ b/app/views/shared/_app_sidebar.html.erb
@@ -1,7 +1,7 @@
 <aside class="app-sidebar hidden lg:block">
   <div class="app-sidebar__panel">
     <div class="app-sidebar__brand">
-      <%= render "shared/app_logo" %>
+      <%= render "shared/app_logo", image_only: true %>
     </div>
 
     <div class="app-sidebar__scroll">

--- a/app/views/shared/_app_topbar.html.erb
+++ b/app/views/shared/_app_topbar.html.erb
@@ -1,0 +1,52 @@
+<header class="app-topbar-wrap">
+  <div class="page-container">
+    <div class="app-topbar">
+      <div class="app-topbar__start">
+        <button type="button"
+                class="app-mobile-menu-button lg:hidden"
+                data-action="mobile-nav#toggle"
+                data-mobile-nav-target="toggleButton"
+                aria-controls="mobile-navigation-panel"
+                aria-expanded="false">
+          <span class="sr-only">メニューを開く</span>
+          <svg data-mobile-nav-target="openIcon" class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7h16M4 12h16M4 17h16"/>
+          </svg>
+          <svg data-mobile-nav-target="closeIcon" class="hidden h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 6 12 12M18 6 6 18"/>
+          </svg>
+        </button>
+
+        <div class="min-w-0">
+          <p class="app-topbar__eyebrow">VS.Mobile for KGY</p>
+          <p class="app-topbar__title">
+            <%= viewing_as_someone_else? ? "#{viewing_as_user.nickname}の視点で表示中" : "KGY 対戦ログ" %>
+          </p>
+        </div>
+      </div>
+
+      <div class="app-topbar__end">
+        <% if viewing_as_someone_else? %>
+          <span class="status-pill hidden sm:inline-flex">
+            <span class="status-pill__dot" aria-hidden="true"></span>
+            <span><%= viewing_as_user.nickname %>の視点</span>
+          </span>
+        <% end %>
+
+        <% if current_user.is_admin? %>
+          <div class="hidden lg:block">
+            <%= render "shared/user_switcher_menu" %>
+          </div>
+        <% end %>
+
+        <div class="app-inline-user">
+          <span class="app-inline-user__avatar"><%= user_avatar_initial(current_user) %></span>
+          <div class="hidden sm:block min-w-0">
+            <p class="app-inline-user__name"><%= current_user.nickname %></p>
+            <p class="app-inline-user__meta"><%= current_user.username %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,43 +1,25 @@
-<%
-  alert_class = case type.to_s
-  when 'notice'
-    'bg-blue-50 border-blue-400 text-blue-800'
-  when 'success'
-    'bg-green-50 border-green-400 text-green-800'
-  when 'alert', 'error'
-    'bg-red-50 border-red-400 text-red-800'
-  when 'warning'
-    'bg-yellow-50 border-yellow-400 text-yellow-800'
-  else
-    'bg-gray-50 border-gray-400 text-gray-800'
-  end
+<% tone = flash_banner_tone(type) %>
 
-  icon_color = case type.to_s
-  when 'notice' then 'text-blue-400'
-  when 'success' then 'text-green-400'
-  when 'alert', 'error' then 'text-red-400'
-  else 'text-yellow-400'
-  end
-%>
-<div class="border-l-4 p-4 mb-4 <%= alert_class %> rounded shadow-sm mt-4" data-controller="auto-dismiss">
-  <div class="flex items-center">
-    <div class="flex-shrink-0">
-      <% if type.to_s == 'notice' || type.to_s == 'success' %>
-        <svg class="h-5 w-5 <%= icon_color %>" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
-        </svg>
-      <% elsif type.to_s == 'alert' || type.to_s == 'error' %>
-        <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-        </svg>
-      <% else %>
-        <svg class="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
-        </svg>
-      <% end %>
-    </div>
-    <div class="ml-3">
-      <p class="text-sm font-medium"><%= message %></p>
-    </div>
+<div class="<%= flash_banner_classes(type) %>" data-controller="auto-dismiss">
+  <div class="<%= flash_banner_icon_classes(type) %>">
+    <% case tone %>
+    <% when :success, :info %>
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+      </svg>
+    <% when :danger %>
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+      </svg>
+    <% else %>
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" />
+      </svg>
+    <% end %>
+  </div>
+
+  <div class="min-w-0">
+    <p class="flash-banner__title"><%= flash_banner_title(type) %></p>
+    <p class="flash-banner__message"><%= message %></p>
   </div>
 </div>

--- a/app/views/shared/_per_page_selector.html.erb
+++ b/app/views/shared/_per_page_selector.html.erb
@@ -3,9 +3,9 @@
   <span>表示件数:</span>
   <% [10, 20, 50].each do |n| %>
     <% if n == per_page %>
-      <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= n %></span>
+      <span class="ui-chip ui-chip--accent min-h-0 px-3 py-1 text-sm"><%= n %></span>
     <% else %>
-      <%= link_to n, url_builder.call(n), class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition duration-150 ease-in-out" %>
+      <%= link_to n, url_builder.call(n), class: "ui-chip ui-chip--muted min-h-0 px-3 py-1 text-sm font-medium" %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_user_switcher_menu.html.erb
+++ b/app/views/shared/_user_switcher_menu.html.erb
@@ -1,0 +1,35 @@
+<div class="app-switcher" data-controller="user-switcher">
+  <button type="button" data-action="click->user-switcher#toggle" class="app-switcher__button">
+    <span class="app-switcher__meta">表示視点</span>
+    <span class="app-switcher__value">
+      <%= viewing_as_someone_else? ? "#{viewing_as_user.nickname}の視点" : "管理者" %>
+    </span>
+    <svg class="h-4 w-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 9 6 6 6-6"/>
+    </svg>
+  </button>
+
+  <div data-user-switcher-target="dropdown" class="hidden app-switcher__menu">
+    <% if viewing_as_someone_else? %>
+      <button type="button" data-action="click->user-switcher#clearView" class="app-switcher__menu-item app-switcher__menu-item--accent border-b border-slate-200/70">
+        <span class="app-switcher__avatar app-switcher__avatar--accent">
+          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 0 1 8 8v2M3 10l6 6m-6-6 6-6"/>
+          </svg>
+        </span>
+        <span>管理者視点に戻す</span>
+      </button>
+    <% end %>
+
+    <div class="max-h-60 overflow-y-auto py-1">
+      <% User.where(is_admin: false).order(:nickname).each do |user| %>
+        <% next if viewing_as_someone_else? && user.id == viewing_as_user.id %>
+
+        <button type="button" data-action="click->user-switcher#switchView" data-user-id="<%= user.id %>" class="app-switcher__menu-item">
+          <span class="app-switcher__avatar"><%= user_avatar_initial(user) %></span>
+          <span class="truncate"><%= user.nickname %></span>
+        </button>
+      <% end %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- `application.html.erb` を shared partial / helper / Stimulus controller ベースの app shell に整理
- `app/assets/tailwind/application.css` に design token と共通 UI primitive を追加し、色・余白・カード・導線の基準を整備
- sidebar / topbar / mobile menu / flash を刷新し、モバイル用ナビゲーションを inline JS から切り離し

## Test plan
- [x] `bin/rails tailwindcss:build`
- [x] `bundle exec rails zeitwerk:check`
- [x] `bundle exec rubocop --cache false app/helpers/application_helper.rb`
- [x] `bundle exec brakeman --no-pager -i .brakeman.ignore`

Closes #290