### PR TITLE
feat: ゲスト閲覧時にプレイヤー名を匿名化し、配信リンク・リアクション名を非表示にする

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -117,6 +117,36 @@
     color: var(--color-accent);
   }
 
+  /* ゲスト閲覧時に無効化した「配信を見る」ボタン。
+     押せないことが分かるようグレーアウト＋not-allowed カーソルにし、
+     ホバーで理由を吹き出し表示する（title をそのまま利用）。
+     opacity は擬似要素の吹き出しまで透過させるため使わない。 */
+  .is-guest-disabled {
+    position: relative;
+    cursor: not-allowed;
+    filter: grayscale(1);
+    color: var(--color-subtle);
+  }
+  .is-guest-disabled:hover::after {
+    content: attr(title);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-bottom: 6px;
+    white-space: nowrap;
+    background: var(--color-ink);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.4;
+    padding: 4px 8px;
+    border-radius: 6px;
+    box-shadow: var(--shadow-card);
+    z-index: 50;
+    pointer-events: none;
+  }
+
   .page-shell {
     min-width: 0;
     min-height: 100vh;
@@ -2174,7 +2204,7 @@
   @media (min-width: 680px) { .st-hlgrid { grid-template-columns: 1fr 1fr; } }
   @media (min-width: 1080px) { .st-hlgrid { grid-template-columns: 1fr 1fr 1fr; } }
   .st-hlcard { position: relative; display: flex; flex-direction: column; padding: 16px 18px; background: var(--color-surface); border-radius: var(--m-r); box-shadow: var(--shadow-card); transition: box-shadow .15s, transform .15s; }
-  .st-hlcard:hover { box-shadow: var(--shadow-floating); transform: translateY(-1px); }
+  .st-hlcard:hover { box-shadow: var(--shadow-floating); transform: translateY(-1px); z-index: 20; }
   .st-hlhead { display: flex; align-items: center; gap: 9px; }
   .st-hlhead .ic { width: 40px; height: 40px; border-radius: 11px; display: grid; place-items: center; flex-shrink: 0; color: var(--color-accent); background: color-mix(in oklab, var(--color-accent) 12%, transparent); }
   .st-hlhead .ic svg { width: 21px; height: 21px; fill: currentColor; }

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,37 @@
 module UsersHelper
+  # プレイヤー名の表示。ゲスト閲覧時（viewing_as_user.is_guest）は実名の代わりに
+  # 安定した仮名（プレイヤーA / プレイヤーB …）を返す。同一ユーザーはアプリ全体で
+  # 常に同じ仮名になる（ユーザーIDの昇順インデックスから決定）。
+  # コンテンツ上のプレイヤー名表示は必ずこのヘルパーを通すこと。
+  def player_name(user)
+    return "" if user.nil?
+    return user.nickname unless guest_view?
+
+    "プレイヤー#{alphabetic_label(player_alias_index(user.id))}"
+  end
+
+  # ゲストとして閲覧中か（管理者の視点切替で「ゲストとして表示」した場合も含む）
+  def guest_view?
+    viewing_as_user&.is_guest
+  end
+
+  private
+
+  # ユーザーIDを安定した連番インデックス（0始まり）に変換する。
+  # リクエスト内でメモ化。未知IDは末尾に積む。
+  def player_alias_index(user_id)
+    @_player_alias_index ||= User.order(:id).pluck(:id).each_with_index.to_h
+    @_player_alias_index[user_id] || (@_player_alias_index[user_id] = @_player_alias_index.size)
+  end
+
+  # 0 -> "A", 25 -> "Z", 26 -> "AA" の bijective base-26 ラベル
+  def alphabetic_label(index)
+    n = index + 1
+    label = +""
+    while n.positive?
+      n, r = (n - 1).divmod(26)
+      label.prepend((65 + r).chr)
+    end
+    label
+  end
 end

--- a/app/javascript/controllers/reaction_tooltip_controller.js
+++ b/app/javascript/controllers/reaction_tooltip_controller.js
@@ -17,8 +17,14 @@ export default class extends Controller {
     this.closeModal()
   }
 
+  // ゲスト閲覧時は「誰がリアクションしたか」を見せない（ツールチップ/モーダルを抑止）
+  get isGuestView() {
+    return document.body.dataset.guestView === "true"
+  }
+
   // PC: マウスホバーで表示
   showTooltip(event) {
+    if (this.isGuestView) return
     // タッチデバイスの場合はホバーを無視（長押しで対応）
     if (this.isTouchDevice()) return
 
@@ -43,6 +49,7 @@ export default class extends Controller {
 
   // スマホ: 長押し開始
   startLongPress(event) {
+    if (this.isGuestView) return
     const nicknames = this.element.dataset.nicknames
     if (!nicknames || nicknames.trim() === '') return
 
@@ -75,6 +82,7 @@ export default class extends Controller {
 
   // スマホ: モーダルを表示（Discord風）
   showModal() {
+    if (this.isGuestView) return
     const nicknames = this.element.dataset.nicknames
     if (!nicknames || nicknames.trim() === '') return
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -89,13 +89,13 @@
         <div class="m-nowmatch">
           <span class="m-lab">現在 ・ 第<%= @rotation_current_match_index.to_i + 1 %>試合</span>
           <div class="m-nm-team">
-            <span class="m-nm-p"><%= @current_rotation_match.team1_player1.nickname %><span class="m-stream"><svg viewBox="0 0 24 24"><path d="M23 7l-7 5 7 5V7zM1 5h15v14H1z"/></svg>配信台</span></span>
-            <span class="m-nm-p m-sub"><%= @current_rotation_match.team1_player2.nickname %></span>
+            <span class="m-nm-p"><%= player_name(@current_rotation_match.team1_player1) %><span class="m-stream"><svg viewBox="0 0 24 24"><path d="M23 7l-7 5 7 5V7zM1 5h15v14H1z"/></svg>配信台</span></span>
+            <span class="m-nm-p m-sub"><%= player_name(@current_rotation_match.team1_player2) %></span>
           </div>
           <span class="m-vs">VS</span>
           <div class="m-nm-team">
-            <span class="m-nm-p"><%= @current_rotation_match.team2_player1.nickname %></span>
-            <span class="m-nm-p m-sub"><%= @current_rotation_match.team2_player2.nickname %></span>
+            <span class="m-nm-p"><%= player_name(@current_rotation_match.team2_player1) %></span>
+            <span class="m-nm-p m-sub"><%= player_name(@current_rotation_match.team2_player2) %></span>
           </div>
         </div>
       <% end %>
@@ -198,7 +198,7 @@
               <div class="m-l">
                 <span class="m-no <%= index.zero? ? "m-top" : "" %>"><%= index + 1 %></span>
                 <div>
-                  <div class="m-nm"><%= partner[:user].nickname %></div>
+                  <div class="m-nm"><%= player_name(partner[:user]) %></div>
                   <div class="m-sub m-num"><%= partner[:wins] %>勝 <%= partner[:total] - partner[:wins] %>敗</div>
                 </div>
               </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body data-guest-view="<%= guest_view? ? "true" : "false" %>">
     <%= render Layout::ShellComponent.new(
       user_signed_in: user_signed_in?,
       current_user: current_user,

--- a/app/views/matches/_match_teams.html.erb
+++ b/app/views/matches/_match_teams.html.erb
@@ -22,7 +22,7 @@
           <%= render Suit::ThumbComponent.new(suit: player.mobile_suit, size: _thumb_size) %>
           <div class="min-w-0 flex-1">
             <p class="truncate text-sm font-black <%= player.id == _streaming_player_id ? 'text-neg' : 'text-ink' %>">
-              <%= player.user.nickname %>
+              <%= player_name(player.user) %>
               <% if player.id == _streaming_player_id %>
                 <span class="ml-1 rounded bg-neg px-1.5 py-0.5 text-xs font-black text-on-accent">配信台</span>
               <% end %>
@@ -56,7 +56,7 @@
           <%= render Suit::ThumbComponent.new(suit: player.mobile_suit, size: _thumb_size) %>
           <div class="min-w-0 flex-1">
             <p class="truncate text-sm font-black <%= player.id == _streaming_player_id ? 'text-neg' : 'text-ink' %>">
-              <%= player.user.nickname %>
+              <%= player_name(player.user) %>
               <% if player.id == _streaming_player_id %>
                 <span class="ml-1 rounded bg-neg px-1.5 py-0.5 text-xs font-black text-on-accent">配信台</span>
               <% end %>

--- a/app/views/matches/_mcard.html.erb
+++ b/app/views/matches/_mcard.html.erb
@@ -15,7 +15,7 @@
         <div class="m-pl">
           <%= render "shared/m_suit", suit: mp.mobile_suit %>
           <div>
-            <div class="m-pn"><%= mp.user&.nickname %></div>
+            <div class="m-pn"><%= player_name(mp.user) %></div>
             <div class="m-sn"><%= mobile_suit_link(mp.mobile_suit, fallback: "") %></div>
           </div>
         </div>
@@ -28,7 +28,7 @@
         <div class="m-pl">
           <%= render "shared/m_suit", suit: mp.mobile_suit %>
           <div>
-            <div class="m-pn"><%= mp.user&.nickname %></div>
+            <div class="m-pn"><%= player_name(mp.user) %></div>
             <div class="m-sn"><%= mobile_suit_link(mp.mobile_suit, fallback: "") %></div>
           </div>
         </div>

--- a/app/views/matches/_md_pcard.html.erb
+++ b/app/views/matches/_md_pcard.html.erb
@@ -27,7 +27,7 @@
     <div class="md-pc-id">
       <div class="md-pc-namerow">
         <span class="md-rankb <%= "r1" if player.match_rank == 1 %>"><%= player.match_rank %></span>
-        <span class="nm"><%= player.user.nickname %></span>
+        <span class="nm"><%= player_name(player.user) %></span>
         <% if local_assigns[:streaming] %><span class="md-stream">配信台</span><% end %>
       </div>
       <% if player.mobile_suit %>

--- a/app/views/matches/_mh_teams.html.erb
+++ b/app/views/matches/_mh_teams.html.erb
@@ -19,7 +19,7 @@
           </span>
           <div class="mh-pinfo">
             <div class="mh-pn <%= "streaming" if streaming %>">
-              <%= mp.user&.nickname %>
+              <%= player_name(mp.user) %>
               <% if streaming %><span class="stream">配信台</span><% end %>
             </div>
             <div class="mh-ps">

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -91,7 +91,7 @@
           </div>
           <%= link_to "全員", matches_path(all_params.merge(users: [])), class: @filter_users.empty? ? chip_on : chip_off %>
           <% @all_users.each do |user| %>
-            <%= link_to user.nickname, toggle.call(:users, user.id), class: @filter_users.include?(user.id) ? chip_on : chip_off %>
+            <%= link_to player_name(user),toggle.call(:users, user.id), class: @filter_users.include?(user.id) ? chip_on : chip_off %>
           <% end %>
         </div>
       </div>
@@ -111,7 +111,7 @@
         <div class="mh-fk">同チーム</div>
         <div class="mh-chips">
           <% @all_users.each do |user| %>
-            <%= link_to user.nickname, team_toggle.call(user.id), class: @filter_team_player_ids.include?(user.id) ? chip_on : chip_off %>
+            <%= link_to player_name(user),team_toggle.call(user.id), class: @filter_team_player_ids.include?(user.id) ? chip_on : chip_off %>
           <% end %>
           <% if @filter_team_player_ids.any? %>
             <%= link_to "クリア", matches_path(all_params.merge(team_player_ids: [])), class: "mh-ch danger" %>
@@ -125,7 +125,7 @@
         <div class="mh-chips">
           <%= link_to "全員", matches_path(all_params.merge(streaming_users: [])), class: @filter_streaming_users.empty? ? chip_on : chip_off %>
           <% visible_streaming.each do |user| %>
-            <%= link_to user.nickname, toggle.call(:streaming_users, user.id), class: @filter_streaming_users.include?(user.id) ? chip_on : chip_off %>
+            <%= link_to player_name(user),toggle.call(:streaming_users, user.id), class: @filter_streaming_users.include?(user.id) ? chip_on : chip_off %>
           <% end %>
         </div>
       </div>
@@ -220,7 +220,7 @@
               <select name="stat_player_id" class="ui-form-control max-w-xs">
                 <option value="">指定なし</option>
                 <% @all_users.each do |user| %>
-                  <option value="<%= user.id %>" <%= "selected" if @filter_stat_player_id == user.id %>><%= user.nickname %></option>
+                  <option value="<%= user.id %>" <%= "selected" if @filter_stat_player_id == user.id %>><%= player_name(user) %></option>
                 <% end %>
               </select>
             </div>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -56,7 +56,7 @@
           <div class="md-rplayer">
             <div class="md-rp-top">
               <span class="md-rankb <%= "r1" if p.match_rank == 1 %>"><%= p.match_rank %></span>
-              <span class="md-rp-name <%= "streaming" if streaming %>"><%= p.user.nickname %></span>
+              <span class="md-rp-name <%= "streaming" if streaming %>"><%= player_name(p.user) %></span>
               <% if streaming %><span class="md-stream">配信台</span><% end %>
             </div>
             <div class="md-rp-suit">
@@ -144,7 +144,7 @@
                 <% players.each do |player| %>
                   <% st = player.survival_times || [] %>
                   <tr>
-                    <td class="l"><span class="md-rankb <%= "r1" if player.match_rank == 1 %>"><%= player.match_rank %></span> <%= player.user.nickname %></td>
+                    <td class="l"><span class="md-rankb <%= "r1" if player.match_rank == 1 %>"><%= player.match_rank %></span> <%= player_name(player.user) %></td>
                     <td><%= number_with_delimiter(player.score) if player.score %></td>
                     <td><%= player.kills %></td>
                     <td><%= player.deaths %></td>
@@ -212,7 +212,8 @@
   <div class="md-sec">
     <h2>タイムライン</h2>
     <div class="md-tlpanel">
-      <div class="overflow-x-auto" data-controller="match-timeline" data-match-timeline-json-value="<%= _timeline_data.to_json %>"></div>
+      <%# ゲスト閲覧時は実名を含む _player_order を除去（クライアント未使用のため表示に影響なし） %>
+      <div class="overflow-x-auto" data-controller="match-timeline" data-match-timeline-json-value="<%= (guest_view? ? _timeline_data.except("_player_order") : _timeline_data).to_json %>"></div>
       <div class="mt-4 space-y-3 text-xs font-semibold text-muted">
         <div>
           <span class="font-black text-subtle">上段 / EXバースト系</span>

--- a/app/views/mobile_suits/show.html.erb
+++ b/app/views/mobile_suits/show.html.erb
@@ -87,7 +87,7 @@
             <div class="s-rankrow">
               <span class="s-rk-no <%= "top" if i < 3 %>"><%= i + 1 %></span>
               <div class="s-rk-nm">
-                <%= d[:user].nickname %>
+                <%= player_name(d[:user]) %>
                 <div class="s-rk-sub"><span class="m-num"><%= d[:uses] %></span>回使用</div>
               </div>
               <span class="s-rk-wr"><%= d[:win_rate] %>%</span>
@@ -263,7 +263,7 @@
               <th class="l sticky">指標</th>
               <th class="ga">全体平均</th>
               <% all_players.each do |d| %>
-                <th><%= d[:user].nickname %><span class="pc">(<%= d[:stats_count] %>)</span></th>
+                <th><%= player_name(d[:user]) %><span class="pc">(<%= d[:stats_count] %>)</span></th>
               <% end %>
             </tr>
           </thead>

--- a/app/views/rotations/show.html.erb
+++ b/app/views/rotations/show.html.erb
@@ -80,14 +80,14 @@
       <div class="r-lvmatch">
         <div class="r-lvteam">
           <div class="tl">チーム1</div>
-          <div class="r-lvp stream"><%= @current_match.team1_player1.nickname %><span class="sm">配信台</span></div>
-          <div class="r-lvp"><%= @current_match.team1_player2.nickname %></div>
+          <div class="r-lvp stream"><%= player_name(@current_match.team1_player1) %><span class="sm">配信台</span></div>
+          <div class="r-lvp"><%= player_name(@current_match.team1_player2) %></div>
         </div>
         <div class="r-lvvs">VS</div>
         <div class="r-lvteam">
           <div class="tl">チーム2</div>
-          <div class="r-lvp"><%= @current_match.team2_player1.nickname %></div>
-          <div class="r-lvp"><%= @current_match.team2_player2.nickname %></div>
+          <div class="r-lvp"><%= player_name(@current_match.team2_player1) %></div>
+          <div class="r-lvp"><%= player_name(@current_match.team2_player2) %></div>
         </div>
       </div>
 
@@ -181,8 +181,8 @@
               <td class="r-tcell <%= match ? (match.winning_team == 1 ? "win" : "lose") : "" %>" data-l="チーム1">
                 <div class="r-tcellwrap">
                   <div class="r-tps">
-                    <div class="r-tp"><span class="r-tpn"><%= rm.team1_player1.nickname %><% if mps_by_position[1]&.mobile_suit %><span class="tsu"><%= mobile_suit_link(mps_by_position[1].mobile_suit) %></span><% end %></span><span class="sm">配信台</span></div>
-                    <div class="r-tp"><span class="r-tpn"><%= rm.team1_player2.nickname %><% if mps_by_position[2]&.mobile_suit %><span class="tsu"><%= mobile_suit_link(mps_by_position[2].mobile_suit) %></span><% end %></span></div>
+                    <div class="r-tp"><span class="r-tpn"><%= player_name(rm.team1_player1) %><% if mps_by_position[1]&.mobile_suit %><span class="tsu"><%= mobile_suit_link(mps_by_position[1].mobile_suit) %></span><% end %></span><span class="sm">配信台</span></div>
+                    <div class="r-tp"><span class="r-tpn"><%= player_name(rm.team1_player2) %><% if mps_by_position[2]&.mobile_suit %><span class="tsu"><%= mobile_suit_link(mps_by_position[2].mobile_suit) %></span><% end %></span></div>
                   </div>
                   <% if match %><span class="r-bx-tag <%= match.winning_team == 1 ? "win" : "lose" %>"><%= match.winning_team == 1 ? "WIN" : "LOSE" %></span><% end %>
                 </div>
@@ -191,8 +191,8 @@
               <td class="r-tcell <%= match ? (match.winning_team == 2 ? "win" : "lose") : "" %>" data-l="チーム2">
                 <div class="r-tcellwrap">
                   <div class="r-tps">
-                    <div class="r-tp"><span class="r-tpn"><%= rm.team2_player1.nickname %><% if mps_by_position[3]&.mobile_suit %><span class="tsu"><%= mobile_suit_link(mps_by_position[3].mobile_suit) %></span><% end %></span></div>
-                    <div class="r-tp"><span class="r-tpn"><%= rm.team2_player2.nickname %><% if mps_by_position[4]&.mobile_suit %><span class="tsu"><%= mobile_suit_link(mps_by_position[4].mobile_suit) %></span><% end %></span></div>
+                    <div class="r-tp"><span class="r-tpn"><%= player_name(rm.team2_player1) %><% if mps_by_position[3]&.mobile_suit %><span class="tsu"><%= mobile_suit_link(mps_by_position[3].mobile_suit) %></span><% end %></span></div>
+                    <div class="r-tp"><span class="r-tpn"><%= player_name(rm.team2_player2) %><% if mps_by_position[4]&.mobile_suit %><span class="tsu"><%= mobile_suit_link(mps_by_position[4].mobile_suit) %></span><% end %></span></div>
                   </div>
                   <% if match %><span class="r-bx-tag <%= match.winning_team == 2 ? "win" : "lose" %>"><%= match.winning_team == 2 ? "WIN" : "LOSE" %></span><% end %>
                 </div>
@@ -244,14 +244,14 @@
         <tbody>
           <% @player_statistics.each_value do |stats| %>
             <tr>
-              <td class="name" data-l="プレイヤー"><%= stats[:user].nickname %><% if stats[:user].id == current_user.id %><span class="r-youtag">あなた</span><% end %></td>
+              <td class="name" data-l="プレイヤー"><%= player_name(stats[:user]) %><% if stats[:user].id == current_user.id %><span class="r-youtag">あなた</span><% end %></td>
               <td class="c" data-l="試合数(済/計画)"><span class="r-frac"><b><%= stats[:registered_match_count] %></b><s> / <%= stats[:match_count] %></s></span></td>
               <td class="c" data-l="配信台(済/計画)"><span class="r-frac"><b><%= stats[:registered_streaming_count] %></b><s> / <%= stats[:streaming_count] %></s></span></td>
               <td data-l="よく組む相手">
                 <% if stats[:pair_counts].any? %>
                   <div class="r-reltop">
                     <% stats[:pair_counts].sort_by { |_, count| -count }.first(3).each do |partner_id, count| %>
-                      <div><b><%= User.find(partner_id).nickname %></b> <%= count %>回</div>
+                      <div><b><%= player_name(User.find(partner_id)) %></b> <%= count %>回</div>
                     <% end %>
                   </div>
                 <% else %><span class="text-subtle">-</span><% end %>
@@ -260,7 +260,7 @@
                 <% if stats[:opponent_counts].any? %>
                   <div class="r-reltop">
                     <% stats[:opponent_counts].sort_by { |_, count| -count }.first(3).each do |opponent_id, count| %>
-                      <div><b><%= User.find(opponent_id).nickname %></b> <%= count %>回</div>
+                      <div><b><%= player_name(User.find(opponent_id)) %></b> <%= count %>回</div>
                     <% end %>
                   </div>
                 <% else %><span class="text-subtle">-</span><% end %>

--- a/app/views/shared/_broadcast_link.html.erb
+++ b/app/views/shared/_broadcast_link.html.erb
@@ -1,10 +1,17 @@
 <%#
   配信アーカイブ（YouTube）へのリンクボタン。表記「配信を見る」をここで一元管理する。
+  ゲスト閲覧時はボタンの見た目は維持しつつ、動画リンクへ遷移できない非リンク要素にする。
   locals:
     url        : 配信URL
     link_class : リンクに適用する CSS クラス
     img_class  : YouTube アイコンに付与するクラス（任意。CSS 側で img サイズ指定がない場合に使う）
 %>
-<%= link_to safe_external_url(url), target: "_blank", rel: "noopener noreferrer", class: link_class do %>
-<%= image_tag "/youtube_social_icon_red.png", alt: "YouTube", class: local_assigns[:img_class] %>配信を見る
+<% if guest_view? %>
+  <span class="<%= link_class %> is-guest-disabled" role="link" aria-disabled="true" title="ゲストは配信ページへ移動できません">
+    <%= image_tag "/youtube_social_icon_red.png", alt: "YouTube", class: local_assigns[:img_class] %>配信を見る
+  </span>
+<% else %>
+  <%= link_to safe_external_url(url), target: "_blank", rel: "noopener noreferrer", class: link_class do %>
+  <%= image_tag "/youtube_social_icon_red.png", alt: "YouTube", class: local_assigns[:img_class] %>配信を見る
+  <% end %>
 <% end %>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -76,7 +76,7 @@
     </div>
   </div>
 
-  <% unless current_user.is_admin %>
+  <% unless current_user.is_admin || guest_view? %>
     <div class="st-userbar">
       <span class="lab">ユーザー</span>
       <%= link_to "#{current_user.nickname}（自分）", statistics_path(tab: @active_tab), class: class_names("st-chip", viewing_as_user.id == current_user.id && "on") %>
@@ -300,7 +300,7 @@
       vs_html = ->(match) {
         t1 = match.match_players.select { |p| p.team_number == 1 }.sort_by(&:position)
         t2 = match.match_players.select { |p| p.team_number == 2 }.sort_by(&:position)
-        names = ->(team) { safe_join(team.map { |p| safe_join([ p.user.nickname, "（", mobile_suit_link(p.mobile_suit, class: "st-hlsuit"), "）" ]) }, " & ") }
+        names = ->(team) { safe_join(team.map { |p| safe_join([ player_name(p.user), "（", mobile_suit_link(p.mobile_suit, class: "st-hlsuit"), "）" ]) }, " & ") }
         c1 = match.winning_team == 1 ? "win" : ""
         c2 = match.winning_team == 2 ? "win" : ""
         %(<div class="st-hlvs"><span class="#{c1}">#{names.call(t1)}</span><span class="vs">vs</span><span class="#{c2}">#{names.call(t2)}</span></div>)
@@ -308,7 +308,7 @@
       hl_card = ->(label, icon, value, mp, match) {
         head = %(<div class="st-hlhead"><div class="ic">#{hl_icons[icon]}</div><div class="t">#{esc.call(label)}</div></div>)
         next %(<div class="st-hlcard">#{head}<div class="st-hlempty">データがありません</div></div>).html_safe if value.nil? || match.nil?
-        player = mp ? %(<div class="st-hlplayer"><span>#{esc.call(mp.user.nickname)}</span><span class="dot">・</span>#{mobile_suit_link(mp.mobile_suit, class: "st-hlsuit")}#{cost_badge(mp.mobile_suit.cost)}</div>) : ""
+        player = mp ? %(<div class="st-hlplayer"><span>#{esc.call(player_name(mp.user))}</span><span class="dot">・</span>#{mobile_suit_link(mp.mobile_suit, class: "st-hlsuit")}#{cost_badge(mp.mobile_suit.cost)}</div>) : ""
         video = match.video_url ? render("shared/broadcast_link", url: match.video_url, link_class: "st-hlvideo") : ""
         foot = %(<div class="st-hlfoot">) +
           link_to("試合詳細 →", match_path(match), class: "st-hllink") +


### PR DESCRIPTION
## Summary
ゲストアカウント閲覧時（`viewing_as_user.is_guest`）の制御を追加します。

- **プレイヤー名の匿名化**: `player_name` ヘルパーを追加し、ゲスト時は実名の代わりに安定仮名（プレイヤーA / プレイヤーB …、同一人物はアプリ全体で常に同じ）を表示。試合・ローテーション・ダッシュボード・機体詳細・統計ダイジェストの選手名を `player_name` 経由に統一
- 統計ページ上部の「ユーザー視点切り替え」バーをゲスト時は非表示（他ユーザー実名の漏れも解消）
- 試合タイムラインの JSON から実名（`_player_order`）をゲスト時は除去
- **配信リンクの無効化**: 「配信を見る」ボタンはゲスト時、見た目を残しつつ非リンク化（グレーアウト＋not-allowed＋ホバーで「ゲストは配信ページへ移動できません」を表示）。試合動画・イベント配信の両方に適用
- **リアクションの匿名化**: ゲスト時は「誰がリアクションしたか」のツールチップ／長押しモーダルを非表示（ActionCable ブロードキャストでもクライアント側で確実に抑止）

## 補足
- 匿名化の基準は `viewing_as_user`（管理者の「ゲストとして表示」でも匿名化される。既存のゲスト分岐と同じ基準）
- 配信動画は限定公開リンクのため、リンクを知っていれば視聴自体は可能。ボタンからの遷移を止める意図

## Test plan
- [x] ゲストでログイン（または管理者で「ゲストとして表示」）し、各画面の選手名が「プレイヤーA/B…」になる
- [x] 同一人物がどの画面でも同じ仮名になる
- [x] 統計のユーザー視点切り替えバーが表示されない
- [x] 「配信を見る」ボタンがグレーアウトし、クリックしても遷移しない／ホバーで説明が出る
- [x] リアクションにホバー／長押ししても誰が押したか表示されない
- [x] 非ゲスト（一般・管理者）では従来通り実名・リンク・ツールチップが機能する

Closes #326
