### PR TITLE
feat: ダッシュボード・イベント・ローテーション画面をモバイル前提で刷新する

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -60,15 +60,9 @@ a {
 }
 
 @media (min-width: 1024px) {
-  .app-shell {
-    display: grid;
-    grid-template-columns: var(--sidebar-shell-width) minmax(0, 1fr);
-    align-items: start;
-  }
-
   .app-with-sidebar {
-    width: 100%;
-    margin-left: 0;
+    width: calc(100% - var(--sidebar-shell-width));
+    margin-left: var(--sidebar-shell-width);
   }
 }
 
@@ -261,12 +255,11 @@ a {
 
 @media (min-width: 1024px) {
   .app-sidebar {
-    position: sticky;
-    top: 0;
-    inset: auto;
-    width: auto;
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: var(--sidebar-shell-width);
     height: 100vh;
-    padding: 1rem 0 1rem 1rem;
+    padding: 1rem;
   }
 }
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -779,6 +779,9 @@ a {
 
 .ui-button-primary,
 .ui-button-secondary,
+.ui-button-neutral,
+.ui-button-success,
+.ui-button-danger,
 .ui-chip {
   display: inline-flex;
   align-items: center;
@@ -810,6 +813,7 @@ a {
 }
 
 .ui-button-secondary,
+.ui-button-neutral,
 .ui-chip {
   border: 1px solid var(--border-soft);
   background: rgba(255, 255, 255, 0.88);
@@ -817,9 +821,46 @@ a {
 }
 
 .ui-button-secondary:hover,
+.ui-button-neutral:hover,
 .ui-chip:hover {
   transform: translateY(-1px);
   border-color: var(--border-strong);
+}
+
+.ui-button-neutral {
+  border: 1px solid transparent;
+  background: rgba(15, 23, 42, 0.86);
+  color: #fff;
+  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.18);
+}
+
+.ui-button-neutral:hover {
+  transform: translateY(-1px);
+  background: rgba(15, 23, 42, 0.96);
+}
+
+.ui-button-success {
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, #0f766e, #0b8a77);
+  color: #fff;
+  box-shadow: 0 14px 26px rgba(15, 118, 110, 0.2);
+}
+
+.ui-button-success:hover {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, #0d5f59, #0f766e);
+}
+
+.ui-button-danger {
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, #c2410c, #dc2626);
+  color: #fff;
+  box-shadow: 0 14px 26px rgba(220, 38, 38, 0.18);
+}
+
+.ui-button-danger:hover {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, #9a3412, #b91c1c);
 }
 
 .ui-chip--accent {
@@ -990,6 +1031,358 @@ a {
   padding-left: 1rem;
   color: var(--text-primary);
   font-size: 0.9rem;
+}
+
+/* ============================================================
+   Feature page primitives
+   ============================================================ */
+
+.feature-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  .feature-grid {
+    grid-template-columns: minmax(0, 1.55fr) minmax(19rem, 1fr);
+    align-items: start;
+  }
+}
+
+.feature-stack {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.feature-surface {
+  border: 1px solid var(--border-soft);
+  border-radius: calc(var(--radius-lg) - 0.1rem);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.feature-surface--muted {
+  background: rgba(246, 247, 255, 0.92);
+}
+
+.feature-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: calc(var(--radius-lg) + 0.15rem);
+  box-shadow: var(--shadow-panel);
+}
+
+.feature-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.16), transparent 30%);
+}
+
+.feature-hero--accent {
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    radial-gradient(circle at top left, rgba(129, 140, 248, 0.3), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(255, 255, 255, 0.08), transparent 26%),
+    linear-gradient(180deg, #1a1d35 0%, #232751 44%, #2a2f66 100%);
+}
+
+.feature-hero--slate {
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    radial-gradient(circle at top left, rgba(96, 165, 250, 0.24), transparent 24%),
+    radial-gradient(circle at bottom right, rgba(255, 255, 255, 0.08), transparent 20%),
+    linear-gradient(180deg, #162034 0%, #1f2b47 46%, #263654 100%);
+}
+
+.feature-hero__top {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 640px) {
+  .feature-hero__top {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+.feature-hero__eyebrow {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.64);
+}
+
+.feature-hero__title {
+  margin-top: 0.7rem;
+  font-size: clamp(1.55rem, 3vw, 2.5rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+}
+
+.feature-hero__description {
+  margin-top: 0.7rem;
+  max-width: 42rem;
+  color: rgba(255, 255, 255, 0.76);
+  line-height: 1.7;
+}
+
+.feature-hero__meta,
+.feature-hero__actions,
+.feature-toolbar__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.feature-hero__meta,
+.feature-hero__actions {
+  margin-top: 1rem;
+}
+
+.feature-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.05rem;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.feature-pill--contrast {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.94);
+}
+
+.feature-pill--surface {
+  border: 1px solid var(--border-soft);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-primary);
+}
+
+.feature-pill--accent {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+}
+
+.feature-pill--warning {
+  background: var(--warning-soft);
+  color: #b45309;
+}
+
+.feature-pill--success {
+  background: var(--success-soft);
+  color: #0f766e;
+}
+
+.feature-pill--danger {
+  background: var(--danger-soft);
+  color: #b91c1c;
+}
+
+.feature-metric-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+}
+
+.feature-metric {
+  padding: 1rem;
+  border-radius: 1.05rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(248, 250, 255, 0.86);
+}
+
+.feature-hero .feature-metric {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.feature-metric__label {
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.feature-hero .feature-metric__label {
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.feature-metric__value {
+  margin-top: 0.45rem;
+  font-size: 1.5rem;
+  font-weight: 800;
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+
+.feature-hero .feature-metric__value {
+  color: #fff;
+}
+
+.feature-metric__meta {
+  margin-top: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.feature-hero .feature-metric__meta {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.feature-section-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+@media (min-width: 640px) {
+  .feature-section-head--row {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+}
+
+.feature-section-head__title {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--text-primary);
+}
+
+.feature-section-head__meta {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.feature-action-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(8.75rem, 1fr));
+}
+
+.feature-action-link {
+  display: grid;
+  gap: 0.45rem;
+  min-height: 6.5rem;
+  padding: 1rem;
+  border-radius: 1.1rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(248, 250, 255, 0.88);
+  transition: transform 0.16s ease, border-color 0.16s ease, background-color 0.16s ease;
+}
+
+.feature-action-link:hover {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  background: #fff;
+}
+
+.feature-action-link__icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.feature-action-link__title {
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: var(--text-primary);
+}
+
+.feature-action-link__meta {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.feature-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.feature-list-item {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1rem;
+  border: 1px solid var(--border-soft);
+  border-radius: 1.05rem;
+  background: rgba(248, 250, 255, 0.88);
+  transition: transform 0.16s ease, border-color 0.16s ease, background-color 0.16s ease;
+}
+
+.feature-list-item--clickable:hover {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  background: #fff;
+}
+
+.feature-progress {
+  width: 100%;
+  height: 0.7rem;
+  border-radius: 999px;
+  background: rgba(94, 108, 153, 0.14);
+  overflow: hidden;
+}
+
+.feature-progress__bar {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+}
+
+.feature-match-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .feature-match-grid {
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: stretch;
+  }
+}
+
+.feature-match-team {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(248, 250, 255, 0.88);
+}
+
+.feature-match-vs {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: var(--text-muted);
+}
+
+.feature-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+}
+
+.feature-inline-note {
+  font-size: 0.84rem;
+  color: var(--text-secondary);
 }
 
 /* ============================================================

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -168,9 +168,35 @@ module ApplicationHelper
     class_names("app-notice__icon", "app-notice__icon--#{tone.to_sym}")
   end
 
+  def safe_external_url(url)
+    return nil if url.blank?
+
+    parsed = URI.parse(url)
+    return nil unless parsed.is_a?(URI::HTTP) && parsed.host.present?
+
+    parsed.to_s
+  rescue URI::InvalidURIError
+    nil
+  end
+
   def app_button_classes(variant: :primary, size: :md, full_width: false)
+    variant_class = case variant.to_sym
+    when :primary
+      "ui-button-primary"
+    when :secondary
+      "ui-button-secondary"
+    when :neutral
+      "ui-button-neutral"
+    when :success
+      "ui-button-success"
+    when :danger
+      "ui-button-danger"
+    else
+      "ui-button-primary"
+    end
+
     class_names(
-      (variant.to_sym == :primary ? "ui-button-primary" : "ui-button-secondary"),
+      variant_class,
       ("ui-button--sm" if size.to_sym == :sm),
       ("w-full" if full_width)
     )

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu"]
+
+  connect() {
+    this.open = false
+  }
+
+  toggle(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    this.open = !this.open
+    this.render()
+  }
+
+  hide(event) {
+    if (this.element.contains(event.target)) return
+    this.open = false
+    this.render()
+  }
+
+  close() {
+    this.open = false
+    this.render()
+  }
+
+  render() {
+    if (!this.hasMenuTarget) return
+    this.menuTarget.classList.toggle("hidden", !this.open)
+  }
+}

--- a/app/views/dashboard/admin_dashboard.html.erb
+++ b/app/views/dashboard/admin_dashboard.html.erb
@@ -1,296 +1,325 @@
-<div class="py-8">
-  <!-- Header -->
-  <div class="mb-8">
-    <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">管理ダッシュボード</h1>
-    <p class="mt-2 text-sm text-gray-600">システム全体の管理と運営</p>
-  </div>
+<div class="py-6 sm:py-8">
+  <div class="feature-stack">
+    <% if @today_event %>
+      <% active_progress = @active_rotation && @rotation_matches.present? ? ((@active_rotation.current_match_index + 1).to_f / @rotation_matches.count * 100) : 0 %>
+      <section class="feature-hero feature-hero--slate px-5 py-6 sm:px-8 sm:py-8" <%= @active_rotation ? "data-controller=\"rotation-subscriber\" data-rotation-subscriber-rotation-id-value=\"#{@active_rotation.id}\"" : "" %>>
+        <div class="feature-hero__top">
+          <div>
+            <p class="feature-hero__eyebrow">Admin Dashboard</p>
+            <h1 class="feature-hero__title">本日の運営状況</h1>
+            <p class="feature-hero__description">
+              <%= @today_event.name %> の進行状況、直近の試合、次の導線をここでまとめて確認できます。
+            </p>
 
-  <!-- 2カラムレイアウト -->
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-    <!-- 左カラム（メインコンテンツ） -->
-    <div class="lg:col-span-2 space-y-6">
-
-      <!-- 今日のイベント管理 -->
-      <% if @today_event %>
-        <div class="bg-gradient-to-r from-purple-500 to-purple-600 text-white shadow-lg rounded-lg p-6" <%= @active_rotation ? "data-controller=\"rotation-subscriber\" data-rotation-subscriber-rotation-id-value=\"#{@active_rotation.id}\"" : "" %>>
-          <div class="flex items-center justify-between mb-4">
-            <div>
-              <h2 class="text-xl font-bold">🎮 本日のイベント</h2>
-              <p class="text-sm text-white text-opacity-90 mt-1"><%= @today_event.name %></p>
-            </div>
-            <div class="flex items-center space-x-2">
+            <div class="feature-hero__meta">
+              <span class="feature-pill feature-pill--contrast"><%= @today_event.held_on.strftime("%Y/%m/%d") %></span>
               <% if @active_rotation %>
-                <div class="inline-flex items-center px-2 py-1 bg-red-100 border border-red-300 rounded-full">
-                  <span class="w-2 h-2 bg-red-500 rounded-full mr-1 animate-pulse"></span>
-                  <span class="text-xs font-medium text-red-800">リアルタイム更新中</span>
-                </div>
+                <span class="feature-pill feature-pill--contrast">リアルタイム更新中</span>
+                <span class="feature-pill feature-pill--contrast"><%= @rotation_matches.count %> 試合構成</span>
+              <% else %>
+                <span class="feature-pill feature-pill--contrast">アクティブなローテーションなし</span>
               <% end %>
-              <span class="bg-white text-purple-600 px-3 py-1 rounded-full text-sm font-semibold">
-                <%= @today_event.held_on.strftime('%Y/%m/%d') %>
-              </span>
             </div>
           </div>
 
-          <% if @active_rotation %>
-            <!-- アクティブなローテーション -->
-            <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm">
-              <div class="text-sm font-semibold mb-2 text-purple-700">🔴 アクティブなローテーション</div>
-              <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.display_name %></div>
-              <div class="text-sm mt-1 text-gray-600">
+          <div class="feature-hero__actions">
+            <% if @active_rotation %>
+              <%= link_to "ローテーション管理", rotation_path(@active_rotation), class: app_button_classes(variant: :primary) %>
+            <% else %>
+              <%= link_to "ローテーション作成", new_event_rotation_path(@today_event), class: app_button_classes(variant: :primary) %>
+            <% end %>
+            <%= link_to "イベントを開く", event_path(@today_event), class: app_button_classes(variant: :secondary) %>
+          </div>
+        </div>
+
+        <div class="mt-6 feature-metric-grid">
+          <div class="feature-metric">
+            <div class="feature-metric__label">総イベント数</div>
+            <div class="feature-metric__value"><%= @total_events %></div>
+            <div class="feature-metric__meta">登録済みイベント</div>
+          </div>
+          <div class="feature-metric">
+            <div class="feature-metric__label">総試合数</div>
+            <div class="feature-metric__value"><%= @total_matches %></div>
+            <div class="feature-metric__meta">記録済み試合</div>
+          </div>
+          <div class="feature-metric">
+            <div class="feature-metric__label">登録ユーザー数</div>
+            <div class="feature-metric__value"><%= @total_users %></div>
+            <div class="feature-metric__meta">regular user</div>
+          </div>
+        </div>
+
+        <% if @active_rotation %>
+          <div class="mt-5 feature-progress">
+            <div class="feature-progress__bar" style="width: <%= active_progress %>%"></div>
+          </div>
+
+          <div class="mt-6 feature-grid lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)]">
+            <div class="feature-surface p-4 sm:p-5">
+              <div class="text-sm font-semibold text-indigo-700">アクティブなローテーション</div>
+              <div class="mt-2 text-2xl font-bold text-slate-950"><%= @active_rotation.display_name %></div>
+              <div class="mt-2 text-sm text-slate-600">
                 進捗: <%= @active_rotation.current_match_index + 1 %> / <%= @rotation_matches.count %> 試合
               </div>
             </div>
 
-            <!-- 現在の試合 -->
             <% if @current_rotation_match %>
-              <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm">
-                <div class="text-sm font-semibold mb-3 text-gray-700">📍 現在の試合</div>
-                <div class="text-3xl font-bold text-gray-900 mb-3 text-center">第<%= @active_rotation.current_match_index + 1 %>試合</div>
-                <div class="grid grid-cols-3 gap-3 text-sm">
-                  <div class="bg-gray-50 rounded p-2">
-                    <div class="text-xs text-gray-500 mb-1">チーム1</div>
-                    <div class="flex items-center">
-                      <span class="font-bold text-red-600"><%= @current_rotation_match.team1_player1.nickname %></span>
-                      <span class="ml-2 px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                    </div>
-                    <div class="text-gray-700 mt-1"><%= @current_rotation_match.team1_player2.nickname %></div>
-                  </div>
-                  <div class="flex items-center justify-center">
-                    <span class="text-xl font-bold text-gray-400">VS</span>
-                  </div>
-                  <div class="bg-gray-50 rounded p-2">
-                    <div class="text-xs text-gray-500 mb-1">チーム2</div>
-                    <div class="font-medium text-gray-900"><%= @current_rotation_match.team2_player1.nickname %></div>
-                    <div class="text-gray-700 mt-1"><%= @current_rotation_match.team2_player2.nickname %></div>
-                  </div>
-                </div>
-              </div>
-            <% end %>
-
-            <!-- 次の試合 -->
-            <% if @upcoming_rotation_matches.any? %>
-              <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm">
-                <div class="text-sm font-semibold mb-3 text-gray-700">📋 次の試合</div>
-                <div class="space-y-2">
-                  <% @upcoming_rotation_matches.each do |rm| %>
-                    <div class="flex items-center justify-between text-xs border-b border-gray-200 pb-2 last:border-b-0">
-                      <div class="text-gray-500">第<%= rm.match_index + 1 %>試合</div>
-                      <div class="flex-1 mx-2 text-gray-700">
-                        <span class="text-red-600 font-bold"><%= rm.team1_player1.nickname %></span> & <%= rm.team1_player2.nickname %>
-                        <span class="text-gray-400 mx-1">vs</span>
-                        <%= rm.team2_player1.nickname %> & <%= rm.team2_player2.nickname %>
+              <div class="feature-surface p-4 sm:p-5">
+                <div class="text-sm font-semibold text-slate-700">現在の試合</div>
+                <div class="mt-2 text-xl font-bold text-slate-950">第<%= @active_rotation.current_match_index + 1 %>試合</div>
+                <div class="mt-4 feature-match-grid">
+                  <div class="feature-match-team">
+                    <div class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">チーム1</div>
+                    <div class="mt-3 space-y-2 text-sm">
+                      <div class="font-semibold text-red-600">
+                        <%= @current_rotation_match.team1_player1.nickname %>
+                        <span class="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">配信台</span>
                       </div>
+                      <div class="font-medium text-slate-900"><%= @current_rotation_match.team1_player2.nickname %></div>
                     </div>
-                  <% end %>
+                  </div>
+                  <div class="feature-match-vs">VS</div>
+                  <div class="feature-match-team">
+                    <div class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">チーム2</div>
+                    <div class="mt-3 space-y-2 text-sm">
+                      <div class="font-medium text-slate-900"><%= @current_rotation_match.team2_player1.nickname %></div>
+                      <div class="font-medium text-slate-900"><%= @current_rotation_match.team2_player2.nickname %></div>
+                    </div>
+                  </div>
                 </div>
               </div>
             <% end %>
-
-            <!-- アクションボタン -->
-            <%= link_to "ローテーション管理", rotation_path(@active_rotation), class: "block w-full bg-gray-600 text-white text-center font-semibold py-3 px-4 rounded hover:bg-gray-700 transition" %>
-          <% else %>
-            <div class="bg-white text-gray-900 rounded-lg p-4 text-center shadow-sm">
-              <p class="text-purple-700 mb-3">アクティブなローテーションがありません</p>
-              <%= link_to "ローテーション作成", new_event_rotation_path(@today_event), class: "inline-block bg-indigo-600 text-white font-semibold py-2 px-4 rounded hover:bg-indigo-700 transition shadow-sm" %>
-            </div>
-          <% end %>
-        </div>
-      <% else %>
-        <!-- 今日のイベントがない場合 -->
-        <div class="bg-white shadow rounded-lg p-6">
-          <h2 class="text-xl font-bold text-purple-900 mb-2">📅 本日のイベント</h2>
-          <p class="text-sm text-purple-700 mb-4">本日はイベントが設定されていません</p>
-          <%= link_to "新しいイベントを作成", new_event_path, class: "inline-block bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded transition" %>
-        </div>
-      <% end %>
-
-      <!-- クイックアクション -->
-      <div class="bg-white shadow rounded-lg p-6">
-        <h2 class="text-lg font-bold text-gray-900 mb-4">⚡ クイックアクション</h2>
-        <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
-          <%= link_to new_event_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
-            <svg class="h-8 w-8 text-indigo-600 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-            </svg>
-            <span class="text-sm font-medium text-gray-900">新規イベント</span>
-          <% end %>
-
-          <%= link_to events_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
-            <svg class="h-8 w-8 text-indigo-600 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
-            <span class="text-sm font-medium text-gray-900">イベント一覧</span>
-          <% end %>
-
-          <%= link_to rotations_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
-            <svg class="h-8 w-8 text-indigo-600 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
-            </svg>
-            <span class="text-sm font-medium text-gray-900">ローテーション</span>
-          <% end %>
-
-          <%= link_to matches_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
-            <svg class="h-8 w-8 text-indigo-600 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-            <span class="text-sm font-medium text-gray-900">試合一覧</span>
-          <% end %>
-
-          <%= link_to admin_mobile_suits_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
-            <svg class="h-8 w-8 text-indigo-600 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
-            </svg>
-            <span class="text-sm font-medium text-gray-900">機体マスタ</span>
-          <% end %>
-
-          <%= link_to admin_users_path, class: "flex flex-col items-center p-4 border-2 border-gray-200 rounded-lg hover:border-indigo-500 hover:bg-indigo-50 transition" do %>
-            <svg class="h-8 w-8 text-indigo-600 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
-            </svg>
-            <span class="text-sm font-medium text-gray-900">ユーザー管理</span>
-          <% end %>
-        </div>
-      </div>
-
-      <!-- 最近の試合 -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <h2 class="text-lg font-bold text-gray-900">🕐 最近の試合</h2>
-        </div>
-        <div class="divide-y divide-gray-200">
-          <% if @recent_matches.any? %>
-            <% @recent_matches.each do |match| %>
-              <%
-                _all_mp = match.match_players.sort_by { |mp| [mp.team_number, mp.position] }
-                _team1  = _all_mp.select { |mp| mp.team_number == 1 }
-                _team2  = _all_mp.select { |mp| mp.team_number == 2 }
-              %>
-              <div class="px-5 py-4">
-                <%# メタ行 %>
-                <div class="flex items-center flex-wrap gap-2 mb-3">
-                  <%= link_to match_path(match), class: "text-sm text-gray-400 hover:text-blue-600 transition-colors", data: { turbo_frame: "_top" } do %>
-                    <%= match.played_at.strftime('%Y年%m月%d日') %>
-                  <% end %>
-                  <span class="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-indigo-50 text-indigo-600">
-                    <%= match.event.name %>
-                  </span>
-                </div>
-                <%# 対戦カード %>
-                <div class="block cursor-pointer"
-                     data-controller="card-link"
-                     data-card-link-url-value="<%= match_path(match) %>"
-                     data-action="click->card-link#navigate">
-                  <%= render "matches/match_teams",
-                        left_players:  _team1,
-                        right_players: _team2,
-                        left_wins:     match.winning_team == 1,
-                        left_label:    "チーム1",
-                        right_label:   "チーム2" %>
-                </div>
-              </div>
-            <% end %>
-          <% else %>
-            <div class="px-6 py-8 text-center">
-              <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              <p class="mt-2 text-sm text-gray-500">まだ試合記録がありません</p>
-            </div>
-          <% end %>
-        </div>
-        <% if @recent_matches.any? %>
-          <div class="px-6 py-4 bg-gray-50 text-center">
-            <%= link_to "すべて見る →", matches_path, class: "text-sm text-blue-600 hover:text-blue-500" %>
           </div>
         <% end %>
-      </div>
-
-    </div>
-
-    <!-- 右カラム（統計・情報） -->
-    <div class="lg:col-span-1 space-y-6">
-
-      <!-- システム統計 -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <h2 class="text-lg font-bold text-gray-900">📊 システム統計</h2>
-        </div>
-        <div class="px-6 py-5">
-          <div class="space-y-4">
-            <div class="flex items-center justify-between">
-              <div class="text-sm text-gray-600">総イベント数</div>
-              <div class="text-2xl font-bold text-blue-600"><%= @total_events %></div>
-            </div>
-            <div class="flex items-center justify-between">
-              <div class="text-sm text-gray-600">総試合数</div>
-              <div class="text-2xl font-bold text-green-600"><%= @total_matches %></div>
-            </div>
-            <div class="flex items-center justify-between">
-              <div class="text-sm text-gray-600">登録ユーザー数</div>
-              <div class="text-2xl font-bold text-purple-600"><%= @total_users %></div>
-            </div>
+      </section>
+    <% else %>
+      <section class="feature-hero feature-hero--slate px-5 py-6 sm:px-8 sm:py-8">
+        <div class="feature-hero__top">
+          <div>
+            <p class="feature-hero__eyebrow">Admin Dashboard</p>
+            <h1 class="feature-hero__title">本日のイベントは未設定です</h1>
+            <p class="feature-hero__description">
+              イベントを作成すると、ここに進行状況と導線がまとまって表示されます。
+            </p>
+          </div>
+          <div class="feature-hero__actions">
+            <%= link_to "新しいイベントを作成", new_event_path, class: app_button_classes(variant: :primary) %>
           </div>
         </div>
-      </div>
+      </section>
+    <% end %>
 
-      <!-- 今後のイベント -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <h2 class="text-lg font-bold text-gray-900">📅 今後のイベント</h2>
-        </div>
-        <div class="divide-y divide-gray-200">
-          <% if @upcoming_events.any? %>
-            <% @upcoming_events.each do |event| %>
-              <%= link_to event_path(event), class: "block hover:bg-gray-50 px-6 py-4" do %>
-                <div class="flex items-center justify-between">
-                  <div class="flex-1">
-                    <div class="text-sm font-medium text-gray-900"><%= event.name %></div>
-                    <div class="text-xs text-gray-500 mt-1"><%= event.held_on.strftime('%Y年%m月%d日') %></div>
+    <div class="feature-grid xl:grid-cols-[minmax(0,1.1fr)_minmax(20rem,0.9fr)]">
+      <div class="feature-stack">
+        <section class="feature-surface p-5 sm:p-6">
+          <div class="feature-section-head">
+            <h2 class="feature-section-head__title">クイックアクション</h2>
+            <p class="feature-section-head__meta">日々の運営フローに必要な導線をまとめています</p>
+          </div>
+
+          <div class="feature-action-grid">
+            <%= link_to new_event_path, class: "feature-action-link" do %>
+              <div class="feature-action-link__icon">+</div>
+              <div class="feature-action-link__title">新規イベント</div>
+              <div class="feature-action-link__meta">イベントを追加</div>
+            <% end %>
+
+            <%= link_to events_path, class: "feature-action-link" do %>
+              <div class="feature-action-link__icon">日</div>
+              <div class="feature-action-link__title">イベント一覧</div>
+              <div class="feature-action-link__meta">開催履歴を確認</div>
+            <% end %>
+
+            <%= link_to rotations_path, class: "feature-action-link" do %>
+              <div class="feature-action-link__icon">回</div>
+              <div class="feature-action-link__title">ローテーション</div>
+              <div class="feature-action-link__meta">進行を管理</div>
+            <% end %>
+
+            <%= link_to matches_path, class: "feature-action-link" do %>
+              <div class="feature-action-link__icon">試</div>
+              <div class="feature-action-link__title">試合一覧</div>
+              <div class="feature-action-link__meta">対戦記録へ移動</div>
+            <% end %>
+
+            <%= link_to admin_mobile_suits_path, class: "feature-action-link" do %>
+              <div class="feature-action-link__icon">機</div>
+              <div class="feature-action-link__title">機体マスタ</div>
+              <div class="feature-action-link__meta">機体データ更新</div>
+            <% end %>
+
+            <%= link_to admin_users_path, class: "feature-action-link" do %>
+              <div class="feature-action-link__icon">人</div>
+              <div class="feature-action-link__title">ユーザー管理</div>
+              <div class="feature-action-link__meta">利用者設定</div>
+            <% end %>
+          </div>
+        </section>
+
+        <% if @upcoming_rotation_matches&.any? %>
+          <section class="feature-surface p-5 sm:p-6">
+            <div class="feature-section-head">
+              <h2 class="feature-section-head__title">次の試合</h2>
+              <p class="feature-section-head__meta">直近 3 試合の並び</p>
+            </div>
+
+            <div class="feature-list">
+              <% @upcoming_rotation_matches.each do |rm| %>
+                <div class="feature-list-item">
+                  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div class="text-sm font-semibold text-slate-900">第<%= rm.match_index + 1 %>試合</div>
+                    <div class="text-sm text-slate-600">
+                      <span class="font-semibold text-red-600"><%= rm.team1_player1.nickname %></span> & <%= rm.team1_player2.nickname %>
+                      <span class="mx-2 text-slate-300">vs</span>
+                      <%= rm.team2_player1.nickname %> & <%= rm.team2_player2.nickname %>
+                    </div>
                   </div>
-                  <% if event.held_on == Time.zone.today %>
-                    <span class="ml-2 px-2 py-1 bg-green-100 text-green-800 text-xs font-semibold rounded">本日</span>
-                  <% end %>
                 </div>
               <% end %>
-            <% end %>
+            </div>
+          </section>
+        <% end %>
+
+        <section class="feature-surface">
+          <div class="p-5 sm:p-6">
+            <div class="feature-section-head feature-section-head--row">
+              <div>
+                <h2 class="feature-section-head__title">最近の試合</h2>
+                <p class="feature-section-head__meta">直近の試合記録を確認</p>
+              </div>
+              <%= link_to "すべて見る", matches_path, class: "text-sm font-semibold text-indigo-600 transition hover:text-indigo-500" %>
+            </div>
+          </div>
+
+          <% if @recent_matches.any? %>
+            <ul class="divide-y divide-slate-100">
+              <% @recent_matches.each do |match| %>
+                <%
+                  _all_mp = match.match_players.sort_by { |mp| [mp.team_number, mp.position] }
+                  _team1 = _all_mp.select { |mp| mp.team_number == 1 }
+                  _team2 = _all_mp.select { |mp| mp.team_number == 2 }
+                %>
+                <li class="px-5 py-5 transition hover:bg-slate-50/80">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <%= link_to match.played_at.strftime("%Y年%m月%d日"), match_path(match), class: "text-sm font-semibold text-slate-400 transition hover:text-indigo-600", data: { turbo_frame: "_top" } %>
+                    <span class="feature-pill feature-pill--surface"><%= match.event.name %></span>
+                  </div>
+                  <div class="mt-4 cursor-pointer"
+                       data-controller="card-link"
+                       data-card-link-url-value="<%= match_path(match) %>"
+                       data-action="click->card-link#navigate">
+                    <%= render "matches/match_teams",
+                          left_players: _team1,
+                          right_players: _team2,
+                          left_wins: match.winning_team == 1,
+                          left_label: "チーム1",
+                          right_label: "チーム2" %>
+                  </div>
+                </li>
+              <% end %>
+            </ul>
           <% else %>
-            <div class="px-6 py-8 text-center">
-              <p class="text-sm text-gray-500">予定されているイベントはありません</p>
+            <div class="px-5 pb-5 sm:px-6 sm:pb-6">
+              <div class="empty-state">
+                <p class="empty-state__title">まだ試合記録がありません</p>
+                <p class="empty-state__description mt-2">イベントのローテーションが始まると、ここに対戦が並びます。</p>
+              </div>
             </div>
           <% end %>
-        </div>
-        <div class="px-6 py-4 bg-gray-50 text-center">
-          <%= link_to "すべて見る →", events_path, class: "text-sm text-blue-600 hover:text-blue-500" %>
-        </div>
+        </section>
       </div>
 
-      <!-- 人気の機体 -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
-          <h2 class="text-lg font-bold text-gray-900">🔥 人気の機体 TOP5</h2>
-        </div>
-        <div class="divide-y divide-gray-200">
+      <div class="feature-stack">
+        <section class="feature-surface p-5 sm:p-6">
+          <div class="feature-section-head">
+            <h2 class="feature-section-head__title">システム統計</h2>
+            <p class="feature-section-head__meta">全体のボリューム感をざっと確認</p>
+          </div>
+
+          <div class="feature-metric-grid">
+            <div class="feature-metric">
+              <div class="feature-metric__label">イベント</div>
+              <div class="feature-metric__value"><%= @total_events %></div>
+              <div class="feature-metric__meta">累計開催数</div>
+            </div>
+            <div class="feature-metric">
+              <div class="feature-metric__label">試合</div>
+              <div class="feature-metric__value"><%= @total_matches %></div>
+              <div class="feature-metric__meta">記録済み試合</div>
+            </div>
+            <div class="feature-metric">
+              <div class="feature-metric__label">ユーザー</div>
+              <div class="feature-metric__value"><%= @total_users %></div>
+              <div class="feature-metric__meta">登録プレイヤー</div>
+            </div>
+          </div>
+        </section>
+
+        <section class="feature-surface p-5 sm:p-6">
+          <div class="feature-section-head feature-section-head--row">
+            <div>
+              <h2 class="feature-section-head__title">今後のイベント</h2>
+              <p class="feature-section-head__meta">次に控えている開催予定</p>
+            </div>
+            <%= link_to "一覧へ", events_path, class: "text-sm font-semibold text-indigo-600 transition hover:text-indigo-500" %>
+          </div>
+
+          <% if @upcoming_events.any? %>
+            <div class="feature-list">
+              <% @upcoming_events.each do |event| %>
+                <%= link_to event_path(event), class: "feature-list-item feature-list-item--clickable" do %>
+                  <div class="flex items-center justify-between gap-3">
+                    <div>
+                      <div class="text-sm font-semibold text-slate-900"><%= event.name %></div>
+                      <div class="mt-1 text-xs text-slate-500"><%= event.held_on.strftime("%Y年%m月%d日") %></div>
+                    </div>
+                    <% if event.held_on == Time.zone.today %>
+                      <span class="feature-pill feature-pill--success">本日</span>
+                    <% end %>
+                  </div>
+                <% end %>
+              <% end %>
+            </div>
+          <% else %>
+            <div class="empty-state">
+              <p class="empty-state__title">予定されているイベントはありません</p>
+              <p class="empty-state__description mt-2">新しいイベントを作成するとここに表示されます。</p>
+            </div>
+          <% end %>
+        </section>
+
+        <section class="feature-surface p-5 sm:p-6">
+          <div class="feature-section-head">
+            <h2 class="feature-section-head__title">人気の機体 TOP5</h2>
+            <p class="feature-section-head__meta">利用頻度の高い機体を確認</p>
+          </div>
+
           <% if @popular_mobile_suits.any? %>
-            <% @popular_mobile_suits.each_with_index do |suit, index| %>
-              <div class="px-6 py-4 flex items-center justify-between">
-                <div class="flex items-center">
-                  <span class="text-2xl font-bold text-gray-300 mr-3"><%= index + 1 %></span>
-                  <div>
-                    <div class="text-sm font-medium text-gray-900"><%= suit.name %></div>
-                    <div class="text-xs text-gray-500"><%= suit.series %></div>
+            <div class="feature-list">
+              <% @popular_mobile_suits.each_with_index do |suit, index| %>
+                <div class="feature-list-item">
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="flex items-center gap-3">
+                      <span class="text-2xl font-bold text-slate-300"><%= index + 1 %></span>
+                      <div>
+                        <div class="text-sm font-semibold text-slate-900"><%= suit.name %></div>
+                        <div class="mt-1 text-xs text-slate-500"><%= suit.series %></div>
+                      </div>
+                    </div>
+                    <span class="feature-pill feature-pill--surface"><%= suit.usage_count %>回</span>
                   </div>
                 </div>
-                <span class="text-sm text-blue-600 font-semibold"><%= suit.usage_count %>回</span>
-              </div>
-            <% end %>
+              <% end %>
+            </div>
           <% else %>
-            <div class="px-6 py-8 text-center">
-              <p class="text-sm text-gray-500">データがありません</p>
+            <div class="empty-state">
+              <p class="empty-state__title">データがありません</p>
+              <p class="empty-state__description mt-2">試合記録が増えると使用回数が集計されます。</p>
             </div>
           <% end %>
-        </div>
+        </section>
       </div>
-
     </div>
   </div>
 </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,213 +1,226 @@
-<div class="py-8">
-  <div class="mb-8">
-    <h1 class="text-2xl sm:text-3xl font-bold text-gray-900">ダッシュボード</h1>
-    <p class="mt-2 text-sm text-gray-600">ようこそ、<%= viewing_as_user.nickname %>さん</p>
-    <% if viewing_as_user.is_guest %>
-      <div class="mt-4">
-        <%= render "shared/app_notice",
-            tone: :warning,
-            title: "ゲストアカウントでログイン中",
-            message: "個人戦績などの機能を利用するには、管理者にアカウント発行を依頼してください。" %>
-      </div>
-    <% elsif @user_total_matches == 0 %>
-      <div class="mt-4">
-        <%= render "shared/app_notice",
-            tone: :info,
-            title: "初めての方へ",
-            message: "対戦会でイベントが作成されたら、ローテーション表から試合に参加しましょう。試合結果を記録すると、ここに統計情報が表示されます。" %>
-      </div>
-    <% end %>
-  </div>
-
-  <!-- 2カラムレイアウト -->
-  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-    <!-- 左カラム（メインコンテンツ） -->
-    <div class="lg:col-span-2 space-y-6">
-
-      <!-- 1. リアルタイム待機状況カード（開催中のローテーション表がある場合のみ） -->
-      <% if @active_rotation %>
-        <div class="bg-gradient-to-r from-purple-500 to-purple-600 text-white shadow-lg rounded-lg p-4 sm:p-6" data-controller="rotation-subscriber" data-rotation-subscriber-rotation-id-value="<%= @active_rotation.id %>">
-          <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 gap-2">
-            <div>
-              <h2 class="text-lg sm:text-xl font-bold">🎮 本日のイベント</h2>
-              <p class="text-sm text-white text-opacity-90 mt-1"><%= @today_event.name %></p>
-            </div>
-            <div class="flex items-center space-x-2 flex-wrap gap-y-2">
-              <div class="inline-flex items-center px-2 py-1 bg-red-100 border border-red-300 rounded-full">
-                <span class="w-2 h-2 bg-red-500 rounded-full mr-1 animate-pulse"></span>
-                <span class="text-xs font-medium text-red-800">リアルタイム更新中</span>
-              </div>
-              <span class="bg-white text-purple-600 px-2 sm:px-3 py-1 rounded-full text-xs sm:text-sm font-semibold">
-                <%= @today_event.held_on.strftime('%Y/%m/%d') %>
-              </span>
-            </div>
-          </div>
-
-          <!-- アクティブなローテーション -->
-          <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm">
-            <div class="text-sm font-semibold mb-2 text-purple-700">🔴 アクティブなローテーション</div>
-            <div class="text-2xl font-bold text-gray-900"><%= @active_rotation.display_name %></div>
-            <div class="text-sm mt-1 text-gray-600">
-              進捗: <%= @rotation_current_match_index + 1 %> / <%= @rotation_total_matches %> 試合
-            </div>
-          </div>
-
-          <!-- 現在の試合 -->
-          <% if @current_rotation_match %>
-            <div class="bg-white text-gray-900 rounded-lg p-3 sm:p-4 mb-4 shadow-sm">
-              <div class="text-sm font-semibold mb-2 sm:mb-3 text-gray-700">📍 現在の試合</div>
-              <div class="text-2xl sm:text-3xl font-bold text-gray-900 mb-2 sm:mb-3 text-center">第<%= @rotation_current_match_index + 1 %>試合</div>
-              <div class="grid grid-cols-3 gap-2 sm:gap-3 text-xs sm:text-sm">
-                <div class="bg-gray-50 rounded p-2">
-                  <div class="text-xs text-gray-500 mb-1">チーム1</div>
-                  <div class="flex flex-wrap items-center">
-                    <span class="font-bold text-red-600"><%= @current_rotation_match.team1_player1.nickname %></span>
-                    <span class="ml-1 sm:ml-2 px-1 sm:px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                  </div>
-                  <div class="text-gray-700 mt-1"><%= @current_rotation_match.team1_player2.nickname %></div>
-                </div>
-                <div class="flex items-center justify-center">
-                  <span class="text-lg sm:text-xl font-bold text-gray-400">VS</span>
-                </div>
-                <div class="bg-gray-50 rounded p-2">
-                  <div class="text-xs text-gray-500 mb-1">チーム2</div>
-                  <div class="font-medium text-gray-900"><%= @current_rotation_match.team2_player1.nickname %></div>
-                  <div class="text-gray-700 mt-1"><%= @current_rotation_match.team2_player2.nickname %></div>
-                </div>
-              </div>
-            </div>
-          <% end %>
-
-          <% if @user_next_rotation_match %>
-            <!-- あなたの次の出番 -->
-            <%
-              if @matches_until_user_turn == 0
-                badge_color = "bg-red-50 text-red-600 border-red-200"
-                urgency_message = "🔔 今です！席についてください！"
-                animate_class = "animate-pulse"
-              elsif @matches_until_user_turn == 1
-                badge_color = "bg-indigo-100 text-indigo-600 border-indigo-300"
-                urgency_message = "⚠️ 次の試合です！準備してください！"
-                animate_class = ""
-              else
-                badge_color = "bg-indigo-50 text-indigo-600 border-indigo-200"
-                if @matches_until_user_turn == 2
-                  urgency_message = "⏳ あと2試合後です"
-                else
-                  urgency_message = "あと#{@matches_until_user_turn}試合後"
-                end
-                animate_class = ""
-              end
-            %>
-            <div class="bg-white text-gray-900 rounded-lg p-4 mb-4 shadow-sm <%= animate_class %>">
-              <div class="text-sm font-semibold mb-3 text-gray-700">⏰ あなたの次の出番</div>
-
-              <div class="mb-4">
-                <div class="text-3xl font-bold text-gray-900 mb-3 text-center">第<%= @user_next_rotation_match.match_index + 1 %>試合</div>
-                <div class="px-4 py-2 rounded-lg text-sm font-bold border-2 <%= badge_color %> text-center">
-                  <%= urgency_message %>
-                </div>
-              </div>
-
-              <% if @is_streaming %>
-                <div class="bg-red-50 border-2 border-red-200 rounded-lg p-2 mb-3">
-                  <div class="text-center">
-                    <div class="text-sm font-bold text-red-600">📹 あなたが配信台担当です</div>
-                  </div>
-                </div>
-              <% else %>
-                <%
-                  streaming_player = @user_next_rotation_match.team1_player1
-                  is_partner_streaming = @user_partner&.id == streaming_player.id
-                  is_opponent_streaming = @opponent_players&.any? { |p| p.id == streaming_player.id }
-                %>
-                <div class="bg-gray-100 border border-gray-300 rounded-lg p-2 mb-3">
-                  <div class="text-center">
-                    <div class="text-sm text-gray-700">
-                      📹 配信台担当:
-                      <span class="font-bold text-red-600"><%= streaming_player.nickname %></span>
-                      <% if is_partner_streaming %>
-                        <span class="text-xs text-gray-500">（パートナー）</span>
-                      <% elsif is_opponent_streaming %>
-                        <span class="text-xs text-gray-500">（対戦相手）</span>
-                      <% end %>
-                    </div>
-                  </div>
-                </div>
-              <% end %>
-
-              <div class="bg-gray-50 rounded-lg p-3">
-                <div class="text-xs text-gray-500 mb-2 font-semibold">対戦情報</div>
-                <div class="space-y-2 text-sm">
-                  <div class="flex items-center justify-between">
-                    <span class="text-gray-600">🤝 パートナー</span>
-                    <span class="font-bold text-gray-900 <%= @user_partner&.id == @user_next_rotation_match.team1_player1_id ? 'text-red-600' : '' %>">
-                      <%= @user_partner.nickname %>
-                      <% if @user_partner&.id == @user_next_rotation_match.team1_player1_id %>
-                        <span class="ml-1 px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                      <% end %>
-                    </span>
-                  </div>
-                  <div class="border-t border-gray-200 pt-2"></div>
-                  <div class="flex items-center justify-between">
-                    <span class="text-gray-600">⚔️ 対戦相手</span>
-                    <span class="font-medium text-gray-900">
-                      <% @opponent_players.each_with_index do |player, index| %>
-                        <% if player.id == @user_next_rotation_match.team1_player1_id %>
-                          <span class="text-red-600 font-bold"><%= player.nickname %></span><span class="ml-1 px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                        <% else %>
-                          <%= player.nickname %>
-                        <% end %>
-                        <%= ' & ' if index == 0 %>
-                      <% end %>
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <%= link_to "📊 ローテーション表全体を見る", rotation_path(@active_rotation), class: "block w-full bg-gray-600 text-white text-center font-semibold py-3 px-4 rounded hover:bg-gray-700 transition" %>
-          <% else %>
-            <div class="bg-white text-gray-900 rounded-lg p-4 text-center shadow-sm">
-              <div class="text-4xl mb-3">🎉</div>
-              <p class="text-gray-900 font-semibold mb-2">お疲れ様でした！</p>
-              <p class="text-gray-600 text-sm mb-3">このローテーションでの出番は終了しました</p>
-              <%= link_to "ローテーション表を見る", rotation_path(@active_rotation), class: "inline-block bg-gray-600 text-white font-semibold py-2 px-4 rounded hover:bg-gray-700 transition" %>
-            </div>
-          <% end %>
-        </div>
-      <% elsif @today_event %>
-        <!-- ローテーション表がない場合の表示 -->
-        <div class="bg-gradient-to-r from-purple-500 to-purple-600 text-white shadow-lg rounded-lg p-6">
-          <div class="flex items-center justify-between mb-4">
-            <div>
-              <h2 class="text-xl font-bold">🎮 本日のイベント</h2>
-              <p class="text-sm text-white text-opacity-90 mt-1"><%= @today_event.name %></p>
-            </div>
-            <span class="bg-white text-purple-600 px-3 py-1 rounded-full text-sm font-semibold">
-              <%= @today_event.held_on.strftime('%Y/%m/%d') %>
-            </span>
-          </div>
-          <div class="bg-white text-gray-900 rounded-lg p-4 text-center shadow-sm">
-            <p class="text-purple-700 mb-3">アクティブなローテーションがありません</p>
-            <% if current_user.is_admin? %>
-              <%= link_to "ローテーション作成", new_event_rotation_path(@today_event), class: "inline-block bg-indigo-600 text-white font-semibold py-2 px-4 rounded hover:bg-indigo-700 transition shadow-sm" %>
+<div class="py-6 sm:py-8">
+  <div class="feature-stack">
+    <section class="feature-hero feature-hero--accent px-5 py-6 sm:px-8 sm:py-8">
+      <div class="feature-hero__top">
+        <div>
+          <p class="feature-hero__eyebrow">Dashboard</p>
+          <h1 class="feature-hero__title"><%= viewing_as_user.nickname %> さん、ようこそ</h1>
+          <p class="feature-hero__description">
+            <% if @active_rotation %>
+              今日のローテーション進行と、あなたの次の出番をここからすぐ確認できます。
+            <% elsif @today_event %>
+              本日のイベントは準備中です。ローテーションの公開や試合記録を待ちましょう。
             <% else %>
-              <p class="text-sm text-gray-500">管理者がローテーションを作成するまでお待ちください</p>
+              次のイベントが始まると、ここに進行状況や個人の戦績が表示されます。
+            <% end %>
+          </p>
+
+          <div class="feature-hero__meta">
+            <% if viewing_as_user.is_guest %>
+              <span class="feature-pill feature-pill--contrast">ゲスト閲覧モード</span>
+            <% else %>
+              <span class="feature-pill feature-pill--contrast">参加試合 <%= @user_total_matches %></span>
+              <span class="feature-pill feature-pill--contrast">勝率 <%= @user_win_rate %>%</span>
+            <% end %>
+            <% if @today_event %>
+              <span class="feature-pill feature-pill--contrast"><%= @today_event.held_on.strftime("%Y/%m/%d") %></span>
             <% end %>
           </div>
         </div>
-      <% else %>
-        <!-- 今日のイベントがない場合 -->
-        <div class="bg-white shadow rounded-lg p-6">
-          <h2 class="text-xl font-bold text-purple-900 mb-2">📅 本日のイベント</h2>
-          <p class="text-sm text-purple-700">本日はイベントが設定されていません</p>
+
+        <div class="feature-hero__actions">
+          <% if @active_rotation %>
+            <%= link_to "ローテーションを開く", rotation_path(@active_rotation), class: app_button_classes(variant: :primary) %>
+          <% end %>
+          <%= link_to "イベント一覧", events_path, class: app_button_classes(variant: :secondary) %>
+          <%= link_to "対戦履歴", matches_path, class: app_button_classes(variant: :secondary) %>
+        </div>
+      </div>
+
+      <% if viewing_as_user.is_guest %>
+        <div class="mt-6 max-w-2xl">
+          <%= render "shared/app_notice",
+              tone: :warning,
+              title: "ゲストアカウントでログイン中",
+              message: "個人戦績などの機能を利用するには、管理者にアカウント発行を依頼してください。" %>
+        </div>
+      <% elsif @user_total_matches == 0 %>
+        <div class="mt-6 max-w-2xl">
+          <%= render "shared/app_notice",
+              tone: :info,
+              title: "初めての方へ",
+              message: "対戦会でイベントが作成されたら、ローテーション表から試合に参加しましょう。試合結果を記録すると、ここに統計情報が表示されます。" %>
         </div>
       <% end %>
+    </section>
+
+    <div class="feature-grid xl:grid-cols-[minmax(0,1.14fr)_minmax(20rem,0.86fr)]">
+      <div class="feature-stack">
+        <% if @active_rotation %>
+          <section class="feature-hero feature-hero--slate px-5 py-6 sm:px-8 sm:py-8" data-controller="rotation-subscriber" data-rotation-subscriber-rotation-id-value="<%= @active_rotation.id %>">
+            <div class="feature-hero__top">
+              <div>
+                <p class="feature-hero__eyebrow">Today</p>
+                <h2 class="feature-hero__title"><%= @today_event.name %></h2>
+                <p class="feature-hero__description">
+                  <%= @active_rotation.display_name %> が進行中です。現在の試合と次の出番を確認できます。
+                </p>
+                <div class="feature-hero__meta">
+                  <span class="feature-pill feature-pill--contrast">リアルタイム更新中</span>
+                  <span class="feature-pill feature-pill--contrast">第<%= @rotation_current_match_index + 1 %> / <%= @rotation_total_matches %>試合</span>
+                </div>
+              </div>
+            </div>
+
+            <% if @current_rotation_match %>
+              <div class="mt-6 feature-surface p-4 sm:p-5">
+                <div class="text-sm font-semibold text-slate-700">現在の試合</div>
+                <div class="mt-2 text-2xl font-bold text-slate-950">第<%= @rotation_current_match_index + 1 %>試合</div>
+                <div class="mt-4 feature-match-grid">
+                  <div class="feature-match-team">
+                    <div class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">チーム1</div>
+                    <div class="mt-3 space-y-2 text-sm">
+                      <div class="font-semibold text-red-600">
+                        <%= @current_rotation_match.team1_player1.nickname %>
+                        <span class="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">配信台</span>
+                      </div>
+                      <div class="font-medium text-slate-900"><%= @current_rotation_match.team1_player2.nickname %></div>
+                    </div>
+                  </div>
+                  <div class="feature-match-vs">VS</div>
+                  <div class="feature-match-team">
+                    <div class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">チーム2</div>
+                    <div class="mt-3 space-y-2 text-sm">
+                      <div class="font-medium text-slate-900"><%= @current_rotation_match.team2_player1.nickname %></div>
+                      <div class="font-medium text-slate-900"><%= @current_rotation_match.team2_player2.nickname %></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+
+            <% if @user_next_rotation_match %>
+              <%
+                if @matches_until_user_turn == 0
+                  badge_class = "feature-pill feature-pill--danger"
+                  urgency_message = "今です。席についてください"
+                  card_emphasis = "ring-2 ring-red-300"
+                elsif @matches_until_user_turn == 1
+                  badge_class = "feature-pill feature-pill--accent"
+                  urgency_message = "次の試合です。準備してください"
+                  card_emphasis = ""
+                else
+                  badge_class = "feature-pill feature-pill--surface"
+                  urgency_message = @matches_until_user_turn == 2 ? "あと2試合後です" : "あと#{@matches_until_user_turn}試合後です"
+                  card_emphasis = ""
+                end
+              %>
+              <div class="mt-6 feature-surface p-4 sm:p-5 <%= card_emphasis %>">
+                <div class="feature-section-head feature-section-head--row">
+                  <div>
+                    <h3 class="feature-section-head__title">あなたの次の出番</h3>
+                    <p class="feature-section-head__meta">第<%= @user_next_rotation_match.match_index + 1 %>試合</p>
+                  </div>
+                  <span class="<%= badge_class %>"><%= urgency_message %></span>
+                </div>
+
+                <% if @is_streaming %>
+                  <div class="mb-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">
+                    あなたが配信台担当です
+                  </div>
+                <% else %>
+                  <%
+                    streaming_player = @user_next_rotation_match.team1_player1
+                    is_partner_streaming = @user_partner&.id == streaming_player.id
+                    is_opponent_streaming = @opponent_players&.any? { |p| p.id == streaming_player.id }
+                  %>
+                  <div class="mb-4 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                    配信台担当:
+                    <span class="font-semibold text-red-600"><%= streaming_player.nickname %></span>
+                    <% if is_partner_streaming %>
+                      <span class="text-xs text-slate-500">（パートナー）</span>
+                    <% elsif is_opponent_streaming %>
+                      <span class="text-xs text-slate-500">（対戦相手）</span>
+                    <% end %>
+                  </div>
+                <% end %>
+
+                <div class="feature-surface feature-surface--muted p-4">
+                  <div class="space-y-3 text-sm">
+                    <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                      <span class="text-slate-500">パートナー</span>
+                      <span class="font-semibold text-slate-900 <%= @user_partner&.id == @user_next_rotation_match.team1_player1_id ? 'text-red-600' : '' %>">
+                        <%= @user_partner.nickname %>
+                        <% if @user_partner&.id == @user_next_rotation_match.team1_player1_id %>
+                          <span class="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">配信台</span>
+                        <% end %>
+                      </span>
+                    </div>
+                    <div class="border-t border-slate-200 pt-3">
+                      <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <span class="text-slate-500">対戦相手</span>
+                        <span class="font-medium text-slate-900">
+                          <% @opponent_players.each_with_index do |player, index| %>
+                            <% if player.id == @user_next_rotation_match.team1_player1_id %>
+                              <span class="font-semibold text-red-600"><%= player.nickname %></span><span class="ml-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">配信台</span>
+                            <% else %>
+                              <%= player.nickname %>
+                            <% end %>
+                            <%= " / " if index == 0 %>
+                          <% end %>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="mt-4">
+                  <%= link_to "ローテーション表全体を見る", rotation_path(@active_rotation), class: app_button_classes(variant: :neutral, full_width: true) %>
+                </div>
+              </div>
+            <% else %>
+              <div class="mt-6 feature-surface p-5 text-center">
+                <div class="text-4xl">🎉</div>
+                <p class="mt-3 font-semibold text-slate-950">このローテーションでの出番は終了しました</p>
+                <p class="mt-2 text-sm text-slate-500">記録済みの試合や全体の進行はローテーション表から確認できます。</p>
+                <div class="mt-4">
+                  <%= link_to "ローテーション表を見る", rotation_path(@active_rotation), class: app_button_classes(variant: :neutral) %>
+                </div>
+              </div>
+            <% end %>
+          </section>
+        <% elsif @today_event %>
+          <section class="feature-surface p-5 sm:p-6">
+            <div class="feature-section-head feature-section-head--row">
+              <div>
+                <h2 class="feature-section-head__title">本日のイベント</h2>
+                <p class="feature-section-head__meta"><%= @today_event.name %> · <%= @today_event.held_on.strftime("%Y/%m/%d") %></p>
+              </div>
+            </div>
+
+            <div class="empty-state">
+              <p class="empty-state__title">アクティブなローテーションがありません</p>
+              <% if current_user.is_admin? %>
+                <div class="mt-4">
+                  <%= link_to "ローテーション作成", new_event_rotation_path(@today_event), class: app_button_classes(variant: :primary, size: :sm) %>
+                </div>
+              <% else %>
+                <p class="empty-state__description mt-2">管理者がローテーションを作成するまでお待ちください。</p>
+              <% end %>
+            </div>
+          </section>
+        <% else %>
+          <section class="feature-surface p-5 sm:p-6">
+            <div class="empty-state">
+              <p class="empty-state__title">本日のイベントはまだ設定されていません</p>
+              <p class="empty-state__description mt-2">イベントが作成されると、ここに進行情報が表示されます。</p>
+            </div>
+          </section>
+        <% end %>
 
       <% if viewing_as_user.is_guest %>
         <!-- ゲスト用: 個人戦績の代わりに案内を表示 -->
-        <div class="bg-white shadow rounded-lg p-6">
+        <div class="feature-surface p-6">
           <div class="text-center py-8">
             <svg class="mx-auto h-16 w-16 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
@@ -229,7 +242,7 @@
         </div>
       <% else %>
       <!-- 2. 調子メーター -->
-      <div class="bg-white shadow rounded-lg p-6">
+      <div class="feature-surface p-6">
         <div class="flex items-center justify-between mb-4">
           <h2 class="text-lg font-bold text-gray-900">📊 調子メーター</h2>
           <span class="text-xs text-gray-500" title="直近の試合結果から、現在の調子を確認できます">ℹ️ 最近の調子</span>
@@ -285,7 +298,7 @@
       </div>
 
       <!-- 3. 対戦会クイック比較 -->
-      <div class="bg-white shadow rounded-lg p-6">
+      <div class="feature-surface p-6">
         <div class="flex items-center justify-between mb-4">
           <h2 class="text-lg font-bold text-gray-900">📈 対戦会クイック比較</h2>
           <span class="text-xs text-gray-500" title="直近のイベントでの成績を比較できます">ℹ️ 最近3回</span>
@@ -328,11 +341,11 @@
       </div>
 
       <!-- 4. 最近の対戦（5件） -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
+      <div class="feature-surface">
+        <div class="px-5 py-5 border-b border-slate-100 sm:px-6">
           <h2 class="text-lg font-bold text-gray-900">🕐 最近の対戦</h2>
         </div>
-        <div class="divide-y divide-gray-200">
+        <div class="divide-y divide-slate-100">
           <% if @recent_matches.any? %>
             <% @recent_matches.each do |match| %>
               <%
@@ -398,7 +411,7 @@
           <% end %>
         </div>
         <% if @recent_matches.any? %>
-          <div class="px-6 py-4 bg-gray-50 text-center">
+          <div class="px-6 py-4 bg-slate-50/80 text-center">
             <%= link_to "すべて見る →", matches_path, class: "text-sm text-blue-600 hover:text-blue-500" %>
           </div>
         <% end %>
@@ -406,7 +419,7 @@
 
       <!-- 5. パフォーマンス スナップショット（stats なし時は対面相性マトリクスを表示） -->
       <% if @performance_snapshot %>
-        <div class="bg-white shadow rounded-lg p-6">
+        <div class="feature-surface p-6">
           <div class="flex items-center justify-between mb-4">
             <h2 class="text-lg font-bold text-gray-900">📊 パフォーマンス スナップショット</h2>
             <span class="text-xs text-gray-500">全試合平均</span>
@@ -448,7 +461,7 @@
         </div>
       <% else %>
         <!-- フォールバック: 対面相性マトリクス -->
-        <div class="bg-white shadow rounded-lg p-6">
+        <div class="feature-surface p-6">
           <div class="flex items-center justify-between mb-4">
             <h2 class="text-lg font-bold text-gray-900">⚔️ 対面相性マトリクス</h2>
             <span class="text-xs text-gray-500" title="よく使う機体での対戦相手との相性を確認できます">ℹ️ 機体相性</span>
@@ -500,7 +513,7 @@
     </div>
 
     <!-- 右カラム（サブコンテンツ） -->
-    <div class="lg:col-span-1 space-y-6">
+    <div class="feature-stack">
 
       <!-- 1. 通知/アラート領域 -->
       <% if @notifications.any? %>
@@ -515,8 +528,8 @@
       <% end %>
 
       <!-- 2. 個人戦績カード -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
+      <div class="feature-surface">
+        <div class="px-5 py-5 border-b border-slate-100 sm:px-6">
           <h2 class="text-lg font-bold text-gray-900">🏆 あなたの戦績</h2>
         </div>
         <% if viewing_as_user.is_guest %>
@@ -562,11 +575,11 @@
       </div>
 
       <!-- 3. ベストパートナーTOP3 -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
+      <div class="feature-surface">
+        <div class="px-5 py-5 border-b border-slate-100 sm:px-6">
           <h2 class="text-lg font-bold text-gray-900">🤝 ベストパートナー</h2>
         </div>
-        <div class="divide-y divide-gray-200">
+        <div class="divide-y divide-slate-100">
           <% if viewing_as_user.is_guest %>
             <div class="px-6 py-8 text-center">
               <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -611,11 +624,11 @@
 
       <!-- 4. パーソナル ハイライト（stats なし時は機体トレンドを表示） -->
       <% if !viewing_as_user.is_guest && (@highlight_best_damage_mp || @highlight_best_kd_mp) %>
-        <div class="bg-white shadow rounded-lg">
-          <div class="px-6 py-5 border-b border-gray-200">
+        <div class="feature-surface">
+          <div class="px-5 py-5 border-b border-slate-100 sm:px-6">
             <h2 class="text-lg font-bold text-gray-900">🏅 パーソナル ハイライト</h2>
           </div>
-          <div class="divide-y divide-gray-200">
+          <div class="divide-y divide-slate-100">
             <% if @highlight_best_damage_mp %>
               <%
                 _hmp = @highlight_best_damage_mp
@@ -652,14 +665,14 @@
               </div>
             <% end %>
           </div>
-          <div class="px-6 py-4 bg-gray-50 text-center">
+          <div class="px-6 py-4 bg-slate-50/80 text-center">
             <%= link_to "ハイライト一覧 →", statistics_path(tab: "highlights"), class: "text-sm text-blue-600 hover:text-blue-500" %>
           </div>
         </div>
       <% else %>
         <!-- フォールバック: 機体使用トレンド -->
-        <div class="bg-white shadow rounded-lg">
-          <div class="px-6 py-5 border-b border-gray-200">
+        <div class="feature-surface">
+          <div class="px-5 py-5 border-b border-slate-100 sm:px-6">
             <div class="flex items-center justify-between">
               <h2 class="text-lg font-bold text-gray-900">📱 機体トレンド</h2>
               <span class="text-xs text-gray-500" title="直近イベントでの使用機体と勝率">ℹ️ イベント別</span>
@@ -673,7 +686,7 @@
               </p>
             <% end %>
           </div>
-          <div class="divide-y divide-gray-200">
+          <div class="divide-y divide-slate-100">
             <% if viewing_as_user.is_guest %>
               <div class="px-6 py-8 text-center">
                 <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -715,7 +728,7 @@
 
       <!-- 5. EXバースト サマリー（stats なし時はコスト帯分析を表示） -->
       <% if !viewing_as_user.is_guest && @exburst_summary %>
-        <div class="bg-white shadow rounded-lg p-6">
+        <div class="feature-surface p-6">
           <div class="flex items-center justify-between mb-4">
             <h2 class="text-lg font-bold text-gray-900">⚡ EXバースト サマリー</h2>
             <span class="text-xs text-gray-500">全試合平均</span>
@@ -745,14 +758,14 @@
         </div>
       <% else %>
         <!-- フォールバック: コスト帯分析 -->
-        <div class="bg-white shadow rounded-lg">
-          <div class="px-6 py-5 border-b border-gray-200">
+        <div class="feature-surface">
+          <div class="px-5 py-5 border-b border-slate-100 sm:px-6">
             <div class="flex items-center justify-between">
               <h2 class="text-lg font-bold text-gray-900">💰 コスト帯分析</h2>
               <span class="text-xs text-gray-500" title="チームコストの組み合わせ別の勝率">ℹ️ コスト別</span>
             </div>
           </div>
-          <div class="divide-y divide-gray-200">
+          <div class="divide-y divide-slate-100">
             <% if viewing_as_user.is_guest %>
               <div class="px-6 py-8 text-center">
                 <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -794,11 +807,11 @@
       <% end %>
 
       <!-- 6. あなたのお気に入り機体（TOP3） -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
+      <div class="feature-surface">
+        <div class="px-5 py-5 border-b border-slate-100 sm:px-6">
           <h2 class="text-lg font-bold text-gray-900">⭐ お気に入り機体</h2>
         </div>
-        <div class="divide-y divide-gray-200">
+        <div class="divide-y divide-slate-100">
           <% if viewing_as_user.is_guest %>
             <div class="px-6 py-8 text-center">
               <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -840,11 +853,11 @@
       </div>
 
       <!-- 7. 今後のイベント -->
-      <div class="bg-white shadow rounded-lg">
-        <div class="px-6 py-5 border-b border-gray-200">
+      <div class="feature-surface">
+        <div class="px-5 py-5 border-b border-slate-100 sm:px-6">
           <h2 class="text-lg font-bold text-gray-900">📅 今後のイベント</h2>
         </div>
-        <div class="divide-y divide-gray-200">
+        <div class="divide-y divide-slate-100">
           <% if @upcoming_events.any? %>
             <% @upcoming_events.each do |event| %>
               <%= link_to event_path(event), class: "block hover:bg-gray-50 px-6 py-4" do %>
@@ -858,7 +871,7 @@
             </div>
           <% end %>
         </div>
-        <div class="px-6 py-4 bg-gray-50 text-center">
+        <div class="px-6 py-4 bg-slate-50/80 text-center">
           <%= link_to "すべて見る →", events_path, class: "text-sm text-blue-600 hover:text-blue-500" %>
         </div>
       </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,125 +1,136 @@
-<div class="py-8">
-  <div class="mb-6">
-    <%= link_to "← イベント一覧に戻る", events_path, class: "text-blue-600 hover:text-blue-500" %>
+<div class="py-6 sm:py-8">
+  <% broadcast_url = safe_external_url(@event.broadcast_url) %>
+  <div class="mb-4">
+    <%= link_to "← イベント一覧に戻る", events_path, class: "text-sm font-semibold text-indigo-600 transition hover:text-indigo-500" %>
   </div>
 
-  <div class="bg-white shadow overflow-hidden sm:rounded-lg mb-6">
-    <div class="px-4 py-5 sm:px-6">
-      <div class="flex items-center gap-3 mb-1">
-        <h1 class="text-2xl font-bold text-gray-900"><%= @event.name %></h1>
-        <% if @event.broadcast_url.present? %>
-          <%= link_to @event.broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "inline-flex items-center gap-1 px-3 py-1 rounded-full bg-red-50 text-red-700 text-sm font-semibold hover:bg-red-100 transition-colors flex-shrink-0" do %>
-            <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-4">
-            配信を見る
-          <% end %>
-          <% if current_user.is_admin? %>
-            <%= button_to post_broadcast_to_discord_event_path(@event), method: :post, data: { turbo_confirm: "「#{@event.name}」の配信URLをDiscordへ投稿しますか？" }, class: "inline-flex items-center gap-1 px-3 py-1 rounded-full bg-indigo-50 text-indigo-700 text-sm font-semibold hover:bg-indigo-100 transition-colors flex-shrink-0 border-0 cursor-pointer" do %>
-              <img src="/discord_logo_blurple.png" alt="Discord" class="h-4">
-              Discordへ共有
+  <div class="feature-stack">
+    <section class="feature-hero feature-hero--slate px-5 py-6 sm:px-8 sm:py-8">
+      <div class="feature-hero__top">
+        <div>
+          <p class="feature-hero__eyebrow">Event Detail</p>
+          <h1 class="feature-hero__title"><%= @event.name %></h1>
+          <p class="feature-hero__description">
+            <%= @event.description.presence || "イベントのローテーション進行、対戦記録、配信導線をここからまとめて管理できます。" %>
+          </p>
+
+          <div class="feature-hero__meta">
+            <span class="feature-pill feature-pill--contrast">
+              <%= @event.held_on.strftime("%Y年%m月%d日") %>
+            </span>
+            <span class="feature-pill feature-pill--contrast">
+              ローテーション <%= @rotations.count %> 件
+            </span>
+            <span class="feature-pill feature-pill--contrast">
+              対戦記録 <%= @matches.total_count %> 試合
+            </span>
+            <% if broadcast_url.present? %>
+              <%= link_to broadcast_url, target: "_blank", rel: "noopener noreferrer", class: "feature-pill feature-pill--danger transition hover:opacity-90" do %>
+                <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-4">
+                配信を見る
+              <% end %>
             <% end %>
-          <% end %>
-        <% end %>
+          </div>
+        </div>
       </div>
-      <p class="text-sm text-gray-500">
-        <%= @event.held_on.strftime('%Y年%m月%d日') %>
-      </p>
+
       <% if current_user.is_admin? %>
-        <div class="flex flex-wrap gap-2 mt-4">
-          <%= link_to "試合を登録", new_event_match_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
-          <%= link_to "ローテーション作成", new_event_rotation_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+        <div class="mt-6 feature-action-grid">
+          <%= link_to "試合を登録", new_event_match_path(@event), class: app_button_classes(variant: :primary) %>
+          <%= link_to "ローテーション作成", new_event_rotation_path(@event), class: app_button_classes(variant: :secondary) %>
           <% if @event.broadcast_url.present? %>
-            <%= link_to "タイムスタンプ一括設定", edit_timestamps_event_path(@event), class: "bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
-            <%= button_to "タイムスタンプ解析開始", trigger_analysis_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で動画解析を開始しますか？完了後にタイムスタンプが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+            <%= link_to "タイムスタンプ一括設定", edit_timestamps_event_path(@event), class: app_button_classes(variant: :secondary) %>
+            <%= button_to "配信URLをDiscordへ共有", post_broadcast_to_discord_event_path(@event), method: :post, data: { turbo_confirm: "「#{@event.name}」の配信URLをDiscordへ投稿しますか？" }, class: app_button_classes(variant: :secondary) %>
+            <%= button_to "タイムスタンプ解析開始", trigger_analysis_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で動画解析を開始しますか？完了後にタイムスタンプが自動登録されます。" }, class: app_button_classes(variant: :success) %>
           <% end %>
-          <%= button_to "統計取得開始", trigger_scraping_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で統計スクレイピングを開始しますか？完了後に統計データが自動登録されます。" }, class: "bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
-          <%= link_to "編集", edit_event_path(@event), class: "bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
-          <%= button_to "削除", event_path(@event), method: :delete, data: { turbo_confirm: "イベント「#{@event.name}」を削除してもよろしいですか？関連する試合やローテーションもすべて削除されます。" }, class: "bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded text-sm" %>
+          <%= button_to "統計取得開始", trigger_scraping_event_path(@event), method: :post, data: { turbo_confirm: "GitHub Actions で統計スクレイピングを開始しますか？完了後に統計データが自動登録されます。" }, class: app_button_classes(variant: :success) %>
+          <%= link_to "編集", edit_event_path(@event), class: app_button_classes(variant: :neutral) %>
+          <%= button_to "削除", event_path(@event), method: :delete, data: { turbo_confirm: "イベント「#{@event.name}」を削除してもよろしいですか？関連する試合やローテーションもすべて削除されます。" }, class: app_button_classes(variant: :danger) %>
         </div>
       <% end %>
-    </div>
-    <% if @event.description.present? %>
-      <div class="border-t border-gray-200 px-4 py-5 sm:px-6">
-        <p class="text-sm text-gray-700"><%= @event.description %></p>
-      </div>
-    <% end %>
-  </div>
+    </section>
 
-  <div class="space-y-6">
-    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
-      <div class="px-4 py-5 sm:px-6">
-        <h2 class="text-lg font-medium text-gray-900">ローテーション</h2>
-        <p class="mt-1 text-sm text-gray-500">全 <%= @rotations.count %> 個</p>
-      </div>
-      <div class="border-t border-gray-200">
+    <div class="feature-grid xl:grid-cols-[minmax(0,0.86fr)_minmax(0,1.14fr)]">
+      <section class="feature-surface p-5 sm:p-6">
+        <div class="feature-section-head feature-section-head--row">
+          <div>
+            <h2 class="feature-section-head__title">ローテーション</h2>
+            <p class="feature-section-head__meta">全 <%= @rotations.count %> 件の進行状況</p>
+          </div>
+          <% if current_user.is_admin? %>
+            <%= link_to "ローテーション作成", new_event_rotation_path(@event), class: app_button_classes(variant: :secondary, size: :sm) %>
+          <% end %>
+        </div>
+
         <% if @rotations.any? %>
-          <ul class="divide-y divide-gray-200">
+          <ul class="feature-list">
             <% @rotations.each do |rotation| %>
-              <%= link_to rotation_path(rotation), class: "block hover:bg-gray-50" do %>
-                <li class="px-4 py-3">
-                  <div class="flex items-center justify-between">
-                    <div>
-                      <p class="text-sm font-medium text-gray-900"><%= rotation.display_name %></p>
-                      <div class="mt-1 flex items-center space-x-2">
-                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
-                          <%= rotation.round_number %>周目
-                        </span>
-                        <% if rotation.is_active %>
-                          <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
-                            アクティブ
-                          </span>
-                        <% end %>
+              <% progress = rotation.rotation_matches.count.positive? ? ((rotation.current_match_index + 1).to_f / rotation.rotation_matches.count * 100) : 0 %>
+              <li>
+                <%= link_to rotation_path(rotation), class: "feature-list-item feature-list-item--clickable" do %>
+                  <div class="flex flex-col gap-4">
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <div class="text-base font-semibold text-slate-950"><%= rotation.display_name %></div>
+                        <div class="mt-2 flex flex-wrap gap-2">
+                          <span class="feature-pill feature-pill--surface"><%= rotation.round_number %>周目</span>
+                          <% if rotation.is_active %>
+                            <span class="feature-pill feature-pill--accent">アクティブ</span>
+                          <% end %>
+                        </div>
+                      </div>
+
+                      <div class="text-sm text-slate-500">
+                        <div><%= rotation.current_match_index + 1 %> / <%= rotation.rotation_matches.count %> 試合</div>
                       </div>
                     </div>
-                    <div class="text-right">
-                      <p class="text-xs text-gray-500">
-                        <%= rotation.current_match_index + 1 %> / <%= rotation.rotation_matches.count %> 試合
-                      </p>
-                      <div class="w-24 bg-gray-200 rounded-full h-1.5 mt-1">
-                        <% progress = rotation.rotation_matches.count > 0 ? ((rotation.current_match_index + 1).to_f / rotation.rotation_matches.count * 100) : 0 %>
-                        <div class="bg-blue-600 h-1.5 rounded-full" style="width: <%= progress %>%"></div>
-                      </div>
+
+                    <div class="feature-progress">
+                      <div class="feature-progress__bar" style="width: <%= progress %>%"></div>
                     </div>
                   </div>
-                </li>
-              <% end %>
+                <% end %>
+              </li>
             <% end %>
           </ul>
         <% else %>
-          <div class="px-4 py-3 text-center">
-            <p class="text-sm text-gray-500">まだローテーションがありません</p>
+          <div class="empty-state">
+            <p class="empty-state__title">まだローテーションがありません</p>
+            <p class="empty-state__description mt-2">イベントの進行管理はローテーション作成から始めます。</p>
             <% if current_user.is_admin? %>
-              <%= link_to "ローテーションを作成", new_event_rotation_path(@event), class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-500" %>
+              <div class="mt-4">
+                <%= link_to "ローテーションを作成", new_event_rotation_path(@event), class: app_button_classes(variant: :primary, size: :sm) %>
+              </div>
             <% end %>
           </div>
         <% end %>
-      </div>
-    </div>
+      </section>
 
-    <div class="bg-white shadow overflow-hidden sm:rounded-lg">
-      <div class="px-4 py-5 sm:px-6">
-        <div class="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <h2 class="text-lg font-medium text-gray-900">対戦記録</h2>
-            <p class="mt-1 text-sm text-gray-500">全 <%= @matches.total_count %> 試合</p>
-            <div class="flex items-center gap-2 text-sm text-gray-600 mt-2">
-              <span>ソート:</span>
-              <% [["oldest", "試合順"], ["reactions", "リアクション順"]].each do |value, label| %>
-                <% if value == @sort %>
-                  <span class="px-3 py-1 text-sm font-semibold text-white bg-indigo-600 border border-indigo-600 rounded-lg"><%= label %></span>
-                <% else %>
-                  <%= link_to label,
-                        event_path(@event, sort: value, per: @per_page),
-                        class: "px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-indigo-50 hover:text-indigo-600 hover:border-indigo-300 transition" %>
+      <section class="feature-surface">
+        <div class="p-5 sm:p-6">
+          <div class="feature-section-head feature-section-head--row">
+            <div>
+              <h2 class="feature-section-head__title">対戦記録</h2>
+              <p class="feature-section-head__meta">全 <%= @matches.total_count %> 試合</p>
+            </div>
+
+            <div class="feature-toolbar">
+              <div class="feature-toolbar__group">
+                <% [["oldest", "試合順"], ["reactions", "リアクション順"]].each do |value, label| %>
+                  <% if value == @sort %>
+                    <span class="ui-chip ui-chip--accent"><%= label %></span>
+                  <% else %>
+                    <%= link_to label, event_path(@event, sort: value, per: @per_page), class: "ui-chip ui-chip--muted" %>
+                  <% end %>
                 <% end %>
-              <% end %>
+              </div>
+              <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, sort: @sort, per: n) } %>
             </div>
           </div>
-          <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, sort: @sort, per: n) } %>
         </div>
-      </div>
-      <div class="border-t border-gray-200">
+
         <% if @matches.any? %>
-          <ul class="divide-y divide-gray-100">
+          <ul class="divide-y divide-slate-100">
             <% @matches.each do |match| %>
               <%
                 _team1 = match.match_players.to_a.select { |p| p.team_number == 1 }.sort_by(&:position)
@@ -127,61 +138,65 @@
                 _streaming_id = _team1.first&.id
               %>
               <%= turbo_stream_from "match_#{match.id}_reactions_compact" %>
-              <li class="px-5 py-5 hover:bg-gray-50 cursor-pointer"
+              <li class="px-5 py-5 transition hover:bg-slate-50/80 cursor-pointer"
                   data-controller="card-link"
                   data-card-link-url-value="<%= match_path(match) %>"
                   data-action="click->card-link#navigate">
-
-                <%# メタ行 %>
-                <div class="flex items-center justify-between gap-2 mb-3">
-                  <div class="flex items-center flex-wrap gap-2">
-                    <span class="text-sm font-semibold text-gray-800">第<%= @match_numbers[match.id] %>試合</span>
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-sm font-semibold text-slate-900">第<%= @match_numbers[match.id] %>試合</span>
                     <% if match.rotation_match&.started_at %>
-                      <span class="text-sm text-gray-400"><%= match.rotation_match.started_at.strftime('%H:%M') %> 開始</span>
+                      <span class="text-sm text-slate-400"><%= match.rotation_match.started_at.strftime("%H:%M") %> 開始</span>
                     <% elsif match.played_at %>
-                      <span class="text-sm text-gray-400"><%= match.played_at.strftime('%H:%M') %> 終了</span>
+                      <span class="text-sm text-slate-400"><%= match.played_at.strftime("%H:%M") %> 終了</span>
                     <% end %>
                     <% if match.video_url %>
                       <span onclick="event.stopPropagation()">
-                        <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer",
-                            class: "inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-600 text-xs font-semibold hover:bg-red-100 transition-colors" do %>
+                        <%= link_to match.video_url, target: "_blank", rel: "noopener noreferrer", class: "feature-pill feature-pill--danger transition hover:opacity-90" do %>
                           <img src="/youtube_social_icon_red.png" alt="YouTube" class="h-3.5">
                           配信
                         <% end %>
                       </span>
                     <% end %>
                   </div>
+
                   <span onclick="event.stopPropagation()">
                     <%= render "favorite_matches/favorite_button", match: match, is_favorited: @my_favorite_match_ids.include?(match.id) %>
                   </span>
                 </div>
 
-                <%# チームグリッド %>
-                <%= render "matches/match_teams",
-                      left_players: _team1,
-                      right_players: _team2,
-                      left_wins: match.winning_team == 1,
-                      streaming_player_id: _streaming_id %>
+                <div class="mt-4">
+                  <%= render "matches/match_teams",
+                        left_players: _team1,
+                        right_players: _team2,
+                        left_wins: match.winning_team == 1,
+                        streaming_player_id: _streaming_id %>
+                </div>
 
-                <%# リアクションバー %>
-                <div class="mt-3" onclick="event.stopPropagation()">
+                <div class="mt-4" onclick="event.stopPropagation()">
                   <%= render "reactions/reaction_bar", match: match, compact: true, emojis: @emojis %>
                 </div>
               </li>
             <% end %>
           </ul>
+
           <% if @matches.respond_to?(:total_pages) && @matches.total_pages > 1 %>
-            <div class="px-4 py-4 flex flex-col items-center gap-4 border-t border-gray-200">
-              <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
-              <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, sort: @sort, per: n) } %>
+            <div class="border-t border-slate-100 px-5 py-5">
+              <div class="flex flex-col items-center gap-4">
+                <%= paginate @matches, params: { per: @per_page, sort: @sort } %>
+                <%= render "shared/per_page_selector", per_page: @per_page, url_builder: ->(n) { event_path(@event, sort: @sort, per: n) } %>
+              </div>
             </div>
           <% end %>
         <% else %>
-          <div class="px-4 py-3 text-center">
-            <p class="text-sm text-gray-500">まだ対戦記録がありません</p>
+          <div class="px-5 pb-5 sm:px-6 sm:pb-6">
+            <div class="empty-state">
+              <p class="empty-state__title">まだ対戦記録がありません</p>
+              <p class="empty-state__description mt-2">ローテーションから試合結果を記録すると、ここに並びます。</p>
+            </div>
           </div>
         <% end %>
-      </div>
+      </section>
     </div>
   </div>
 </div>

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -1,778 +1,626 @@
-<!-- All Matches Completed Modal -->
+<% completed_count = @rotation_matches.count { |rm| rm.match.present? } %>
+<% total_match_count = @rotation_matches.count %>
+<% progress = total_match_count.positive? ? (completed_count.to_f / total_match_count * 100) : 0 %>
+<% initial_edit_payload = if @current_match&.match.present? && !@show_completion_modal
+     initial_match = @current_match.match
+     mp1 = initial_match.match_players.find { |mp| mp.team_number == 1 && mp.position == 1 }
+     mp2 = initial_match.match_players.find { |mp| mp.team_number == 1 && mp.position == 2 }
+     mp3 = initial_match.match_players.find { |mp| mp.team_number == 2 && mp.position == 3 }
+     mp4 = initial_match.match_players.find { |mp| mp.team_number == 2 && mp.position == 4 }
+     {
+       matchIndex: @rotation.current_match_index,
+       matchId: initial_match.id,
+       winningTeam: initial_match.winning_team,
+       suit1: mp1&.mobile_suit_id,
+       suit2: mp2&.mobile_suit_id,
+       suit3: mp3&.mobile_suit_id,
+       suit4: mp4&.mobile_suit_id
+     }.to_json
+   else
+     "null"
+   end %>
+
 <% if @show_completion_modal %>
-  <div id="completion-modal" class="fixed inset-0 flex items-center justify-center z-50" style="background-color: rgba(0, 0, 0, 0.5);">
-    <div class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 animate-fade-in">
-      <div class="p-6">
-        <div class="flex items-center justify-center w-12 h-12 mx-auto bg-green-100 rounded-full mb-4">
-          <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-          </svg>
-        </div>
-        <h3 class="text-lg font-bold text-gray-900 text-center mb-2">全試合完了しました！</h3>
-        <p class="text-sm text-gray-600 text-center mb-6">
-          <%= @rotation.display_name %>の全試合が記録されました。<br>
-          同じローテーション設定で<%= @rotation.round_number + 1 %>周目を作成しますか？
+  <div id="completion-modal" class="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 px-4 backdrop-blur-sm">
+    <div class="feature-surface w-full max-w-lg p-6 sm:p-7">
+      <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+        </svg>
+      </div>
+      <div class="mt-4 text-center">
+        <h2 class="text-xl font-bold text-slate-950">全試合完了しました</h2>
+        <p class="mt-2 text-sm leading-7 text-slate-600">
+          <%= @rotation.display_name %> の全試合が記録されました。<br>
+          同じ設定で <%= @rotation.round_number + 1 %> 周目を作成しますか？
         </p>
-        <div class="flex flex-col space-y-3">
-          <%= button_to "#{@rotation.round_number + 1}周目を作成する", copy_for_next_round_rotation_path(@rotation), method: :post, class: "w-full px-4 py-3 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700", form: { data: { turbo: false } } %>
-          <button onclick="closeCompletionModal()" class="w-full px-4 py-2 bg-gray-200 text-gray-700 font-semibold rounded-md hover:bg-gray-300">
-            後で作成する
-          </button>
-        </div>
+      </div>
+      <div class="mt-6 grid gap-3">
+        <%= button_to "#{@rotation.round_number + 1}周目を作成する", copy_for_next_round_rotation_path(@rotation), method: :post, class: app_button_classes(variant: :primary, full_width: true), form: { data: { turbo: false } } %>
+        <button type="button" onclick="closeCompletionModal()" class="<%= app_button_classes(variant: :secondary, full_width: true) %>">
+          後で作成する
+        </button>
       </div>
     </div>
   </div>
-
-  <style>
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
-        transform: scale(0.9);
-      }
-      to {
-        opacity: 1;
-        transform: scale(1);
-      }
-    }
-    .animate-fade-in {
-      animation: fadeIn 0.3s ease-out;
-    }
-  </style>
-
-  <script>
-    function closeCompletionModal() {
-      const modal = document.getElementById('completion-modal');
-      modal.style.opacity = '0';
-      setTimeout(() => {
-        modal.style.display = 'none';
-      }, 200);
-    }
-
-    // Prevent closing modal by clicking outside (optional)
-    document.getElementById('completion-modal').addEventListener('click', function(e) {
-      if (e.target === this) {
-        // Optionally allow closing by clicking backdrop
-        // closeCompletionModal();
-      }
-    });
-  </script>
 <% end %>
 
-<div class="py-8">
-  <!-- Header -->
-  <div class="mb-6">
-    <div class="flex justify-between items-start">
-      <div>
-        <h1 class="text-3xl font-bold text-gray-900"><%= @rotation.display_name %></h1>
-        <p class="mt-2 text-sm text-gray-600">
-          イベント: <%= link_to @rotation.event.name, @rotation.event, class: "text-blue-600 hover:text-blue-800" %>
-          (<%= @rotation.event.held_on.strftime('%Y/%m/%d') %>)
-        </p>
-        <div class="mt-2 flex items-center space-x-3">
-          <span class="px-3 py-1 inline-flex text-sm leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
-            <%= @rotation.round_number %>周目
-          </span>
-          <% if @rotation.is_active %>
-            <span class="px-3 py-1 inline-flex text-sm leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
-              🔴 アクティブ
-            </span>
+<div class="py-6 sm:py-8">
+  <div class="mb-4">
+    <%= link_to "← ローテーション一覧に戻る", rotations_path, class: "text-sm font-semibold text-indigo-600 transition hover:text-indigo-500" %>
+  </div>
+
+  <div class="feature-stack">
+    <section class="feature-hero feature-hero--accent px-5 py-6 sm:px-8 sm:py-8" <%= @rotation.is_active ? "data-controller=\"rotation-subscriber\" data-rotation-subscriber-rotation-id-value=\"#{@rotation.id}\"" : "" %>>
+      <div class="feature-hero__top">
+        <div>
+          <p class="feature-hero__eyebrow">Rotation Detail</p>
+          <h1 class="feature-hero__title"><%= @rotation.display_name %></h1>
+          <p class="feature-hero__description">
+            イベント:
+            <%= link_to @rotation.event.name, @rotation.event, class: "font-semibold text-white underline decoration-white/30 underline-offset-4" %>
+            <span class="text-white/70">(<%= @rotation.event.held_on.strftime("%Y/%m/%d") %>)</span>
+          </p>
+
+          <div class="feature-hero__meta">
+            <span class="feature-pill feature-pill--contrast"><%= @rotation.round_number %>周目</span>
+            <% if @rotation.is_active %>
+              <span class="feature-pill feature-pill--contrast">アクティブ</span>
+            <% else %>
+              <span class="feature-pill feature-pill--contrast">待機中</span>
+            <% end %>
+            <span class="feature-pill feature-pill--contrast"><%= completed_count %> / <%= total_match_count %> 試合完了</span>
+          </div>
+        </div>
+
+        <div class="feature-hero__actions">
+          <% if current_user.is_admin? %>
+            <% if @rotation.is_active %>
+              <%= button_to "非アクティブにする", deactivate_rotation_path(@rotation), method: :post, class: app_button_classes(variant: :neutral) %>
+            <% else %>
+              <%= button_to "アクティブにする", activate_rotation_path(@rotation), method: :post, class: app_button_classes(variant: :primary) %>
+            <% end %>
+
+            <div class="relative" data-controller="dropdown" data-action="click@window->dropdown#hide">
+              <button type="button" data-action="dropdown#toggle" class="<%= app_button_classes(variant: :secondary) %>">
+                その他
+                <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                  <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+                </svg>
+              </button>
+
+              <div data-dropdown-target="menu" class="hidden absolute right-0 z-20 mt-2 w-60 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl">
+                <div class="p-2">
+                  <%= button_to copy_for_next_round_rotation_path(@rotation), method: :post, class: "flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-semibold text-slate-700 transition hover:bg-slate-50", form: { data: { turbo: false } } do %>
+                    <svg class="h-5 w-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                    </svg>
+                    周回をコピー
+                  <% end %>
+
+                  <%= button_to rotation_path(@rotation), method: :delete, data: { turbo_confirm: "ローテーション「#{@rotation.display_name}」を削除してもよろしいですか？関連する試合データは削除されません。" }, class: "flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-semibold text-red-700 transition hover:bg-red-50" do %>
+                    <svg class="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                    </svg>
+                    削除
+                  <% end %>
+                </div>
+              </div>
+            </div>
           <% end %>
         </div>
       </div>
 
-      <div class="flex flex-wrap gap-3">
+      <div class="mt-6 feature-metric-grid">
+        <div class="feature-metric">
+          <div class="feature-metric__label">進捗率</div>
+          <div class="feature-metric__value"><%= progress.round %>%</div>
+          <div class="feature-metric__meta">記録済み <%= completed_count %> 試合</div>
+        </div>
+        <div class="feature-metric">
+          <div class="feature-metric__label">現在位置</div>
+          <div class="feature-metric__value">第<%= @rotation.current_match_index + 1 %>試合</div>
+          <div class="feature-metric__meta">全 <%= total_match_count %> 試合</div>
+        </div>
+        <div class="feature-metric">
+          <div class="feature-metric__label">残り試合</div>
+          <div class="feature-metric__value"><%= [total_match_count - completed_count, 0].max %></div>
+          <div class="feature-metric__meta">この周回で未記録の件数</div>
+        </div>
+      </div>
+
+      <div class="mt-5 feature-progress">
+        <div class="feature-progress__bar" style="width: <%= progress %>%"></div>
+      </div>
+    </section>
+
+    <% if @current_match.present? %>
+      <div class="feature-grid xl:grid-cols-[minmax(0,0.84fr)_minmax(0,1.16fr)]">
+        <section class="feature-surface p-5 sm:p-6">
+          <div class="feature-section-head feature-section-head--row">
+            <div>
+              <h2 class="feature-section-head__title">現在の試合</h2>
+              <p class="feature-section-head__meta">第<%= @rotation.current_match_index + 1 %>試合の進行状況</p>
+            </div>
+            <% if @current_match.match.present? %>
+              <span class="feature-pill feature-pill--success">記録済み</span>
+            <% else %>
+              <span class="feature-pill feature-pill--warning">未記録</span>
+            <% end %>
+          </div>
+
+          <div class="feature-match-grid">
+            <div class="feature-match-team">
+              <div class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">チーム1</div>
+              <div class="mt-3 space-y-2 text-sm">
+                <div class="font-semibold text-red-600">
+                  <%= @current_match.team1_player1.nickname %>
+                  <span class="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">配信台</span>
+                </div>
+                <div class="font-medium text-slate-900"><%= @current_match.team1_player2.nickname %></div>
+              </div>
+            </div>
+
+            <div class="feature-match-vs">VS</div>
+
+            <div class="feature-match-team">
+              <div class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">チーム2</div>
+              <div class="mt-3 space-y-2 text-sm">
+                <div class="font-medium text-slate-900"><%= @current_match.team2_player1.nickname %></div>
+                <div class="font-medium text-slate-900"><%= @current_match.team2_player2.nickname %></div>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <% if current_user.is_admin? %>
-          <% if @rotation.is_active %>
-            <%= button_to "非アクティブにする", deactivate_rotation_path(@rotation), method: :post, class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
-          <% else %>
-            <%= button_to "アクティブにする", activate_rotation_path(@rotation), method: :post, class: "px-4 py-2 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700" %>
-          <% end %>
-
-          <!-- Actions Dropdown -->
-          <div class="relative inline-block text-left" data-controller="dropdown">
-            <button type="button" onclick="toggleDropdown()" class="inline-flex justify-center items-center px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700">
-              その他
-              <svg class="-mr-1 ml-2 h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-              </svg>
-            </button>
-            <div id="dropdown-menu" class="hidden absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-10">
-              <div class="py-1">
-                <%= button_to copy_for_next_round_rotation_path(@rotation), method: :post, class: "w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center", form: { data: { turbo: false } } do %>
-                  <svg class="mr-3 h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
-                  </svg>
-                  周回をコピー
-                <% end %>
-                <%= button_to rotation_path(@rotation), method: :delete, data: { turbo_confirm: "ローテーション「#{@rotation.display_name}」を削除してもよろしいですか？関連する試合データは削除されません。" }, class: "w-full text-left px-4 py-2 text-sm text-red-700 hover:bg-gray-100 flex items-center" do %>
-                  <svg class="mr-3 h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
-                  </svg>
-                  削除
-                <% end %>
-              </div>
-            </div>
-          </div>
-
-          <script>
-            function toggleDropdown() {
-              const menu = document.getElementById('dropdown-menu');
-              menu.classList.toggle('hidden');
-            }
-
-            // Close dropdown when clicking outside
-            document.addEventListener('click', function(event) {
-              const dropdown = document.querySelector('[data-controller="dropdown"]');
-              const menu = document.getElementById('dropdown-menu');
-              if (dropdown && !dropdown.contains(event.target)) {
-                menu.classList.add('hidden');
-              }
-            });
-          </script>
-        <% end %>
-        <%= link_to "一覧に戻る", rotations_path, class: "px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" %>
-      </div>
-    </div>
-  </div>
-
-  <!-- Progress Bar -->
-  <div class="mb-6 bg-white shadow sm:rounded-lg p-6">
-    <% completed_count = @rotation_matches.count { |rm| rm.match.present? } %>
-    <div class="flex justify-between items-center mb-2">
-      <h3 class="text-lg font-semibold text-gray-900">進捗状況</h3>
-      <span class="text-sm text-gray-600">
-        <%= completed_count %> / <%= @rotation_matches.count %> 試合
-      </span>
-    </div>
-    <div class="w-full bg-gray-200 rounded-full h-4">
-      <% progress = @rotation_matches.count > 0 ? (completed_count.to_f / @rotation_matches.count * 100) : 0 %>
-      <div class="bg-blue-600 h-4 rounded-full transition-all duration-300" style="width: <%= progress %>%"></div>
-    </div>
-  </div>
-
-  <!-- Current Match -->
-  <% if @current_match.present? %>
-    <div class="mb-6 bg-indigo-100 shadow sm:rounded-lg p-6">
-      <div class="flex justify-between items-start mb-4">
-        <h3 class="text-xl font-bold text-gray-900">現在の試合（第<%= @rotation.current_match_index + 1 %>試合）</h3>
-        <% if @current_match.match.present? %>
-          <span class="px-3 py-1 inline-flex text-sm leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-            記録済み
-          </span>
-        <% else %>
-          <span class="px-3 py-1 inline-flex text-sm leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-            未記録
-          </span>
-        <% end %>
-      </div>
-
-      <!-- Match Display -->
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-        <!-- Team 1 -->
-        <div class="bg-white rounded-lg p-4 shadow">
-          <h4 class="text-sm font-semibold text-gray-500 mb-3">チーム1</h4>
-          <div class="space-y-2">
-            <div class="flex items-center">
-              <span class="text-sm font-bold text-red-600"><%= @current_match.team1_player1.nickname %></span>
-              <span class="ml-2 px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-            </div>
-            <div class="flex items-center">
-              <span class="text-sm font-medium text-gray-900"><%= @current_match.team1_player2.nickname %></span>
-            </div>
-          </div>
-        </div>
-
-        <!-- VS -->
-        <div class="flex items-center justify-center">
-          <span class="text-3xl font-bold text-gray-400">VS</span>
-        </div>
-
-        <!-- Team 2 -->
-        <div class="bg-white rounded-lg p-4 shadow">
-          <h4 class="text-sm font-semibold text-gray-500 mb-3">チーム2</h4>
-          <div class="space-y-2">
-            <div class="flex items-center">
-              <span class="text-sm font-medium text-gray-900"><%= @current_match.team2_player1.nickname %></span>
-            </div>
-            <div class="flex items-center">
-              <span class="text-sm font-medium text-gray-900"><%= @current_match.team2_player2.nickname %></span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Record Match Form -->
-      <% if current_user.is_admin? %>
-        <div class="bg-white rounded-lg p-6 shadow" id="match-record-container">
-          <div class="flex items-center justify-between mb-4">
-            <h4 class="text-lg font-semibold text-gray-900" id="form-title">
-              <% if @current_match.match.present? %>
-                試合結果を編集
-              <% else %>
-                試合結果を記録
-              <% end %>
-            </h4>
-            <span class="text-xs text-gray-500 hidden md:inline">💡 Tip: Tabキーで次の項目へ移動できます</span>
-          </div>
-          <form action="<% if @current_match.match.present? %><%= update_match_record_rotation_path(@rotation) %><% else %><%= record_match_rotation_path(@rotation) %><% end %>" method="post" data-turbo="false" id="match-record-form">
-            <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-            <%= hidden_field_tag :match_index, @rotation.current_match_index, id: 'editing_match_index' %>
-
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <!-- Team 1 Suits -->
+          <section class="feature-surface p-5 sm:p-6" id="match-record-container">
+            <div class="feature-section-head feature-section-head--row">
               <div>
-                <h5 class="text-sm font-semibold text-gray-700 mb-3">チーム1 使用機体</h5>
-                <div class="space-y-3">
-                  <div>
-                    <label class="block text-sm text-gray-600 mb-1"><%= @current_match.team1_player1.nickname %> <span class="text-red-500">*</span></label>
-                    <select name="team1_player1_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" data-has-favorites="<%= @current_match.team1_player1.user_favorite_suits.any? %>">
-                      <option value="">機体を選択...</option>
-                      <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team1_player1) %>
-                    </select>
-                  </div>
-                  <div>
-                    <label class="block text-sm text-gray-600 mb-1"><%= @current_match.team1_player2.nickname %> <span class="text-red-500">*</span></label>
-                    <select name="team1_player2_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" data-has-favorites="<%= @current_match.team1_player2.user_favorite_suits.any? %>">
-                      <option value="">機体を選択...</option>
-                      <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team1_player2) %>
-                    </select>
-                  </div>
-                </div>
+                <h2 class="feature-section-head__title" id="form-title">
+                  <% if @current_match.match.present? %>
+                    試合結果を編集
+                  <% else %>
+                    試合結果を記録
+                  <% end %>
+                </h2>
+                <p class="feature-section-head__meta">試合ごとの使用機体と勝敗をここで更新します</p>
               </div>
-
-              <!-- Team 2 Suits -->
-              <div>
-                <h5 class="text-sm font-semibold text-gray-700 mb-3">チーム2 使用機体</h5>
-                <div class="space-y-3">
-                  <div>
-                    <label class="block text-sm text-gray-600 mb-1"><%= @current_match.team2_player1.nickname %> <span class="text-red-500">*</span></label>
-                    <select name="team2_player1_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" data-has-favorites="<%= @current_match.team2_player1.user_favorite_suits.any? %>">
-                      <option value="">機体を選択...</option>
-                      <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team2_player1) %>
-                    </select>
-                  </div>
-                  <div>
-                    <label class="block text-sm text-gray-600 mb-1"><%= @current_match.team2_player2.nickname %> <span class="text-red-500">*</span></label>
-                    <select name="team2_player2_suit" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" data-has-favorites="<%= @current_match.team2_player2.user_favorite_suits.any? %>">
-                      <option value="">機体を選択...</option>
-                      <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team2_player2) %>
-                    </select>
-                  </div>
-                </div>
-              </div>
+              <span class="feature-inline-note hidden md:inline-flex">Tab キーで入力を移動できます</span>
             </div>
 
-            <!-- Winning Team -->
-            <div class="mt-6">
-              <label class="block text-sm font-semibold text-gray-700 mb-3">勝利チーム <span class="text-red-500">*</span></label>
-              <div class="flex space-x-4">
-                <div class="flex items-center">
-                  <input type="radio" name="winning_team" value="1" id="team1_win" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300">
-                  <label for="team1_win" class="ml-2 block text-sm text-gray-900">チーム1</label>
-                </div>
-                <div class="flex items-center">
-                  <input type="radio" name="winning_team" value="2" id="team2_win" class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300">
-                  <label for="team2_win" class="ml-2 block text-sm text-gray-900">チーム2</label>
-                </div>
-              </div>
-            </div>
+            <form action="<% if @current_match.match.present? %><%= update_match_record_rotation_path(@rotation) %><% else %><%= record_match_rotation_path(@rotation) %><% end %>" method="post" data-turbo="false" id="match-record-form">
+              <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+              <%= hidden_field_tag :match_index, @rotation.current_match_index, id: "editing_match_index" %>
 
-            <!-- Submit Button -->
-            <div class="mt-6 flex justify-between items-center">
-              <div class="text-xs text-gray-500">
-                <span class="font-medium">必須項目：</span>各プレイヤーの機体 + 勝利チーム
+              <div class="grid gap-6 lg:grid-cols-2">
+                <div class="feature-surface feature-surface--muted p-4">
+                  <h3 class="text-sm font-semibold text-slate-700">チーム1 使用機体</h3>
+                  <div class="mt-4 space-y-4">
+                    <div>
+                      <label class="mb-1 block text-sm text-slate-600"><%= @current_match.team1_player1.nickname %> <span class="text-red-500">*</span></label>
+                      <select name="team1_player1_suit" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2.5 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100" data-has-favorites="<%= @current_match.team1_player1.user_favorite_suits.any? %>">
+                        <option value="">機体を選択...</option>
+                        <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team1_player1) %>
+                      </select>
+                    </div>
+                    <div>
+                      <label class="mb-1 block text-sm text-slate-600"><%= @current_match.team1_player2.nickname %> <span class="text-red-500">*</span></label>
+                      <select name="team1_player2_suit" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2.5 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100" data-has-favorites="<%= @current_match.team1_player2.user_favorite_suits.any? %>">
+                        <option value="">機体を選択...</option>
+                        <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team1_player2) %>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="feature-surface feature-surface--muted p-4">
+                  <h3 class="text-sm font-semibold text-slate-700">チーム2 使用機体</h3>
+                  <div class="mt-4 space-y-4">
+                    <div>
+                      <label class="mb-1 block text-sm text-slate-600"><%= @current_match.team2_player1.nickname %> <span class="text-red-500">*</span></label>
+                      <select name="team2_player1_suit" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2.5 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100" data-has-favorites="<%= @current_match.team2_player1.user_favorite_suits.any? %>">
+                        <option value="">機体を選択...</option>
+                        <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team2_player1) %>
+                      </select>
+                    </div>
+                    <div>
+                      <label class="mb-1 block text-sm text-slate-600"><%= @current_match.team2_player2.nickname %> <span class="text-red-500">*</span></label>
+                      <select name="team2_player2_suit" class="w-full rounded-2xl border border-slate-200 bg-white px-3 py-2.5 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100" data-has-favorites="<%= @current_match.team2_player2.user_favorite_suits.any? %>">
+                        <option value="">機体を選択...</option>
+                        <%= mobile_suit_options_with_favorites(@all_mobile_suits, @current_match.team2_player2) %>
+                      </select>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div class="flex space-x-3">
-                <button type="button" id="cancel-edit-btn" onclick="cancelEdit()" class="px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700" style="display: none;">
-                  キャンセル
-                </button>
-                <% unless @current_match.match.present? %>
-                  <button type="button" id="skip-match-btn" onclick="if(confirm('この試合をスキップしますか？')) { document.getElementById('skip-match-form').submit(); }" class="px-4 py-2 bg-gray-600 text-white font-semibold rounded-md hover:bg-gray-700">
-                    試合をスキップ
+
+              <div class="mt-6 feature-surface feature-surface--muted p-4">
+                <label class="block text-sm font-semibold text-slate-700">勝利チーム <span class="text-red-500">*</span></label>
+                <div class="mt-3 flex flex-wrap gap-4">
+                  <label class="inline-flex items-center gap-2 text-sm text-slate-900">
+                    <input type="radio" name="winning_team" value="1" id="team1_win" class="h-4 w-4 border-slate-300 text-indigo-600 focus:ring-indigo-500">
+                    チーム1
+                  </label>
+                  <label class="inline-flex items-center gap-2 text-sm text-slate-900">
+                    <input type="radio" name="winning_team" value="2" id="team2_win" class="h-4 w-4 border-slate-300 text-indigo-600 focus:ring-indigo-500">
+                    チーム2
+                  </label>
+                </div>
+              </div>
+
+              <div class="mt-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div class="text-xs text-slate-500">
+                  <span class="font-semibold text-slate-700">必須項目:</span>
+                  各プレイヤーの機体と勝利チーム
+                </div>
+
+                <div class="flex flex-wrap gap-3">
+                  <button type="button" id="cancel-edit-btn" onclick="cancelEdit()" class="<%= app_button_classes(variant: :secondary) %>" style="display: none;">
+                    キャンセル
                   </button>
-                <% end %>
-                <% if @current_match.match.present? && @rotation.current_match_index < @rotation_matches.count - 1 %>
-                  <%= button_to "次の試合へ →", next_match_rotation_path(@rotation), method: :post, id: "next-match-btn", class: "px-4 py-2 bg-green-600 text-white font-semibold rounded-md hover:bg-green-700", form: { data: { turbo: false } } %>
-                <% end %>
-                <button type="submit" id="submit-btn" class="px-6 py-3 bg-indigo-600 text-white font-semibold rounded-md hover:bg-indigo-700">
-                  <span id="submit-btn-text">
-                    <% if @current_match.match.present? %>
-                      ✓ 更新
-                    <% else %>
-                      ✓ 記録して次へ
-                    <% end %>
-                  </span>
-                </button>
+                  <% unless @current_match.match.present? %>
+                    <button type="button" id="skip-match-btn" onclick="if (confirm('この試合をスキップしますか？')) { document.getElementById('skip-match-form').submit(); }" class="<%= app_button_classes(variant: :neutral) %>">
+                      試合をスキップ
+                    </button>
+                  <% end %>
+                  <% if @current_match.match.present? && @rotation.current_match_index < @rotation_matches.count - 1 %>
+                    <%= button_to "次の試合へ", next_match_rotation_path(@rotation), method: :post, id: "next-match-btn", class: app_button_classes(variant: :success), form: { data: { turbo: false } } %>
+                  <% end %>
+                  <button type="submit" id="submit-btn" class="<%= app_button_classes(variant: :primary) %>">
+                    <span id="submit-btn-text">
+                      <% if @current_match.match.present? %>
+                        更新
+                      <% else %>
+                        記録して次へ
+                      <% end %>
+                    </span>
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
 
-          <!-- Skip Match Form (hidden) -->
-          <form id="skip-match-form" action="<%= next_match_rotation_path(@rotation) %>" method="post" style="display:none;" data-turbo="false">
-            <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-          </form>
-
-          <script>
-            // Edit match function with simplified parameters
-            function editMatchById(matchIndex, matchId, winningTeam, suit1, suit2, suit3, suit4) {
-              console.log('Editing match:', matchIndex, matchId, winningTeam, suit1, suit2, suit3, suit4);
-
-              // Update form title
-              document.getElementById('form-title').textContent = '試合結果を編集（第' + (matchIndex + 1) + '試合）';
-
-              // Update form action to update endpoint
-              const form = document.getElementById('match-record-form');
-              form.action = '<%= update_match_record_rotation_path(@rotation) %>';
-
-              // Set match index
-              document.getElementById('editing_match_index').value = matchIndex;
-
-              // Set mobile suits using TomSelect
-              const select1 = document.querySelector('select[name="team1_player1_suit"]');
-              if (select1 && select1.tomselect) {
-                select1.tomselect.setValue(suit1.toString());
-              }
-
-              const select2 = document.querySelector('select[name="team1_player2_suit"]');
-              if (select2 && select2.tomselect) {
-                select2.tomselect.setValue(suit2.toString());
-              }
-
-              const select3 = document.querySelector('select[name="team2_player1_suit"]');
-              if (select3 && select3.tomselect) {
-                select3.tomselect.setValue(suit3.toString());
-              }
-
-              const select4 = document.querySelector('select[name="team2_player2_suit"]');
-              if (select4 && select4.tomselect) {
-                select4.tomselect.setValue(suit4.toString());
-              }
-
-              // Set winning team
-              if (winningTeam === 1) {
-                document.getElementById('team1_win').checked = true;
-              } else {
-                document.getElementById('team2_win').checked = true;
-              }
-
-              // Update button text and visibility
-              document.getElementById('submit-btn-text').textContent = '✓ 更新';
-
-              const skipBtn = document.getElementById('skip-match-btn');
-              if (skipBtn) {
-                skipBtn.style.display = 'none';
-              }
-
-              document.getElementById('cancel-edit-btn').style.display = 'inline-block';
-
-              // Hide "next match" button if editing a different match
-              const nextMatchBtn = document.getElementById('next-match-btn');
-              if (nextMatchBtn) {
-                nextMatchBtn.style.display = 'none';
-              }
-
-              // Scroll to form
-              document.getElementById('match-record-container').scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }
-
-            // Cancel edit function
-            function cancelEdit() {
-              // Reload the page to reset to current match state
-              window.location.reload();
-            }
-
-            // Initialize Tom-Select for mobile suit selects
-            function initializeTomSelect() {
-              const selects = document.querySelectorAll('select[name*="_suit"]');
-              selects.forEach(function(select) {
-                // Skip if already initialized
-                if (select.tomselect) {
-                  return;
-                }
-
-                const optgroups = select.dataset.hasFavorites === 'true'
-                  ? [{ value: 'favorites', label: '★ お気に入り機体' }, { value: 'others', label: '── その他の機体 ──' }]
-                  : [];
-                new TomSelect(select, {
-                  placeholder: '機体を検索...',
-                  allowEmptyOption: true,
-                  plugins: ['clear_button'],
-                  optgroupField: 'optgroup',
-                  optgroups: optgroups,
-                  render: {
-                    no_results: function(data, escape) {
-                      return '<div class="no-results">該当する機体が見つかりません</div>';
-                    }
-                  }
-                });
-              });
-            }
-
-            function initializeFormValidation() {
-              const form = document.getElementById('match-record-form');
-              if (!form) return;
-
-              // Check if already initialized
-              if (form.dataset.validationInitialized === 'true') return;
-              form.dataset.validationInitialized = 'true';
-
-              // Form validation
-              form.addEventListener('submit', function(e) {
-                const team1p1 = document.querySelector('select[name="team1_player1_suit"]').value;
-                const team1p2 = document.querySelector('select[name="team1_player2_suit"]').value;
-                const team2p1 = document.querySelector('select[name="team2_player1_suit"]').value;
-                const team2p2 = document.querySelector('select[name="team2_player2_suit"]').value;
-                const winner = document.querySelector('input[name="winning_team"]:checked');
-
-                if (!team1p1 || !team1p2 || !team2p1 || !team2p2) {
-                  e.preventDefault();
-                  alert('すべてのプレイヤーの機体を選択してください');
-                  return false;
-                }
-
-                if (!winner) {
-                  e.preventDefault();
-                  alert('勝利チームを選択してください');
-                  return false;
-                }
-
-                return true;
-              });
-
-              // Keyboard shortcuts
-              document.addEventListener('keydown', function(e) {
-                // Ctrl/Cmd + Enter to submit form
-                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-                  e.preventDefault();
-                  if (form.reportValidity()) {
-                    form.submit();
-                  }
-                }
-              });
-            }
-
-            // Initialize on both DOMContentLoaded and turbo:load
-            document.addEventListener('DOMContentLoaded', function() {
-              initializeTomSelect();
-              initializeFormValidation();
-
-              <% if @current_match.match.present? && !@show_completion_modal %>
-                // Load current match data for editing
-                <%
-                  mp1 = @current_match.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 1 }
-                  mp2 = @current_match.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 2 }
-                  mp3 = @current_match.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 3 }
-                  mp4 = @current_match.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 4 }
-                %>
-                setTimeout(function() {
-                  editMatchById(<%= @rotation.current_match_index %>, <%= @current_match.match.id %>, <%= @current_match.match.winning_team %>, <%= mp1&.mobile_suit_id %>, <%= mp2&.mobile_suit_id %>, <%= mp3&.mobile_suit_id %>, <%= mp4&.mobile_suit_id %>);
-                }, 100);
-              <% end %>
-            });
-
-            document.addEventListener('turbo:load', function() {
-              initializeTomSelect();
-              initializeFormValidation();
-
-              <% if @current_match.match.present? && !@show_completion_modal %>
-                // Load current match data for editing
-                <%
-                  mp1 = @current_match.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 1 }
-                  mp2 = @current_match.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 2 }
-                  mp3 = @current_match.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 3 }
-                  mp4 = @current_match.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 4 }
-                %>
-                setTimeout(function() {
-                  editMatchById(<%= @rotation.current_match_index %>, <%= @current_match.match.id %>, <%= @current_match.match.winning_team %>, <%= mp1&.mobile_suit_id %>, <%= mp2&.mobile_suit_id %>, <%= mp3&.mobile_suit_id %>, <%= mp4&.mobile_suit_id %>);
-                }, 100);
-              <% end %>
-            });
-
-            // Also initialize immediately in case the script runs after DOM is ready
-            if (document.readyState === 'loading') {
-              // DOM not ready, wait for event
-            } else {
-              // DOM is ready, initialize now
-              initializeTomSelect();
-              initializeFormValidation();
-
-              <% if @current_match.match.present? && !@show_completion_modal %>
-                // Load current match data for editing
-                <%
-                  mp1 = @current_match.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 1 }
-                  mp2 = @current_match.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 2 }
-                  mp3 = @current_match.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 3 }
-                  mp4 = @current_match.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 4 }
-                %>
-                setTimeout(function() {
-                  editMatchById(<%= @rotation.current_match_index %>, <%= @current_match.match.id %>, <%= @current_match.match.winning_team %>, <%= mp1&.mobile_suit_id %>, <%= mp2&.mobile_suit_id %>, <%= mp3&.mobile_suit_id %>, <%= mp4&.mobile_suit_id %>);
-                }, 100);
-              <% end %>
-            }
-          </script>
+            <form id="skip-match-form" action="<%= next_match_rotation_path(@rotation) %>" method="post" style="display: none;" data-turbo="false">
+              <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+            </form>
+          </section>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="feature-surface p-5 sm:p-6">
+        <div class="empty-state">
+          <p class="empty-state__title">現在進行中の試合はありません</p>
+          <p class="empty-state__description mt-2">このローテーションの記録がすべて完了したか、まだ試合が開始されていません。</p>
         </div>
-<% end %>
-    </div>
-  <% end %>
+      </div>
+    <% end %>
 
-  <!-- All Matches List -->
-  <div class="bg-white shadow sm:rounded-lg">
-    <div class="px-6 py-5 border-b border-gray-200">
-      <div class="flex items-center justify-between">
-        <h3 class="text-lg font-semibold text-gray-900">全試合一覧</h3>
-        <div class="flex items-center space-x-2 text-xs text-gray-500">
-          <div class="flex items-center">
-            <span class="w-3 h-3 bg-blue-100 border border-blue-300 rounded mr-1"></span>
-            <span>記録済み</span>
+    <section class="feature-surface">
+      <div class="p-5 sm:p-6">
+        <div class="feature-section-head feature-section-head--row">
+          <div>
+            <h2 class="feature-section-head__title">全試合一覧</h2>
+            <p class="feature-section-head__meta">セット区切りと記録状態をまとめて確認できます</p>
           </div>
-          <div class="flex items-center ml-3">
-            <span class="w-3 h-3 bg-indigo-100 border border-indigo-300 rounded mr-1"></span>
-            <span>現在の試合</span>
-          </div>
-          <div class="flex items-center ml-3">
-            <span class="w-3 h-3 bg-gray-100 border border-gray-300 rounded mr-1"></span>
-            <span>スキップ</span>
+          <div class="flex flex-wrap gap-2">
+            <span class="feature-pill feature-pill--success">記録済み</span>
+            <span class="feature-pill feature-pill--accent">現在の試合</span>
+            <span class="feature-pill feature-pill--surface">スキップ済み</span>
           </div>
         </div>
       </div>
-    </div>
-    <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              試合
-            </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              チーム1
-            </th>
-            <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-              VS
-            </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              チーム2
-            </th>
-            <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-              状態
-            </th>
-          </tr>
-        </thead>
-        <tbody class="bg-white">
+
+      <div class="px-5 pb-5 sm:px-6 sm:pb-6">
+        <ul class="feature-list">
           <% mps = @rotation.matches_per_set %>
           <% @rotation_matches.each_with_index do |rm, index| %>
             <%
-              # 人数に応じた1セットあたりの試合数（8人: 6試合、それ以外: 3試合）
               set_number = index / mps
               is_set_start = (index % mps == 0)
-              in_set_position = index % mps
-
-              # 背景色（現在の試合のみハイライト）
-              if index == @rotation.current_match_index
-                row_bg = "bg-indigo-100"  # 現在の試合
-              else
-                row_bg = "bg-white"
-              end
-
-              # セット間の境界線（セットの最初かつ最初の試合ではない場合）
-              border_class = (is_set_start && index > 0) ? "border-t-4 border-indigo-300" : "border-t border-gray-200"
+              mp1 = rm.match&.match_players&.find { |mp| mp.position == 1 }
+              mp2 = rm.match&.match_players&.find { |mp| mp.position == 2 }
+              mp3 = rm.match&.match_players&.find { |mp| mp.position == 3 }
+              mp4 = rm.match&.match_players&.find { |mp| mp.position == 4 }
+              state_pill =
+                if index == @rotation.current_match_index
+                  ['feature-pill feature-pill--accent', '現在の試合']
+                elsif rm.match.present?
+                  ['feature-pill feature-pill--success', '記録済み']
+                elsif index < @rotation.current_match_index
+                  ['feature-pill feature-pill--surface', 'スキップ']
+                else
+                  ['feature-pill feature-pill--warning', '未記録']
+                end
             %>
-            <tr class="<%= row_bg %> <%= border_class %> hover:bg-gray-100 transition <%= rm.match ? 'cursor-pointer' : '' %>" <% if rm.match %>onclick="window.location='<%= match_path(rm.match) %>'"<% end %>>
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="flex items-center">
-                  <% if is_set_start %>
-                    <div class="flex flex-col items-start">
-                      <span class="text-xs font-semibold text-indigo-600 mb-1">第<%= set_number + 1 %>セット</span>
-                      <span class="text-sm font-medium text-gray-900">第<%= index + 1 %>試合</span>
+            <li>
+              <div class="feature-list-item <%= 'feature-list-item--clickable' if rm.match.present? %>"
+                   <% if rm.match.present? %>data-controller="card-link" data-card-link-url-value="<%= match_path(rm.match) %>" data-action="click->card-link#navigate"<% end %>>
+                <div class="flex flex-col gap-4">
+                  <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <% if is_set_start %>
+                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-indigo-600">第<%= set_number + 1 %>セット</div>
+                      <% end %>
+                      <div class="mt-1 text-lg font-semibold text-slate-950">第<%= index + 1 %>試合</div>
                     </div>
-                  <% else %>
-                    <span class="text-sm font-medium text-gray-900 ml-1">第<%= index + 1 %>試合</span>
-                  <% end %>
-                  <% if index == @rotation.current_match_index %>
-                    <span class="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-600 text-white">
-                      現在
-                    </span>
-                  <% end %>
-                </div>
-              </td>
-              <%
-                mp1 = rm.match&.match_players&.find { |mp| mp.position == 1 }
-                mp2 = rm.match&.match_players&.find { |mp| mp.position == 2 }
-                mp3 = rm.match&.match_players&.find { |mp| mp.position == 3 }
-                mp4 = rm.match&.match_players&.find { |mp| mp.position == 4 }
-              %>
-              <td class="px-6 py-4 whitespace-nowrap <%= rm.match ? (rm.match.winning_team == 1 ? 'bg-sky-50/70' : 'bg-red-50/70') : '' %>">
-                <div class="flex items-start justify-between gap-2">
-                  <div class="text-sm text-gray-900">
-                    <span class="font-bold text-red-600"><%= rm.team1_player1.nickname %></span>
-                    <span class="ml-1 px-1.5 py-0.5 bg-red-100 text-red-700 rounded text-xs font-semibold">配信台</span>
-                    <% if mp1&.mobile_suit %>
-                      <a href="<%= mobile_suit_path(mp1.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp1.mobile_suit.name %>)</a>
-                    <% end %>
-                    <br>
-                    <%= rm.team1_player2.nickname %>
-                    <% if mp2&.mobile_suit %>
-                      <a href="<%= mobile_suit_path(mp2.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp2.mobile_suit.name %>)</a>
-                    <% end %>
+                    <span class="<%= state_pill[0] %>"><%= state_pill[1] %></span>
                   </div>
-                  <% if rm.match %>
-                    <span class="shrink-0 px-2.5 py-1 rounded-full text-xs font-bold leading-none <%= rm.match.winning_team == 1 ? 'bg-sky-100 text-sky-700' : 'bg-red-100 text-red-600' %>">
-                      <%= rm.match.winning_team == 1 ? 'WIN' : 'LOSE' %>
-                    </span>
-                  <% end %>
-                </div>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-center">
-                <span class="text-gray-400 font-semibold">VS</span>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap <%= rm.match ? (rm.match.winning_team == 2 ? 'bg-sky-50/70' : 'bg-red-50/70') : '' %>">
-                <div class="flex items-start justify-between gap-2">
-                  <div class="text-sm text-gray-900">
-                    <%= rm.team2_player1.nickname %>
-                    <% if mp3&.mobile_suit %>
-                      <a href="<%= mobile_suit_path(mp3.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp3.mobile_suit.name %>)</a>
-                    <% end %>
-                    <br>
-                    <%= rm.team2_player2.nickname %>
-                    <% if mp4&.mobile_suit %>
-                      <a href="<%= mobile_suit_path(mp4.mobile_suit) %>" class="ml-1 text-xs text-gray-500 hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp4.mobile_suit.name %>)</a>
-                    <% end %>
-                  </div>
-                  <% if rm.match %>
-                    <span class="shrink-0 px-2.5 py-1 rounded-full text-xs font-bold leading-none <%= rm.match.winning_team == 2 ? 'bg-sky-100 text-sky-700' : 'bg-red-100 text-red-600' %>">
-                      <%= rm.match.winning_team == 2 ? 'WIN' : 'LOSE' %>
-                    </span>
-                  <% end %>
-                </div>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-center">
-                <% if rm.match %>
-                  <div class="flex flex-col items-center space-y-2">
-                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-                      記録済み
-                    </span>
-                    <% if current_user.is_admin? %>
-                      <div class="flex items-center justify-center space-x-2" onclick="event.stopPropagation()">
-                        <a href="#match-record-container"
-                           onclick="editMatchById(<%= index %>, <%= rm.match.id %>, <%= rm.match.winning_team %>, <%= rm.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 1 }.mobile_suit_id %>, <%= rm.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 2 }.mobile_suit_id %>, <%= rm.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 3 }.mobile_suit_id %>, <%= rm.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 4 }.mobile_suit_id %>); return false;"
-                           class="text-xs text-blue-600 hover:text-blue-800 underline cursor-pointer">
-                          編集
-                        </a>
-                        <span class="text-gray-300">|</span>
-                        <%= button_to "削除", match_path(rm.match), method: :delete, data: { turbo_confirm: "この試合記録を削除してもよろしいですか？" }, class: "text-xs text-red-600 hover:text-red-800 underline", form: { style: "display: inline;" } %>
-                      </div>
-                    <% end %>
-                  </div>
-                <% elsif index < @rotation.current_match_index %>
-                  <div class="flex flex-col items-center space-y-1">
-                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
-                      スキップ
-                    </span>
-                    <% if current_user.is_admin? %>
-                      <div onclick="event.stopPropagation()">
-                        <%= button_to "ここに戻る", go_to_match_rotation_path(@rotation, match_index: index), method: :post, class: "text-xs text-gray-500 hover:text-gray-700 underline", form: { data: { turbo: false } } %>
-                      </div>
-                    <% end %>
-                  </div>
-                <% else %>
-                  <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                    未記録
-                  </span>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </div>
 
-  <!-- Player Statistics -->
-  <div class="mt-6 bg-white shadow sm:rounded-lg">
-    <div class="px-6 py-5 border-b border-gray-200">
-      <div class="flex items-center justify-between">
-        <div>
-          <h3 class="text-lg font-semibold text-gray-900">プレイヤー統計（平等性チェック）</h3>
-          <p class="mt-1 text-sm text-gray-500">各プレイヤーの試合数（記録済 / 計画）、ペア回数、対戦相手回数が均等に配分されているか確認できます</p>
-        </div>
-        <span class="text-xs text-gray-500" title="試合数の偏りがないか確認">ℹ️ 公平性</span>
-      </div>
-    </div>
-    <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              プレイヤー
-            </th>
-            <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-              試合数<br><span class="normal-case font-normal">(記録済 / 計画)</span>
-            </th>
-            <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-              配信台回数<br><span class="normal-case font-normal">(記録済 / 計画)</span>
-            </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              最もペアを組んだ相手
-            </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              最も対戦した相手
-            </th>
-          </tr>
-        </thead>
-        <tbody class="bg-white divide-y divide-gray-200">
-          <% @player_statistics.each do |player_id, stats| %>
-            <tr class="hover:bg-gray-50">
-              <td class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm font-medium text-gray-900">
-                  <%= stats[:user].nickname %>
-                  <% if stats[:user].id == current_user.id %>
-                    <span class="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
-                      あなた
-                    </span>
-                  <% end %>
-                </div>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-center">
-                <span class="text-sm font-semibold text-gray-900"><%= stats[:registered_match_count] %></span>
-                <span class="text-xs text-gray-400"> / <%= stats[:match_count] %></span>
-              </td>
-              <td class="px-6 py-4 whitespace-nowrap text-center">
-                <span class="text-sm font-semibold text-gray-900"><%= stats[:registered_streaming_count] %></span>
-                <span class="text-xs text-gray-400"> / <%= stats[:streaming_count] %></span>
-              </td>
-              <td class="px-6 py-4">
-                <div class="text-sm text-gray-700">
-                  <% if stats[:pair_counts].any? %>
-                    <% top_pairs = stats[:pair_counts].sort_by { |_, count| -count }.first(3) %>
-                    <% top_pairs.each do |partner_id, count| %>
-                      <% partner = User.find(partner_id) %>
-                      <div class="text-xs">
-                        <%= partner.nickname %>: <span class="font-semibold"><%= count %>回</span>
+                  <div class="feature-match-grid">
+                    <div class="feature-match-team <%= rm.match ? (rm.match.winning_team == 1 ? 'bg-sky-50' : 'bg-rose-50') : '' %>">
+                      <div class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">チーム1</div>
+                      <div class="mt-3 space-y-2 text-sm text-slate-900">
+                        <div>
+                          <span class="font-semibold text-red-600"><%= rm.team1_player1.nickname %></span>
+                          <span class="ml-2 rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700">配信台</span>
+                          <% if mp1&.mobile_suit %>
+                            <a href="<%= mobile_suit_path(mp1.mobile_suit) %>" class="ml-1 text-xs text-slate-500 transition hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp1.mobile_suit.name %>)</a>
+                          <% end %>
+                        </div>
+                        <div>
+                          <span class="font-medium"><%= rm.team1_player2.nickname %></span>
+                          <% if mp2&.mobile_suit %>
+                            <a href="<%= mobile_suit_path(mp2.mobile_suit) %>" class="ml-1 text-xs text-slate-500 transition hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp2.mobile_suit.name %>)</a>
+                          <% end %>
+                        </div>
                       </div>
-                    <% end %>
-                  <% else %>
-                    <span class="text-gray-400">-</span>
-                  <% end %>
-                </div>
-              </td>
-              <td class="px-6 py-4">
-                <div class="text-sm text-gray-700">
-                  <% if stats[:opponent_counts].any? %>
-                    <% top_opponents = stats[:opponent_counts].sort_by { |_, count| -count }.first(3) %>
-                    <% top_opponents.each do |opponent_id, count| %>
-                      <% opponent = User.find(opponent_id) %>
-                      <div class="text-xs">
-                        <%= opponent.nickname %>: <span class="font-semibold"><%= count %>回</span>
+                    </div>
+
+                    <div class="feature-match-vs">VS</div>
+
+                    <div class="feature-match-team <%= rm.match ? (rm.match.winning_team == 2 ? 'bg-sky-50' : 'bg-rose-50') : '' %>">
+                      <div class="text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">チーム2</div>
+                      <div class="mt-3 space-y-2 text-sm text-slate-900">
+                        <div>
+                          <span class="font-medium"><%= rm.team2_player1.nickname %></span>
+                          <% if mp3&.mobile_suit %>
+                            <a href="<%= mobile_suit_path(mp3.mobile_suit) %>" class="ml-1 text-xs text-slate-500 transition hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp3.mobile_suit.name %>)</a>
+                          <% end %>
+                        </div>
+                        <div>
+                          <span class="font-medium"><%= rm.team2_player2.nickname %></span>
+                          <% if mp4&.mobile_suit %>
+                            <a href="<%= mobile_suit_path(mp4.mobile_suit) %>" class="ml-1 text-xs text-slate-500 transition hover:text-indigo-600 hover:underline" onclick="event.stopPropagation()">(<%= mp4.mobile_suit.name %>)</a>
+                          <% end %>
+                        </div>
                       </div>
-                    <% end %>
-                  <% else %>
-                    <span class="text-gray-400">-</span>
+                    </div>
+                  </div>
+
+                  <% if rm.match.present? && current_user.is_admin? %>
+                    <div class="flex flex-wrap gap-3 text-sm" onclick="event.stopPropagation()">
+                      <a href="#match-record-container"
+                         onclick="editMatchById(<%= index %>, <%= rm.match.id %>, <%= rm.match.winning_team %>, <%= rm.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 1 }.mobile_suit_id %>, <%= rm.match.match_players.find { |mp| mp.team_number == 1 && mp.position == 2 }.mobile_suit_id %>, <%= rm.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 3 }.mobile_suit_id %>, <%= rm.match.match_players.find { |mp| mp.team_number == 2 && mp.position == 4 }.mobile_suit_id %>); return false;"
+                         class="font-semibold text-indigo-600 transition hover:text-indigo-500">
+                        編集
+                      </a>
+                      <%= button_to "削除", match_path(rm.match), method: :delete, data: { turbo_confirm: "この試合記録を削除してもよろしいですか？" }, class: "font-semibold text-red-600 transition hover:text-red-500", form: { style: "display: inline;" } %>
+                    </div>
+                  <% elsif !rm.match.present? && index < @rotation.current_match_index && current_user.is_admin? %>
+                    <div onclick="event.stopPropagation()">
+                      <%= button_to "ここに戻る", go_to_match_rotation_path(@rotation, match_index: index), method: :post, class: app_button_classes(variant: :secondary, size: :sm), form: { data: { turbo: false } } %>
+                    </div>
                   <% end %>
                 </div>
-              </td>
-            </tr>
+              </div>
+            </li>
           <% end %>
-        </tbody>
-      </table>
-    </div>
+        </ul>
+      </div>
+    </section>
+
+    <section class="feature-surface">
+      <div class="p-5 sm:p-6">
+        <div class="feature-section-head feature-section-head--row">
+          <div>
+            <h2 class="feature-section-head__title">プレイヤー統計</h2>
+            <p class="feature-section-head__meta">平等性チェック用に、試合数と組み合わせの偏りを確認します</p>
+          </div>
+          <span class="feature-inline-note">試合配分の偏り確認</span>
+        </div>
+      </div>
+
+      <div class="overflow-x-auto border-t border-slate-100">
+        <table class="min-w-full divide-y divide-slate-200">
+          <thead class="bg-slate-50/80">
+            <tr>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">プレイヤー</th>
+              <th scope="col" class="px-6 py-3 text-center text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">試合数<br><span class="normal-case font-normal">(記録済 / 計画)</span></th>
+              <th scope="col" class="px-6 py-3 text-center text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">配信台回数<br><span class="normal-case font-normal">(記録済 / 計画)</span></th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">最もペアを組んだ相手</th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-[0.12em] text-slate-500">最も対戦した相手</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-100 bg-white">
+            <% @player_statistics.each do |_player_id, stats| %>
+              <tr class="transition hover:bg-slate-50/80">
+                <td class="px-6 py-4 whitespace-nowrap">
+                  <div class="text-sm font-semibold text-slate-900">
+                    <%= stats[:user].nickname %>
+                    <% if stats[:user].id == current_user.id %>
+                      <span class="ml-2 rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">あなた</span>
+                    <% end %>
+                  </div>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-center">
+                  <span class="text-sm font-semibold text-slate-900"><%= stats[:registered_match_count] %></span>
+                  <span class="text-xs text-slate-400"> / <%= stats[:match_count] %></span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-center">
+                  <span class="text-sm font-semibold text-slate-900"><%= stats[:registered_streaming_count] %></span>
+                  <span class="text-xs text-slate-400"> / <%= stats[:streaming_count] %></span>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="space-y-1 text-sm text-slate-700">
+                    <% if stats[:pair_counts].any? %>
+                      <% stats[:pair_counts].sort_by { |_, count| -count }.first(3).each do |partner_id, count| %>
+                        <% partner = User.find(partner_id) %>
+                        <div class="text-xs">
+                          <%= partner.nickname %>: <span class="font-semibold"><%= count %>回</span>
+                        </div>
+                      <% end %>
+                    <% else %>
+                      <span class="text-slate-400">-</span>
+                    <% end %>
+                  </div>
+                </td>
+                <td class="px-6 py-4">
+                  <div class="space-y-1 text-sm text-slate-700">
+                    <% if stats[:opponent_counts].any? %>
+                      <% stats[:opponent_counts].sort_by { |_, count| -count }.first(3).each do |opponent_id, count| %>
+                        <% opponent = User.find(opponent_id) %>
+                        <div class="text-xs">
+                          <%= opponent.nickname %>: <span class="font-semibold"><%= count %>回</span>
+                        </div>
+                      <% end %>
+                    <% else %>
+                      <span class="text-slate-400">-</span>
+                    <% end %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </section>
   </div>
 </div>
+
+<script>
+  function closeCompletionModal() {
+    const modal = document.getElementById("completion-modal")
+    if (modal) modal.classList.add("hidden")
+  }
+
+  function editMatchById(matchIndex, matchId, winningTeam, suit1, suit2, suit3, suit4) {
+    const form = document.getElementById("match-record-form")
+    if (!form) return
+
+    document.getElementById("form-title").textContent = `試合結果を編集（第${matchIndex + 1}試合）`
+    form.action = "<%= update_match_record_rotation_path(@rotation) %>"
+    document.getElementById("editing_match_index").value = matchIndex
+
+    const suitMappings = [
+      ["team1_player1_suit", suit1],
+      ["team1_player2_suit", suit2],
+      ["team2_player1_suit", suit3],
+      ["team2_player2_suit", suit4]
+    ]
+
+    suitMappings.forEach(([name, value]) => {
+      const select = document.querySelector(`select[name="${name}"]`)
+      if (!select) return
+
+      if (select.tomselect) {
+        select.tomselect.setValue(value ? value.toString() : "")
+      } else {
+        select.value = value || ""
+      }
+    })
+
+    document.getElementById("team1_win").checked = winningTeam === 1
+    document.getElementById("team2_win").checked = winningTeam === 2
+    document.getElementById("submit-btn-text").textContent = "更新"
+
+    const skipBtn = document.getElementById("skip-match-btn")
+    if (skipBtn) skipBtn.style.display = "none"
+
+    const cancelBtn = document.getElementById("cancel-edit-btn")
+    if (cancelBtn) cancelBtn.style.display = "inline-flex"
+
+    const nextMatchBtn = document.getElementById("next-match-btn")
+    if (nextMatchBtn) nextMatchBtn.style.display = "none"
+
+    document.getElementById("match-record-container")?.scrollIntoView({ behavior: "smooth", block: "start" })
+  }
+
+  function cancelEdit() {
+    window.location.reload()
+  }
+
+  function initializeTomSelect() {
+    const selects = document.querySelectorAll('select[name*="_suit"]')
+
+    selects.forEach((select) => {
+      if (select.tomselect) return
+
+      const optgroups = select.dataset.hasFavorites === "true"
+        ? [{ value: "favorites", label: "★ お気に入り機体" }, { value: "others", label: "── その他の機体 ──" }]
+        : []
+
+      new TomSelect(select, {
+        placeholder: "機体を検索...",
+        allowEmptyOption: true,
+        plugins: ["clear_button"],
+        optgroupField: "optgroup",
+        optgroups,
+        render: {
+          no_results: function() {
+            return '<div class="no-results">該当する機体が見つかりません</div>'
+          }
+        }
+      })
+    })
+  }
+
+  function initializeFormValidation() {
+    const form = document.getElementById("match-record-form")
+    if (!form || form.dataset.validationInitialized === "true") return
+
+    form.dataset.validationInitialized = "true"
+
+    form.addEventListener("submit", function(event) {
+      const team1p1 = document.querySelector('select[name="team1_player1_suit"]')?.value
+      const team1p2 = document.querySelector('select[name="team1_player2_suit"]')?.value
+      const team2p1 = document.querySelector('select[name="team2_player1_suit"]')?.value
+      const team2p2 = document.querySelector('select[name="team2_player2_suit"]')?.value
+      const winner = document.querySelector('input[name="winning_team"]:checked')
+
+      if (!team1p1 || !team1p2 || !team2p1 || !team2p2) {
+        event.preventDefault()
+        alert("すべてのプレイヤーの機体を選択してください")
+        return
+      }
+
+      if (!winner) {
+        event.preventDefault()
+        alert("勝利チームを選択してください")
+      }
+    })
+
+    if (document.body.dataset.rotationShortcutBound !== "true") {
+      document.body.dataset.rotationShortcutBound = "true"
+      document.addEventListener("keydown", function(event) {
+        if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+          const activeForm = document.getElementById("match-record-form")
+          if (!activeForm) return
+          event.preventDefault()
+          activeForm.requestSubmit()
+        }
+      })
+    }
+  }
+
+  function preloadInitialEdit() {
+    const payload = <%= raw(initial_edit_payload) %>
+    if (!payload) return
+
+    setTimeout(function() {
+      editMatchById(payload.matchIndex, payload.matchId, payload.winningTeam, payload.suit1, payload.suit2, payload.suit3, payload.suit4)
+    }, 100)
+  }
+
+  function initializeRotationPage() {
+    initializeTomSelect()
+    initializeFormValidation()
+    preloadInitialEdit()
+  }
+
+  if (document.readyState !== "loading") {
+    initializeRotationPage()
+  }
+
+  document.addEventListener("DOMContentLoaded", initializeRotationPage)
+  document.addEventListener("turbo:load", initializeRotationPage)
+</script>


### PR DESCRIPTION
## Summary
- dashboard の member/admin 画面を feature hero / surface ベースに再設計
- events/show と rotations/show をモバイル前提のカードレイアウトへ刷新
- feature page 用の shared primitive、button variant、dropdown controller を追加

## Test plan
- [x] bin/rails tailwindcss:build
- [x] bundle exec rails zeitwerk:check
- [x] bundle exec rubocop --cache false app/helpers/application_helper.rb
- [x] bundle exec brakeman --no-pager -i .brakeman.ignore

Closes #293