### PR TITLE
feat: 統計-機体別タブで並び替え指標の数値・バーを連動表示し勝率を常時併記

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -2070,7 +2070,6 @@
   /* 多項目（機体別）は横スクロールのピル列。ネイティブ select を避け描画の差異をなくす */
   .st-sortbar-scroll { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: thin; }
   .st-sortbar-scroll .st-sortlab, .st-sortbar-scroll .st-sortbtn { flex-shrink: 0; }
-  .st-srmetric { color: var(--color-accent); font-weight: 700; }
 
   /* ===== 機体別/プレイヤー別/イベント別の戦績行（勝率バー付き）===== */
   .st-srow { padding: 14px 18px 16px; border-bottom: 1px solid var(--color-line); }
@@ -2083,8 +2082,11 @@
   .st-srsub { font-size: 11px; color: var(--color-subtle); margin-top: 3px; line-height: 1.55; }
   .st-srsub b { color: var(--color-muted); font-weight: 700; }
   .st-winbar { position: relative; height: 9px; border-radius: var(--m-r-pill); background: var(--color-surface-2); }
-  .st-winbar .wfill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: var(--m-r-pill); background: var(--m-grad); min-width: 3px; }
+  .st-winbar .wfill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: var(--m-r-pill); background: var(--m-grad); min-width: 3px; transition: width 0.2s ease; }
   .st-winbar .ref50 { position: absolute; left: 50%; top: -4px; bottom: -4px; width: 2px; border-radius: 2px; background: color-mix(in oklab, var(--color-ink) 38%, transparent); }
+  /* 機体別タブの指標連動バー：50%基準線は勝率指標のときだけ表示する */
+  .st-winbar-metric .ref50 { display: none; }
+  .st-winbar-metric.show-ref .ref50 { display: block; }
 
   /* ===== イベント別 参加統計（列揃えテーブル）===== */
   .st-evtable { padding: 2px 8px 8px; }

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -2,9 +2,11 @@ import { Controller } from "@hotwired/stimulus"
 
 // 戦績リストのクライアントサイド並べ替え。
 // ボタン式（少数キー）と セレクト＋昇降順ボタン式（多数キー）の両対応。
-// data-disp-<key> があれば、並べ替えキーに応じて各行の .st-srmetric を更新。
+// metric value が true の時は、並べ替えキーに連動して各行の右の数値(.st-srwr)と
+// バー(.st-winbar)を data-val-<key> / data-bar-<key> から更新する。
 export default class extends Controller {
   static targets = ["list", "btn", "select", "dirbtn"]
+  static values = { metric: Boolean }
 
   connect() {
     if (this.hasSelectTarget) {
@@ -54,9 +56,16 @@ export default class extends Controller {
   }
 
   applySort(key, dir) {
-    const dataKey = "sort" + key.charAt(0).toUpperCase() + key.slice(1)
+    const cap = (s) => s.charAt(0).toUpperCase() + s.slice(1)
+    const dataKey = "sort" + cap(key)
+    // 指標にデータが無い行（表示値が "—"）は昇順・降順どちらでも常に最下部へ
+    const valKey = "val" + cap(key)
+    const noData = (el) => el.dataset[valKey] === "—"
     const rows = Array.from(this.listTarget.children)
     rows.sort((a, b) => {
+      const na = noData(a)
+      const nb = noData(b)
+      if (na !== nb) return na ? 1 : -1
       const an = parseFloat(a.dataset[dataKey])
       const bn = parseFloat(b.dataset[dataKey])
       let cmp
@@ -71,12 +80,30 @@ export default class extends Controller {
   }
 
   updateMetric() {
-    if (!this.currentKey) return
-    const dispKey = "disp" + this.currentKey.charAt(0).toUpperCase() + this.currentKey.slice(1)
-    this.listTarget.querySelectorAll(".st-srmetric").forEach((el) => {
-      const row = el.closest(".st-srow")
-      const v = row && row.dataset[dispKey]
-      if (v != null) el.textContent = v
+    if (!this.metricValue || !this.currentKey) return
+    const cap = (s) => s.charAt(0).toUpperCase() + s.slice(1)
+    const valKey = "val" + cap(this.currentKey)
+    const barKey = "bar" + cap(this.currentKey)
+    const isRate = this.currentKey === "winrate"
+    this.listTarget.querySelectorAll(".st-srow").forEach((row) => {
+      const val = row.dataset[valKey]
+      const bar = parseFloat(row.dataset[barKey])
+      const neg = isRate && row.dataset.negWinrate === "1"
+
+      const srwr = row.querySelector(".st-srwr")
+      if (srwr && val != null) {
+        srwr.textContent = val
+        srwr.classList.toggle("neg", neg)
+      }
+
+      const fill = row.querySelector(".st-winbar .wfill")
+      if (fill && !isNaN(bar)) {
+        fill.style.width = bar + "%"
+        fill.classList.toggle("neg", neg)
+      }
+
+      const winbar = row.querySelector(".st-winbar")
+      if (winbar) winbar.classList.toggle("show-ref", isRate)
     })
   }
 }

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1034,25 +1034,34 @@
   <% elsif @active_tab == "mobile_suits" %>
     <%
       dmg = ->(v) { v ? number_with_delimiter(v) : "—" }
-      # [key, ピル表示, ソート値, 行に出す表示文字列, 既定方向]
+      # [key, ピル表示, ソート値(sp), 右の大きな数値表示(vp), 既定方向]
       suit_metrics = [
-        ["total", "使用回数", ->(r) { r[:total] }, ->(r) { "使用 #{r[:total]}回" }, "desc"],
-        ["winrate", "勝率", ->(r) { r[:win_rate] }, ->(r) { "勝率 #{r[:win_rate]}%" }, "desc"],
-        ["dealt", "与ダメ", ->(r) { r[:avg_damage_dealt] || 0 }, ->(r) { "与ダメージ #{dmg.call(r[:avg_damage_dealt])}" }, "desc"],
-        ["received", "被ダメ", ->(r) { r[:avg_damage_received] || 0 }, ->(r) { "被ダメージ #{dmg.call(r[:avg_damage_received])}" }, "asc"],
-        ["exdmg", "EXダメ", ->(r) { r[:avg_exburst_damage] || 0 }, ->(r) { "EXバーストダメージ #{dmg.call(r[:avg_exburst_damage])}" }, "desc"],
-        ["excount", "EX回数", ->(r) { r[:avg_exburst_count] || 0 }, ->(r) { "EXバースト発動 #{r[:avg_exburst_count] || "—"}回" }, "desc"],
-        ["ol", "OL率", ->(r) { r[:ol_rate] || 0 }, ->(r) { "OL発動率 #{r[:ol_rate] ? "#{r[:ol_rate]}%" : "—"}" }, "desc"],
-        ["life", "1機目生存", ->(r) { r[:first_life_cs] || 0 }, ->(r) { "1機目生存 #{format_survival_cs(r[:first_life_cs]) || "—"}" }, "desc"]
+        ["total", "使用回数", ->(r) { r[:total] }, ->(r) { "#{r[:total]}回" }, "desc"],
+        ["winrate", "勝率", ->(r) { r[:win_rate] }, ->(r) { "#{r[:win_rate]}%" }, "desc"],
+        ["dealt", "与ダメ", ->(r) { r[:avg_damage_dealt] || 0 }, ->(r) { dmg.call(r[:avg_damage_dealt]) }, "desc"],
+        ["received", "被ダメ", ->(r) { r[:avg_damage_received] || 0 }, ->(r) { dmg.call(r[:avg_damage_received]) }, "asc"],
+        ["exdmg", "EXダメ", ->(r) { r[:avg_exburst_damage] || 0 }, ->(r) { dmg.call(r[:avg_exburst_damage]) }, "desc"],
+        ["excount", "EX回数", ->(r) { r[:avg_exburst_count] || 0 }, ->(r) { r[:avg_exburst_count] ? "#{r[:avg_exburst_count]}回" : "—" }, "desc"],
+        ["ol", "OL率", ->(r) { r[:ol_rate] || 0 }, ->(r) { r[:ol_rate] ? "#{r[:ol_rate]}%" : "—" }, "desc"],
+        ["life", "1機目生存", ->(r) { r[:first_life_cs] || 0 }, ->(r) { format_survival_cs(r[:first_life_cs]) || "—" }, "desc"]
       ]
       suit_rows = @mobile_suits_list || []
+      # 相対バー用に各指標の最大値を算出（勝率は 0〜100 の絶対バー）
+      suit_bar_max = {}
+      suit_metrics.each { |key, _, sp, _, _| suit_bar_max[key] = suit_rows.map { |r| sp.call(r).to_f }.max.to_f }
+      suit_bar_w = ->(key, sp, r) {
+        next r[:win_rate].to_f if key == "winrate"
+        max = suit_bar_max[key]
+        max.positive? ? (sp.call(r).to_f / max * 100).round(2) : 0
+      }
+      suit_default = suit_metrics.first
     %>
     <div class="m-panel">
       <div class="m-phead"><h2>使用機体別戦績</h2><span class="m-eyebrow">全<%= suit_rows.size %>機体</span></div>
       <% if suit_rows.empty? %>
         <div class="m-pbody"><p class="text-sm font-bold text-muted">使用機体の記録がありません</p></div>
       <% else %>
-        <div data-controller="sortable">
+        <div data-controller="sortable" data-sortable-metric-value="true">
           <div class="st-sortbar st-sortbar-scroll">
             <span class="st-sortlab">並び替え</span>
             <% suit_metrics.each_with_index do |(key, label, _, _, dir), i| %>
@@ -1062,15 +1071,15 @@
           <div data-sortable-target="list">
             <% suit_rows.each do |row| %>
               <% wr = row[:win_rate].to_f %>
-              <div class="st-srow"<% suit_metrics.each do |key, _, sp, dp, _| %> data-sort-<%= key %>="<%= sp.call(row) %>" data-disp-<%= key %>="<%= dp.call(row) %>"<% end %>>
+              <div class="st-srow"<% suit_metrics.each do |key, _, sp, vp, _| %> data-sort-<%= key %>="<%= sp.call(row) %>" data-val-<%= key %>="<%= vp.call(row) %>" data-bar-<%= key %>="<%= suit_bar_w.call(key, sp, row) %>"<% end %> data-neg-winrate="<%= wr < 50 ? 1 : 0 %>">
                 <div class="st-srtop">
                   <span class="suit-thumb suit-thumb-sm"><% if row[:mobile_suit]&.image_filename.present? %><%= image_tag "/mobile_suits/#{row[:mobile_suit].image_filename}", alt: row[:mobile_suit].name, loading: "lazy" %><% end %></span>
                   <div class="st-srmeta">
-                    <div class="st-srl1"><span class="st-srnm"><%= mobile_suit_link(row[:mobile_suit]) %></span><span class="st-srwr <%= "neg" if wr < 50 %>"><%= row[:win_rate] %>%</span></div>
-                    <div class="st-srsub"><div><%= row[:total] %>戦 <%= row[:wins] %>勝<%= row[:total] - row[:wins] %>敗 ・ 最終使用 <%= compact_date.call(row[:last_used_at]) %></div><div class="st-srmetric">使用 <%= row[:total] %>回</div></div>
+                    <div class="st-srl1"><span class="st-srnm"><%= mobile_suit_link(row[:mobile_suit]) %></span><span class="st-srwr"><%= suit_default[3].call(row) %></span></div>
+                    <div class="st-srsub"><div><%= row[:total] %>戦 <%= row[:wins] %>勝<%= row[:total] - row[:wins] %>敗 ・ 勝率 <%= row[:win_rate] %>% ・ 最終使用 <%= compact_date.call(row[:last_used_at]) %></div></div>
                   </div>
                 </div>
-                <div class="st-winbar"><div class="wfill <%= "neg" if wr < 50 %>" style="width:<%= wr %>%"></div><div class="ref50"></div></div>
+                <div class="st-winbar st-winbar-metric"><div class="wfill" style="width:<%= suit_bar_w.call(suit_default[0], suit_default[2], row) %>%"></div><div class="ref50"></div></div>
               </div>
             <% end %>
           </div>


### PR DESCRIPTION
## Summary
- 統計「機体別（使用機体別戦績）」タブで、並び替えで選んだ指標を右の青い大きな数値とバーに連動表示
- 右の数値 = 選択指標の値（使用回数 / 勝率 / 与ダメ / 被ダメ / EXダメ / EX回数 / OL率 / 1機目生存）
- バー = 指標連動。勝率は 0〜100% の絶対バー（50%基準線あり）、それ以外は「表示中の最大値を100%とした相対バー」
- 勝率を各行のサブ行に常時併記し、指標と勝率の関係を読み取れるように
- 選択指標にデータが無い機体（「—」）は、昇順・降順どちらでも常に最下部へ

## 設計
案A（並び替え＝表示・バー連動 + 勝率常時併記）で実装。並び替えピルが表示も兼ねるため UI 追加なし。並び順と表示を別指標にしたくなった場合は表示項目セレクタの追加で拡張可能。

## Test plan
- [x] 機体別タブで各並び替えピルを選ぶと、右の数値・バー・並び順がその指標に連動する
- [x] 勝率指標のときだけバーが絶対値（50%基準線あり）、他は相対バーになる
- [x] 各行に「勝率 XX%」が常時表示される
- [x] 与ダメ等でデータが無い機体が昇順・降順どちらでも最下部にまとまる

Closes #324
